### PR TITLE
Add Google Images search operators (imagesize: and larger:) to search…

### DIFF
--- a/api-reference/v2-endpoint/search.mdx
+++ b/api-reference/v2-endpoint/search.mdx
@@ -55,6 +55,8 @@ We support a variety of query operators that allow you to filter your searches b
 | `intitle:` | Only returns results that include a word in the title of the page | `intitle:Firecrawl`
 | `allintitle:` | Only returns results that include multiple words in the title of the page | `allintitle:firecrawl playground`
 | `related:` | Only returns results that are related to a specific domain | `related:firecrawl.dev`
+| `imagesize:` | Only returns images with exact dimensions | `imagesize:1920x1080`
+| `larger:` | Only returns images larger than specified dimensions | `larger:1920x1080`
 
 ## Location Parameter
 

--- a/features/search.mdx
+++ b/features/search.mdx
@@ -94,6 +94,39 @@ curl -X POST https://api.firecrawl.dev/v2/search \
   }'
 ```
 
+### HD Image Search with Size Filtering
+
+Use Google Images operators to find high-resolution images:
+
+```bash cURL
+curl -X POST https://api.firecrawl.dev/v2/search \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer fc-YOUR_API_KEY" \
+  -d '{
+    "query": "sunset imagesize:1920x1080",
+    "sources": ["images"],
+    "limit": 5
+  }'
+```
+
+```bash cURL
+curl -X POST https://api.firecrawl.dev/v2/search \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer fc-YOUR_API_KEY" \
+  -d '{
+    "query": "mountain wallpaper larger:2560x1440",
+    "sources": ["images"],
+    "limit": 8
+  }'
+```
+
+**Common HD resolutions:**
+- `imagesize:1920x1080` - Full HD (1080p)
+- `imagesize:2560x1440` - QHD (1440p)  
+- `imagesize:3840x2160` - 4K UHD
+- `larger:1920x1080` - HD and above
+- `larger:2560x1440` - QHD and above
+
 ## Search with Content Scraping
 
 Search and retrieve content from the search results in one operation.

--- a/v1/api-reference/endpoint/search.mdx
+++ b/v1/api-reference/endpoint/search.mdx
@@ -22,6 +22,8 @@ We support a variety of query operators that allow you to filter your searches b
 | `intitle:` | Only returns results that include a word in the title of the page | `intitle:Firecrawl`
 | `allintitle:` | Only returns results that include multiple words in the title of the page | `allintitle:firecrawl playground`
 | `related:` | Only returns results that are related to a specific domain | `related:firecrawl.dev`
+| `imagesize:` | Only returns images with exact dimensions | `imagesize:1920x1080`
+| `larger:` | Only returns images larger than specified dimensions | `larger:1920x1080`
 
 ## Location Parameter
 


### PR DESCRIPTION
… documentation

- Added imagesize: and larger: operators to v1 and v2 API reference operator tables
- Added HD Image Search section with practical examples in features/search.mdx
- Included common HD resolutions (1080p, 1440p, 4K) with clear explanations
- Examples demonstrate filtering for exact dimensions and minimum size requirements