### PR TITLE
docs(agent): document Spark 2, retire Spark 1 Pro and Mini

### DIFF
--- a/advanced-scraping-guide.mdx
+++ b/advanced-scraping-guide.mdx
@@ -464,7 +464,7 @@ Use the `/v2/agent` endpoint for autonomous, multi-page data extraction. The age
 | `schema` | `object` | — | JSON schema to structure the extracted data. |
 | `maxCredits` | `number` | `2500` | Maximum credits the agent can spend. The dashboard supports up to 2,500; for higher limits, set this via the API (values above 2,500 are always billed as paid requests). |
 | `strictConstrainToURLs` | `boolean` | `false` | When `true`, the agent only visits the provided URLs. |
-| `model` | `string` | `"spark-1-mini"` | AI model to use. `"spark-1-mini"` (default, 60% cheaper) or `"spark-1-pro"` (higher accuracy). |
+| `model` | `string` | `"spark-2"` | AI model to use. `"spark-2"` is the only model and the default. |
 
 <CodeGroup>
 

--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -2510,11 +2510,10 @@
                   "model": {
                     "type": "string",
                     "enum": [
-                      "spark-1-mini",
-                      "spark-1-pro"
+                      "spark-2"
                     ],
-                    "default": "spark-1-mini",
-                    "description": "The model to use for the agent task. spark-1-mini (default) is 60% cheaper, spark-1-pro offers higher accuracy for complex tasks"
+                    "default": "spark-2",
+                    "description": "The model to use for the agent task. spark-2 is the default and handles every task; the retired spark-1-mini and spark-1-pro presets are also accepted and run on spark-2"
                   },
                   "auditMetadata": {
                     "$ref": "#/components/schemas/AuditMetadata"
@@ -2634,12 +2633,8 @@
                     },
                     "model": {
                       "type": "string",
-                      "enum": [
-                        "spark-1-pro",
-                        "spark-1-mini"
-                      ],
-                      "default": "spark-1-pro",
-                      "description": "Model preset used for the agent run"
+                      "default": "spark-2",
+                      "description": "Model preset used for the agent run. New runs report spark-2; archived runs may report the retired spark-1-pro or spark-1-mini"
                     },
                     "error": {
                       "type": "string",

--- a/developer-guides/usage-guides/choosing-the-data-extractor.mdx
+++ b/developer-guides/usage-guides/choosing-the-data-extractor.mdx
@@ -41,7 +41,7 @@ The `/agent` endpoint is Firecrawl's most advanced offering—the successor to `
 - **Autonomous Navigation**: The agent searches and navigates deep into sites to find your data
 - **Deep Web Search**: Autonomously discovers information across multiple domains and pages
 - **Parallel Processing**: Processes multiple sources simultaneously for faster results
-- **Models Available**: `spark-1-mini` (default, 60% cheaper) and `spark-1-pro` (higher accuracy)
+- **Model**: `spark-2` (default, and the only model)
 
 ### Example
 
@@ -204,7 +204,7 @@ result = app.agent(
     urls=["https://example.com"],  # Optional - can omit entirely
     prompt="Extract product information from example.com",
     schema=schema,
-    model="spark-1-mini"  # or "spark-1-pro" for higher accuracy
+    model="spark-2"  # default, can be omitted
 )
 ```
 

--- a/features/agent.mdx
+++ b/features/agent.mdx
@@ -131,40 +131,19 @@ You can share agent runs directly from the Agent playground. Shared links are pu
 
 ## Model Selection
 
-Firecrawl Agent offers two models. **Spark 1 Mini is 60% cheaper** and is the default — perfect for most use cases. Upgrade to Spark 1 Pro when you need maximum accuracy on complex tasks.
+Firecrawl Agent runs on **Spark 2**, which handles every kind of task — from single data points to complex multi-domain research. It is faster and considerably cheaper than the Spark 1 models it replaces, at the same output quality.
 
-| Model | Cost | Accuracy | Best For |
-|-------|------|----------|----------|
-| `spark-1-mini` | **60% cheaper** | Standard | Most tasks (default) |
-| `spark-1-pro` | Standard | Higher | Complex research, critical extraction |
+| Model | Best For |
+|-------|----------|
+| `spark-2` | All agent tasks (default) |
 
-<Tip>
-**Start with Spark 1 Mini** (default) — it handles most extraction tasks well at 60% lower cost. Switch to Pro only for complex multi-domain research or when accuracy is critical.
-</Tip>
-
-### Spark 1 Mini (Default)
-
-`spark-1-mini` is our efficient model, ideal for straightforward data extraction tasks.
-
-**Use Mini when:**
-- Extracting simple data points (contact info, pricing, etc.)
-- Working with well-structured websites
-- Cost efficiency is a priority
-- Running high-volume extraction jobs
-
-### Spark 1 Pro
-
-`spark-1-pro` is our flagship model, designed for maximum accuracy on complex extraction tasks.
-
-**Use Pro when:**
-- Performing complex competitive analysis
-- Extracting data that requires deep reasoning
-- Accuracy is critical for your use case
-- Dealing with ambiguous or hard-to-find data
+<Info>
+`spark-1-mini` and `spark-1-pro` are retired. Requests that still pass them run on `spark-2`.
+</Info>
 
 ### Specifying a Model
 
-Pass the `model` parameter to select which model to use:
+`spark-2` is the default, so the `model` parameter is optional:
 
 <CodeGroup>
 
@@ -179,7 +158,7 @@ Pass the `model` parameter to select which model to use:
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `prompt` | string | **Yes** | Natural language description of the data you want to extract (max 10,000 characters) |
-| `model` | string | No | Model to use: `spark-1-mini` (default) or `spark-1-pro` |
+| `model` | string | No | Model to use: `spark-2` (default) |
 | `urls` | array | No | Optional list of URLs to focus the extraction |
 | `schema` | object | No | Optional JSON schema for structured output |
 | `maxCredits` | number | No | Maximum number of credits to spend on this agent task. Defaults to **2,500** if not set. The dashboard supports values up to **2,500**; for higher limits, set `maxCredits` via the API (values above 2,500 are always treated as paid requests). If the limit is reached, the job fails and **no data is returned**. Failed runs are not billed: credits used for AI reasoning are never charged on failure, any credits used for tool calls during the run (scraping, search, mapping, etc.) are refunded, and the response reports `creditsUsed: 0`. |

--- a/features/models.mdx
+++ b/features/models.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Models"
-description: "Choose the right model for your agent extraction tasks."
+description: "The model behind Firecrawl Agent."
 og:title: "Agent Models | Firecrawl"
-og:description: "Choose between Spark 1 Mini and Spark 1 Pro for your agent extraction tasks."
+og:description: "Spark 2 powers Firecrawl Agent: faster, cheaper, and available on every agent task."
 sidebarTitle: "Models"
 hidden: true
 noindex: true
@@ -13,54 +13,27 @@ import AgentWithModelPython from "/snippets/v2/agent/with-model/python.mdx";
 import AgentWithModelJS from "/snippets/v2/agent/with-model/js.mdx";
 import AgentWithModelCURL from "/snippets/v2/agent/with-model/curl.mdx";
 
-Firecrawl Agent offers two models optimized for different use cases. Choose the right model based on your extraction complexity and cost requirements.
+Firecrawl Agent runs on a single model, **Spark 2**. There is nothing to tune: the same model handles simple lookups and deep multi-domain research.
 
 ## Available Models
 
-| Model | Cost | Accuracy | Best For |
-|-------|------|----------|----------|
-| `spark-1-mini` | **60% cheaper** | Standard | Most tasks (default) |
-| `spark-1-pro` | Standard | Higher | Complex research, critical extraction |
+| Model | Best For |
+|-------|----------|
+| `spark-2` | All agent tasks (default) |
 
-<Tip>
-**Start with Spark 1 Mini** (default) — it handles most extraction tasks well at 60% lower cost. Switch to Pro only for complex multi-domain research or when accuracy is critical.
-</Tip>
+Spark 2 replaces `spark-1-mini` and `spark-1-pro`. Compared to Spark 1 it is:
 
-## Spark 1 Mini (Default)
+- **Cheaper** — most runs cost a fraction of what the same task cost on Spark 1
+- **Faster** — it finishes in a small fraction of the time at the median, and its slowest runs are far shorter
+- **At least as accurate** — output quality matches `spark-1-pro`, and more runs finish successfully
 
-`spark-1-mini` is our efficient model, ideal for straightforward data extraction tasks.
-
-**Use Mini when:**
-- Extracting simple data points (contact info, pricing, etc.)
-- Working with well-structured websites
-- Cost efficiency is a priority
-- Running high-volume extraction jobs
-
-**Example use cases:**
-- Extracting product prices from e-commerce sites
-- Gathering contact information from company pages
-- Pulling basic metadata from articles
-- Simple data point lookups
-
-## Spark 1 Pro
-
-`spark-1-pro` is our flagship model, designed for maximum accuracy on complex extraction tasks.
-
-**Use Pro when:**
-- Performing complex competitive analysis
-- Extracting data that requires deep reasoning
-- Accuracy is critical for your use case
-- Dealing with ambiguous or hard-to-find data
-
-**Example use cases:**
-- Multi-domain competitive analysis
-- Complex research tasks requiring reasoning
-- Extracting nuanced information from multiple sources
-- Critical business intelligence gathering
+<Info>
+`spark-1-mini` and `spark-1-pro` are retired. Requests that still pass them run on `spark-2`, so no code change is required.
+</Info>
 
 ## Specifying a Model
 
-Pass the `model` parameter to select which model to use:
+`spark-2` is the default, so the `model` parameter is optional:
 
 <CodeGroup>
 
@@ -70,53 +43,18 @@ Pass the `model` parameter to select which model to use:
 
 </CodeGroup>
 
-## Model Comparison
+## Pricing
 
-| Feature | Spark 1 Mini | Spark 1 Pro |
-|---------|--------------|-------------|
-| **Cost** | 60% cheaper | Standard |
-| **Accuracy** | Standard | Higher |
-| **Speed** | Fast | Fast |
-| **Best for** | Most tasks | Complex tasks |
-| **Reasoning** | Standard | Advanced |
-| **Multi-domain** | Good | Excellent |
-
-## Pricing by Model
-
-Both models use dynamic, credit-based pricing that scales with task complexity:
-
-- **Spark 1 Mini**: Uses approximately 60% fewer credits than Pro for equivalent tasks
-- **Spark 1 Pro**: Standard credit consumption for maximum accuracy
+Spark 2 uses dynamic, credit-based pricing that scales with task complexity.
 
 <Info>
-Credit usage varies based on prompt complexity, data processed, and output structure — regardless of model selected.
+Credit usage varies based on prompt complexity, data processed, and output structure.
 </Info>
-
-## Choosing the Right Model
-
-```
-                    ┌─────────────────────────────────┐
-                    │   What type of task?            │
-                    └─────────────────────────────────┘
-                                   │
-                    ┌──────────────┴──────────────┐
-                    ▼                             ▼
-          ┌─────────────────┐           ┌─────────────────┐
-          │  Simple/Direct  │           │ Complex/Research│
-          │  extraction     │           │ multi-domain    │
-          └─────────────────┘           └─────────────────┘
-                    │                             │
-                    ▼                             ▼
-          ┌─────────────────┐           ┌─────────────────┐
-          │  spark-1-mini   │           │  spark-1-pro    │
-          │  (60% cheaper)  │           │  (higher acc.)  │
-          └─────────────────┘           └─────────────────┘
-```
 
 ## API Reference
 
 See the [Agent API Reference](/api-reference/endpoint/agent) for complete parameter documentation.
 
-Have questions about which model to use? Email [help@firecrawl.com](mailto:help@firecrawl.com).
+Have questions? Email [help@firecrawl.com](mailto:help@firecrawl.com).
 
 > Are you an AI agent that needs a Firecrawl API key? See [firecrawl.dev/agent-onboarding/SKILL.md](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for automated onboarding instructions.

--- a/sdks/cli.mdx
+++ b/sdks/cli.mdx
@@ -356,7 +356,7 @@ Search and gather data from the web using natural language prompts.
 | Option                      | Description                                                                            |
 | --------------------------- | -------------------------------------------------------------------------------------- |
 | `--urls <urls>`             | Optional list of URLs to focus the agent on (comma-separated)                          |
-| `--model <model>`           | Model to use: `spark-1-mini` (default, 60% cheaper) or `spark-1-pro` (higher accuracy) |
+| `--model <model>`           | Model to use: `spark-2` (default)                                                      |
 | `--schema <json>`           | JSON schema for structured output (inline JSON string)                                 |
 | `--schema-file <path>`      | Path to JSON schema file for structured output                                         |
 | `--max-credits <number>`    | Maximum credits to spend (job fails if limit reached)                                  |

--- a/snippets/v2/agent/base/curl.mdx
+++ b/snippets/v2/agent/base/curl.mdx
@@ -4,7 +4,7 @@ curl -X POST "https://api.firecrawl.dev/v2/agent" \
   -H "Content-Type: application/json" \
   -d '{
     "prompt": "Extract the main features and benefits of Firecrawl",
-    "model": "spark-1-mini"
+    "model": "spark-2"
   }'
 ```
 

--- a/snippets/v2/agent/base/js.mdx
+++ b/snippets/v2/agent/base/js.mdx
@@ -5,7 +5,7 @@ const firecrawl = new Firecrawl({ apiKey: "fc-YOUR_API_KEY" });
 
 const result = await firecrawl.agent({
   prompt: "Extract the main features and benefits of Firecrawl",
-  model: "spark-1-mini"
+  model: "spark-2"
 });
 
 console.log(result.data);

--- a/snippets/v2/agent/base/python.mdx
+++ b/snippets/v2/agent/base/python.mdx
@@ -5,7 +5,7 @@ app = Firecrawl(api_key="fc-YOUR_API_KEY")
 
 result = app.agent(
     prompt="Extract the main features and benefits of Firecrawl",
-    model="spark-1-mini"
+    model="spark-2"
 )
 
 print(result.data)

--- a/snippets/v2/agent/with-model/curl.mdx
+++ b/snippets/v2/agent/with-model/curl.mdx
@@ -1,21 +1,10 @@
 ```bash cURL
-# Using Spark 1 Mini (default)
+# spark-2 is the default, so model can be omitted
 curl -X POST "https://api.firecrawl.dev/v2/agent" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "prompt": "Find the pricing of Firecrawl",
-    "model": "spark-1-mini"
-  }'
-
-# Using Spark 1 Pro for complex tasks
-curl -X POST "https://api.firecrawl.dev/v2/agent" \
-  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "prompt": "Compare all enterprise features and pricing across Firecrawl, Apify, and ScrapingBee",
-    "model": "spark-1-pro"
+    "model": "spark-2"
   }'
 ```
-
-

--- a/snippets/v2/agent/with-model/js.mdx
+++ b/snippets/v2/agent/with-model/js.mdx
@@ -3,19 +3,11 @@ import { Firecrawl } from 'firecrawl';
 
 const firecrawl = new Firecrawl({ apiKey: "fc-YOUR_API_KEY" });
 
-// Using Spark 1 Mini (default - can be omitted)
+// spark-2 is the default, so model can be omitted
 const result = await firecrawl.agent({
   prompt: "Find the pricing of Firecrawl",
-  model: "spark-1-mini"
-});
-
-// Using Spark 1 Pro for complex tasks
-const resultPro = await firecrawl.agent({
-  prompt: "Compare all enterprise features and pricing across Firecrawl, Apify, and ScrapingBee",
-  model: "spark-1-pro"
+  model: "spark-2"
 });
 
 console.log(result.data);
 ```
-
-

--- a/snippets/v2/agent/with-model/python.mdx
+++ b/snippets/v2/agent/with-model/python.mdx
@@ -3,19 +3,11 @@ from firecrawl import Firecrawl
 
 app = Firecrawl(api_key="fc-YOUR_API_KEY")
 
-# Using Spark 1 Mini (default - can be omitted)
+# spark-2 is the default, so model can be omitted
 result = app.agent(
     prompt="Find the pricing of Firecrawl",
-    model="spark-1-mini"
-)
-
-# Using Spark 1 Pro for complex tasks
-result = app.agent(
-    prompt="Compare all enterprise features and pricing across Firecrawl, Apify, and ScrapingBee",
-    model="spark-1-pro"
+    model="spark-2"
 )
 
 print(result.data)
 ```
-
-

--- a/snippets/v2/cli/agent/options.mdx
+++ b/snippets/v2/cli/agent/options.mdx
@@ -1,6 +1,6 @@
 ```bash CLI
-# Use Spark 1 Pro for higher accuracy
-firecrawl agent "Competitive analysis across multiple domains" --model spark-1-pro --wait
+# Explicitly select the model (spark-2 is the default)
+firecrawl agent "Competitive analysis across multiple domains" --model spark-2 --wait
 
 # Set max credits to limit costs
 firecrawl agent "Gather contact information from company websites" --max-credits 100 --wait


### PR DESCRIPTION
## What

Agent runs on a single model now, **Spark 2**. `spark-1-mini` and `spark-1-pro` are removed from the docs as selectable models.

- `features/agent.mdx` — Model Selection collapses to one `spark-2` row; the Mini/Pro tip, the per-model "use when" sections, and the two-model parameter description are gone.
- `features/models.mdx` — rewritten around Spark 2: one model, what improved versus Spark 1 (cheaper, faster, quality at least on par), pricing, and a note that the retired presets still run.
- Snippets — `agent/with-model/{python,js,curl}` now show a single `spark-2` call, `agent/base/*` sends `spark-2`, and the CLI options snippet uses `--model spark-2`.
- `advanced-scraping-guide.mdx`, `sdks/cli.mdx`, `developer-guides/usage-guides/choosing-the-data-extractor.mdx` — model tables and inline comments updated.
- `api-reference/v2-openapi.json` — request `model` enum is `["spark-2"]` with `spark-2` as the default. The response `model` field drops its enum, since archived runs still report the retired presets.

Each page states that `spark-1-mini` and `spark-1-pro` are retired but still accepted, so existing integrations know they need no code change.

## Notes

- Localized files (`ja/`, `zh/`, `pt-BR/`, `fr/`, `es/`, and their snippets) are untouched per the repo guideline — translations land through locadex.
- The Parallel Agents pricing line mentioning Spark-1 Fast is left as is; that is a separate feature, not agent model selection.
- Comparative claims are qualitative on purpose. Happy to swap in the concrete cost/latency multiples from the Spark 2 pricing analysis if we want them public.

Companion to firecrawl/firecrawl-web#3252, which makes the playground send `spark-2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
