### PR TITLE
docs: add agent quickstart files for all SDK languages

### DIFF
--- a/agent-quickstart/elixir.mdx
+++ b/agent-quickstart/elixir.mdx
@@ -1,0 +1,208 @@
+---
+title: "Elixir Agent Quickstart"
+description: "Canonical Firecrawl Elixir quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Elixir Agent Quickstart
+
+Canonical quickstart for external agents integrating with Firecrawl via the Elixir SDK. Generated from SDK source and the OpenAPI spec.
+
+## Install
+
+Add to your `mix.exs`:
+
+```elixir
+defp deps do
+  [
+    {:firecrawl, "~> 1.9"}
+  ]
+end
+```
+
+## Authenticate
+
+Set the API key in application config:
+
+```elixir
+# config/config.exs
+config :firecrawl, api_key: "fc-YOUR_API_KEY"
+```
+
+Or pass it per-request via the `opts` keyword list:
+
+```elixir
+Firecrawl.scrape_and_extract_from_url([url: "https://example.com"], api_key: "fc-YOUR_API_KEY")
+```
+
+The default base URL is `https://api.firecrawl.dev/v2`. Override with:
+
+```elixir
+config :firecrawl, base_url: "https://your-instance.com/v2"
+```
+
+No API key is required — scrape, search, and interact fall back to a keyless free tier (rate-limited per IP).
+
+## When To Use What
+
+- **`search_and_scrape`**: Start with a query and discover relevant pages. Returns URLs, titles, descriptions, and optionally scraped content.
+- **`scrape_and_extract_from_url`**: You already have a URL and want structured page content — markdown, HTML, screenshots, JSON extraction, etc.
+- **`interact_with_scrape_browser_session`**: The page needs post-scrape browser actions — clicking, typing, or executing code in a live browser session.
+
+## Search
+
+### Why use it
+
+Discover web pages matching a query. Optionally scrape each result for full content in one call.
+
+### Preferred SDK method
+
+`Firecrawl.search_and_scrape(params, opts \\ [])`
+
+Bang variant: `Firecrawl.search_and_scrape!(params, opts \\ [])`
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.search_and_scrape(
+  query: "firecrawl web scraping",
+  limit: 5
+)
+
+IO.inspect(response.body)
+```
+
+### Parameters
+
+All parameters are passed as a keyword list (first argument). Validated at runtime via NimbleOptions.
+
+| Parameter | Elixir key | JSON key | Type | Description |
+|---|---|---|---|---|
+| query | `:query` | `"query"` | `:string` | Search query. **Required**. |
+| limit | `:limit` | `"limit"` | `:integer` | Max results to return. |
+| country | `:country` | `"country"` | `:string` | ISO country code for geo-targeting (e.g. `"US"`). |
+| location | `:location` | `"location"` | `:string` | Location string (e.g. `"San Francisco,California,United States"`). |
+| tbs | `:tbs` | `"tbs"` | `:string` | Time-based filter: `"qdr:h"`, `"qdr:d"`, `"qdr:w"`, `"qdr:m"`, `"qdr:y"`, or custom date ranges. |
+| categories | `:categories` | `"categories"` | `{:list, :any}` | Category filters. |
+| sources | `:sources` | `"sources"` | `{:list, :any}` | Sources to search. Defaults to `["web"]`. |
+| include_domains | `:include_domains` | `"includeDomains"` | `{:list, :string}` | Restrict to these domains. |
+| exclude_domains | `:exclude_domains` | `"excludeDomains"` | `{:list, :string}` | Exclude these domains. |
+| highlights | `:highlights` | `"highlights"` | `:boolean` | Generate query-relevant highlights. Defaults to `true`. |
+| ignore_invalid_urls | `:ignore_invalid_urls` | `"ignoreInvalidURLs"` | `:boolean` | Skip invalid URLs in results. |
+| enterprise | `:enterprise` | `"enterprise"` | `{:list, :string}` | Enterprise ZDR options: `["zdr"]` or `["anon"]`. |
+| scrape_options | `:scrape_options` | `"scrapeOptions"` | `:keyword_list` | Options for scraping search results. |
+| timeout | `:timeout` | `"timeout"` | `:integer` | Timeout in milliseconds. |
+
+## Scrape
+
+### Why use it
+
+Extract structured content from a single URL — markdown, HTML, screenshots, JSON extraction, audio, video, and more.
+
+### Preferred SDK method
+
+`Firecrawl.scrape_and_extract_from_url(params, opts \\ [])`
+
+Bang variant: `Firecrawl.scrape_and_extract_from_url!(params, opts \\ [])`
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown", "links"]
+)
+
+IO.inspect(response.body["data"]["markdown"])
+```
+
+### Parameters
+
+| Parameter | Elixir key | JSON key | Type | Description |
+|---|---|---|---|---|
+| url | `:url` | `"url"` | `:string` | URL to scrape. **Required**. |
+| formats | `:formats` | `"formats"` | `{:list, :any}` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`, or format objects. |
+| actions | `:actions` | `"actions"` | `{:list, :any}` | Browser actions to perform before grabbing content. |
+| headers | `:headers` | `"headers"` | `:any` | Custom HTTP headers. |
+| include_tags | `:include_tags` | `"includeTags"` | `{:list, :string}` | Only include content from these HTML tags. |
+| exclude_tags | `:exclude_tags` | `"excludeTags"` | `{:list, :string}` | Exclude content from these HTML tags. |
+| only_main_content | `:only_main_content` | `"onlyMainContent"` | `:boolean` | Extract only main content. |
+| timeout | `:timeout` | `"timeout"` | `:integer` | Timeout in ms. Min `1000`, default `60000`, max `300000`. |
+| wait_for | `:wait_for` | `"waitFor"` | `:integer` | Wait in ms before fetching content. |
+| mobile | `:mobile` | `"mobile"` | `:boolean` | Emulate a mobile device. |
+| location | `:location` | `"location"` | `:keyword_list` | Location settings for proxy/language/timezone. |
+| proxy | `:proxy` | `"proxy"` | `{:in, [:basic, :enhanced, :auto]}` | Proxy tier. |
+| block_ads | `:block_ads` | `"blockAds"` | `:boolean` | Block ads and cookie popups. |
+| max_age | `:max_age` | `"maxAge"` | `:integer` | Max cache age in ms. Default 2 days. |
+| min_age | `:min_age` | `"minAge"` | `:integer` | Cache-only mode, min age in ms. |
+| store_in_cache | `:store_in_cache` | `"storeInCache"` | `:boolean` | Store result in Firecrawl cache. |
+| lockdown | `:lockdown` | `"lockdown"` | `:boolean` | Serve only cached results. |
+| parsers | `:parsers` | `"parsers"` | `{:list, :any}` | Parser config (e.g. PDF handling). |
+| profile | `:profile` | `"profile"` | `:keyword_list` | Persistent browser profile: `[name: "my-profile", save_changes: true]`. |
+| redact_pii | `:redact_pii` | `"redactPII"` | `:boolean` | Redact PII from content. |
+| remove_base64_images | `:remove_base64_images` | `"removeBase64Images"` | `:boolean` | Remove base64 images from markdown. |
+| skip_tls_verification | `:skip_tls_verification` | `"skipTlsVerification"` | `:boolean` | Skip TLS verification. |
+| audit_metadata | `:audit_metadata` | `"auditMetadata"` | `:keyword_list` | SIEM logging: `[username: "user"]`. |
+| zero_data_retention | `:zero_data_retention` | `"zeroDataRetention"` | `:boolean` | Enable zero data retention. |
+
+## Interact
+
+### Why use it
+
+Continue interacting with a live browser session after scraping. Execute code in the browser to click buttons, fill forms, navigate, and extract dynamic content.
+
+### Preferred SDK method
+
+`Firecrawl.interact_with_scrape_browser_session(job_id, params, opts \\ [])`
+
+Bang variant: `Firecrawl.interact_with_scrape_browser_session!(job_id, params, opts \\ [])`
+
+### Example
+
+```elixir
+{:ok, scrape_response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://www.amazon.com",
+  formats: ["markdown"]
+)
+
+scrape_id = scrape_response.body["data"]["metadata"]["scrapeId"]
+
+{:ok, response} = Firecrawl.interact_with_scrape_browser_session(scrape_id, [
+  code: """
+  document.querySelector('input[name=field-keywords]').value = 'iPhone 16 Pro Max';
+  document.querySelector('form[role=search]').submit();
+  """
+])
+
+IO.inspect(response.body)
+
+Firecrawl.stop_interactive_scrape_browser_session(scrape_id)
+```
+
+### Parameters
+
+The first argument is the `job_id` (string). The second argument is a keyword list of parameters.
+
+| Parameter | Elixir key | JSON key | Type | Description |
+|---|---|---|---|---|
+| code | `:code` | `"code"` | `:string` | Code to execute in the browser session. **Required**. |
+| language | `:language` | `"language"` | `{:in, [:python, :node, :bash]}` | Language for code execution. Use `:node` for JavaScript, `:bash` for agent-browser CLI. |
+| timeout | `:timeout` | `"timeout"` | `:integer` | Execution timeout in seconds. |
+| origin | `:origin` | `"origin"` | `:string` | Origin label for telemetry. |
+
+Call `Firecrawl.stop_interactive_scrape_browser_session(job_id)` to end the browser session when done.
+
+## Notes
+
+- **OpenAPI-generated client**: The Elixir SDK is auto-generated from the OpenAPI spec. Function names mirror the OpenAPI operation IDs.
+- **No client constructor**: There is no client object/struct. All functions are module-level on `Firecrawl`.
+- **Keyword list parameters**: All body parameters are passed as a keyword list using snake_case atoms (e.g. `:only_main_content`). They are auto-converted to camelCase JSON keys.
+- **NimbleOptions validation**: Parameters are validated at runtime before any HTTP request. Invalid params return `{:error, %NimbleOptions.ValidationError{}}`.
+- **Bang variants**: Every function has a `!` variant (e.g. `search_and_scrape!`) that raises on error instead of returning `{:error, _}`.
+- **Per-request overrides**: Pass `:api_key` and `:base_url` in the trailing `opts` keyword list of any function.
+- **No `prompt` for interact**: Unlike the Node.js and Python SDKs, the Elixir SDK's interact function only supports `code`, not natural-language `prompt`.
+- **Req-based HTTP**: The SDK uses `Req` for HTTP. Any `Req` option can be passed through via `opts`.
+
+## Source Of Truth
+
+- SDK source: `firecrawl/apps/elixir-sdk/lib/firecrawl.ex`
+- OpenAPI spec: `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/java.mdx
+++ b/agent-quickstart/java.mdx
@@ -1,0 +1,223 @@
+---
+title: "Java Agent Quickstart"
+description: "Canonical Firecrawl Java quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Java Agent Quickstart
+
+Canonical quickstart for external agents integrating with Firecrawl via the Java SDK. Generated from SDK source and the OpenAPI spec.
+
+## Install
+
+**Gradle (Kotlin DSL):**
+
+```kotlin
+implementation("com.firecrawl:firecrawl-java:1.12.1")
+```
+
+**Maven:**
+
+```xml
+<dependency>
+    <groupId>com.firecrawl</groupId>
+    <artifactId>firecrawl-java</artifactId>
+    <version>1.12.1</version>
+</dependency>
+```
+
+Requires Java 11+.
+
+## Authenticate
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey("fc-YOUR_API_KEY")
+    .build();
+```
+
+Or use the `FIRECRAWL_API_KEY` environment variable:
+
+```java
+FirecrawlClient client = FirecrawlClient.fromEnv();
+```
+
+Builder options:
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `apiKey` | `String` | `null` | API key. Falls back to `FIRECRAWL_API_KEY` env var, then `firecrawl.apiKey` system property, then keyless free tier. |
+| `apiUrl` | `String` | `"https://api.firecrawl.dev"` | Base API URL. Falls back to `FIRECRAWL_API_URL` env var. |
+| `timeoutMs` | `long` | `300000` (5 min) | HTTP request timeout in milliseconds. |
+| `maxRetries` | `int` | `3` | Max retries for failed requests. |
+| `backoffFactor` | `double` | `0.5` | Exponential backoff factor. |
+| `asyncExecutor` | `Executor` | `ForkJoinPool.commonPool()` | Executor for async methods. |
+| `httpClient` | `OkHttpClient` | auto-configured | Fully custom HTTP client. |
+
+## When To Use What
+
+- **`search`**: Start with a query and discover relevant pages. Returns URLs, titles, descriptions, and optionally scraped content.
+- **`scrape`**: You already have a URL and want structured page content — markdown, HTML, screenshots, JSON extraction, etc.
+- **`interact`**: The page needs post-scrape browser actions — clicking, typing, or executing code in a live browser session.
+
+## Search
+
+### Why use it
+
+Discover web pages matching a query. Optionally scrape each result for full content in one call.
+
+### Preferred SDK method
+
+`client.search(query, options)`
+
+### Example
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+import com.firecrawl.models.SearchData;
+import com.firecrawl.models.SearchOptions;
+
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey("fc-YOUR_API_KEY")
+    .build();
+
+SearchData results = client.search("firecrawl web scraping", SearchOptions.builder()
+    .limit(5)
+    .build());
+
+for (Map<String, Object> result : results.getWeb()) {
+    System.out.println(result.get("title") + " " + result.get("url"));
+}
+```
+
+### Parameters
+
+`SearchOptions.builder()` fields:
+
+| Parameter | Type | Description |
+|---|---|---|
+| `limit` | `Integer` | Max results per source type. |
+| `sources` | `List<Object>` | Result sources: `"web"`, `"news"`, `"images"` as strings. |
+| `categories` | `List<Object>` | Narrow results: `"github"`, `"research"`, `"pdf"`. |
+| `includeDomains` | `List<String>` | Restrict to these domains. |
+| `excludeDomains` | `List<String>` | Exclude these domains. |
+| `tbs` | `String` | Time-based filter (e.g. `"qdr:d"` for past day). |
+| `location` | `String` | Location string for geo-targeted results. |
+| `ignoreInvalidURLs` | `Boolean` | Skip invalid URLs in results. |
+| `timeout` | `Integer` | Timeout in milliseconds. |
+| `highlights` | `Boolean` | Generate query-relevant highlights. Defaults to `true`. |
+| `scrapeOptions` | `ScrapeOptions` | Scrape each result page. Same builder as the scrape parameters below. |
+| `integration` | `String` | Integration identifier. |
+
+Results are accessed via `results.getWeb()`, `results.getNews()`, `results.getImages()`. Each entry is a `Map<String, Object>`.
+
+## Scrape
+
+### Why use it
+
+Extract structured content from a single URL — markdown, HTML, screenshots, JSON extraction, audio, video, and more.
+
+### Preferred SDK method
+
+`client.scrape(url, options)`
+
+### Example
+
+```java
+import com.firecrawl.models.Document;
+import com.firecrawl.models.ScrapeOptions;
+
+Document result = client.scrape("https://example.com", ScrapeOptions.builder()
+    .formats(List.of("markdown", "links"))
+    .build());
+
+System.out.println(result.getMarkdown());
+System.out.println(result.getLinks());
+```
+
+### Parameters
+
+`ScrapeOptions.builder()` fields:
+
+| Parameter | Type | Description |
+|---|---|---|
+| `formats` | `List<Object>` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"screenshot"`, `"json"`, `"audio"`, `"video"`, or format objects like `JsonFormat`, `QuestionFormat`, `HighlightsFormat`. |
+| `headers` | `Map<String, String>` | Custom HTTP headers. |
+| `includeTags` | `List<String>` | Only include content from these HTML tags. |
+| `excludeTags` | `List<String>` | Exclude content from these HTML tags. |
+| `onlyMainContent` | `Boolean` | Extract only main content, excluding headers/navs/footers. |
+| `timeout` | `Integer` | Timeout in milliseconds. |
+| `waitFor` | `Integer` | Additional wait in ms before scraping. |
+| `mobile` | `Boolean` | Emulate a mobile device. |
+| `parsers` | `List<Object>` | Parser config: `"pdf"` or `{"type":"pdf","maxPages":10}`. |
+| `actions` | `List<Map<String, Object>>` | Browser actions before scraping. |
+| `location` | `LocationConfig` | Location settings: `.country("US").languages(List.of("en-US"))`. |
+| `skipTlsVerification` | `Boolean` | Skip TLS certificate verification. |
+| `removeBase64Images` | `Boolean` | Remove base64 images from markdown. |
+| `blockAds` | `Boolean` | Block ads and cookie popups. |
+| `proxy` | `String` | Proxy tier: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. |
+| `maxAge` | `Long` | Max age in ms of cached content. |
+| `storeInCache` | `Boolean` | Store result in Firecrawl cache. |
+| `lockdown` | `Boolean` | Serve only cached results. |
+| `redactPII` | `Boolean` | Redact PII from content. |
+| `auditMetadata` | `AuditMetadata` | User attribution for SIEM logging. |
+| `integration` | `String` | Integration identifier. |
+
+## Interact
+
+### Why use it
+
+Continue interacting with a live browser session after scraping. Execute code in the browser to click buttons, fill forms, navigate, and extract dynamic content.
+
+### Preferred SDK method
+
+`client.interact(jobId, code)` or `client.interact(jobId, code, language, timeout)`
+
+### Example
+
+```java
+import com.firecrawl.models.BrowserExecuteResponse;
+
+Document result = client.scrape("https://www.amazon.com", ScrapeOptions.builder()
+    .formats(List.of("markdown"))
+    .build());
+
+String scrapeId = (String) result.getMetadata().get("scrapeId");
+
+BrowserExecuteResponse response = client.interact(scrapeId,
+    "document.querySelector('input[name=field-keywords]').value = 'iPhone 16 Pro Max';"
+    + "document.querySelector('form[role=search]').submit();");
+
+System.out.println(response.getStdout());
+
+client.stopInteractiveBrowser(scrapeId);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `jobId` | `String` | Scrape job ID. Required. Obtained from `result.getMetadata().get("scrapeId")` of a previous scrape. |
+| `code` | `String` | Code to execute in the browser session. Required. |
+| `language` | `String` | Language for code execution: `"python"`, `"node"`, `"bash"`. Defaults to `"node"`. |
+| `timeout` | `Integer` | Execution timeout in seconds (1-300). |
+| `origin` | `String` | Origin identifier. Auto-set to `"java-sdk@{version}"`. |
+
+Call `client.stopInteractiveBrowser(jobId)` to end the browser session when done.
+
+Every sync method has an async variant returning `CompletableFuture`: `interactAsync(...)`, `scrapeAsync(...)`, `searchAsync(...)`.
+
+## Notes
+
+- **Builder pattern**: `FirecrawlClient`, `ScrapeOptions`, `SearchOptions`, and `LocationConfig` all use `Builder` classes. Construct via `.builder()...build()`.
+- **camelCase parameters**: All options use camelCase (e.g. `onlyMainContent`, `includeTags`).
+- **`List<Object>` for polymorphic fields**: `formats`, `sources`, and `categories` accept both strings and structured config objects.
+- **Search results are generic Maps**: `SearchData.getWeb()` returns `List<Map<String, Object>>` rather than typed model objects. Cast or use Jackson to deserialize individual results.
+- **No `prompt` for interact**: Unlike the Node.js and Python SDKs, the Java SDK's `interact` method only supports `code`, not natural-language `prompt`.
+- **Deprecated aliases**: `scrapeExecute` -> `interact`, `deleteScrapeBrowser` -> `stopInteractiveBrowser`.
+
+## Source Of Truth
+
+- SDK source: `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
+- OpenAPI spec: `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/node.mdx
+++ b/agent-quickstart/node.mdx
@@ -1,0 +1,195 @@
+---
+title: "Node.js Agent Quickstart"
+description: "Canonical Firecrawl Node.js quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Node.js Agent Quickstart
+
+Canonical quickstart for external agents integrating with Firecrawl via the Node.js SDK. Generated from SDK source and the OpenAPI spec.
+
+## Install
+
+```bash
+npm install firecrawl
+```
+
+Requires Node.js 22+.
+
+## Authenticate
+
+```javascript
+import Firecrawl from "firecrawl";
+
+const firecrawl = new Firecrawl({ apiKey: "fc-YOUR_API_KEY" });
+```
+
+Or use the `FIRECRAWL_API_KEY` environment variable:
+
+```javascript
+const firecrawl = new Firecrawl();
+```
+
+Constructor accepts a string (API key) or an options object:
+
+| Option | Type | Description |
+|---|---|---|
+| `apiKey` | `string` | API key. Falls back to `FIRECRAWL_API_KEY` env var, then keyless free tier (rate-limited per IP). |
+| `apiUrl` | `string` | Base URL. Defaults to `https://api.firecrawl.dev`. |
+| `timeoutMs` | `number` | Per-request timeout in milliseconds. |
+| `maxRetries` | `number` | Max automatic retries for transient failures. |
+| `backoffFactor` | `number` | Exponential backoff factor for retries. |
+
+## When To Use What
+
+- **`search`**: Start with a query and discover relevant pages. Returns URLs, titles, descriptions, and optionally scraped content.
+- **`scrape`**: You already have a URL and want structured page content — markdown, HTML, screenshots, JSON extraction, etc.
+- **`interact`**: The page needs post-scrape browser actions — clicking, typing, executing code, or natural-language browser instructions.
+
+## Search
+
+### Why use it
+
+Discover web pages matching a query. Optionally scrape each result for full content in one call.
+
+### Preferred SDK method
+
+`firecrawl.search(query, options?)`
+
+### Example
+
+```javascript
+import Firecrawl from "firecrawl";
+
+const firecrawl = new Firecrawl({ apiKey: "fc-YOUR_API_KEY" });
+const results = await firecrawl.search("firecrawl web scraping", { limit: 5 });
+
+for (const result of results.web) {
+  console.log(result.title, result.url);
+}
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `string` | Search query. Required (first positional argument). |
+| `limit` | `number` | Max number of results per source type. |
+| `sources` | `Array<"web" \| "news" \| "images">` | Result sources to include. Defaults to `["web"]`. |
+| `categories` | `Array<"github" \| "research" \| "pdf" \| "developer">` | Narrow results by category. Use when you want domain-specific filtering. |
+| `includeDomains` | `string[]` | Restrict to these domains. Mutually exclusive with `excludeDomains`. |
+| `excludeDomains` | `string[]` | Exclude these domains. Mutually exclusive with `includeDomains`. |
+| `tbs` | `string` | Time-based filter. Use `"qdr:h"` (past hour), `"qdr:d"` (day), `"qdr:w"` (week), `"qdr:m"` (month), `"qdr:y"` (year), or custom date ranges. |
+| `location` | `string` | Location string for geo-targeted results (e.g. `"San Francisco,California,United States"`). |
+| `ignoreInvalidURLs` | `boolean` | Skip invalid URLs instead of failing. Useful when piping results to other Firecrawl endpoints. |
+| `timeout` | `number` | Timeout in milliseconds. |
+| `highlights` | `boolean` | Generate query-relevant highlights. Defaults to `true`. Set `false` for raw provider descriptions. |
+| `scrapeOptions` | `ScrapeOptions` | Scrape each result page. Same parameters as the scrape endpoint below. |
+| `enterprise` | `Array<"default" \| "anon" \| "zdr">` | Enterprise options: `"zdr"` for zero data retention, `"anon"` for anonymized search. |
+| `threatProtection` | `ThreatProtectionOptions` | Per-request threat protection override. |
+| `integration` | `string` | Integration identifier for attribution. |
+| `origin` | `string` | Origin identifier. |
+
+Results are grouped by source: `results.web`, `results.news`, `results.images`, `results.developer`.
+
+## Scrape
+
+### Why use it
+
+Extract structured content from a single URL — markdown, HTML, screenshots, JSON extraction, audio, video, and more.
+
+### Preferred SDK method
+
+`firecrawl.scrape(url, options?)`
+
+### Example
+
+```javascript
+const result = await firecrawl.scrape("https://example.com", {
+  formats: ["markdown", "links"],
+});
+console.log(result.markdown);
+console.log(result.links);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `string` | URL to scrape. Required (first positional argument). |
+| `formats` | `FormatOption[]` | Output formats. Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`. Or format objects like `{ type: "json", schema: {...}, prompt: "..." }`, `{ type: "question", question: "..." }`, `{ type: "highlights", query: "..." }`. |
+| `headers` | `Record<string, string>` | Custom HTTP headers for the request. Use for cookies, auth tokens, user-agent. |
+| `includeTags` | `string[]` | Only include content from these HTML tags. |
+| `excludeTags` | `string[]` | Exclude content from these HTML tags. |
+| `onlyMainContent` | `boolean` | Extract only main content, excluding headers/navs/footers. |
+| `timeout` | `number` | Timeout in milliseconds. Min `1000`, max `300000`. Default `60000`. |
+| `waitFor` | `number` | Additional wait in milliseconds before scraping. Use for JS-rendered content. |
+| `mobile` | `boolean` | Emulate a mobile device. Use for responsive pages or mobile-specific content. |
+| `parsers` | `Array` | Parser config. Use `["pdf"]` or `[{ type: "pdf", mode: "fast" \| "auto" \| "ocr", maxPages: number }]`. |
+| `actions` | `ActionOption[]` | Browser actions before scraping: `wait`, `screenshot`, `click`, `write`, `press`, `scroll`, `scrape`, `executeJavascript`, `pdf`. |
+| `location` | `{ country?: string, languages?: string[] }` | Location settings for geo-targeting and language preference. |
+| `skipTlsVerification` | `boolean` | Skip TLS certificate verification. |
+| `removeBase64Images` | `boolean` | Remove base64 images from markdown output. |
+| `fastMode` | `boolean` | Faster scrape with reduced accuracy. |
+| `blockAds` | `boolean` | Block ads and cookie popups. |
+| `proxy` | `"basic" \| "stealth" \| "enhanced" \| "auto"` | Proxy tier. `"auto"` retries with enhanced if basic fails. |
+| `maxAge` | `number` | Max age in ms of cached content for reuse. `0` bypasses cache. Default `172800000` (2 days). |
+| `minAge` | `number` | Cache-only mode. Returns cached data of at least this age in ms. Use `1` to accept any cached data. |
+| `storeInCache` | `boolean` | Store result in Firecrawl cache. |
+| `lockdown` | `boolean` | Serve only cached results, never make outbound requests. |
+| `redactPII` | `boolean \| RedactPIIOptions` | Redact PII from content. Pass `true` for defaults or `{ mode, entities, replaceStyle }`. |
+| `auditMetadata` | `{ username: string }` | User attribution for SIEM logging. |
+| `profile` | `{ name: string, saveChanges?: boolean }` | Persistent browser profile for shared state across sessions. |
+| `threatProtection` | `ThreatProtectionOptions` | Per-request threat protection override. |
+| `integration` | `string` | Integration identifier. |
+| `origin` | `string` | Origin identifier. |
+
+## Interact
+
+### Why use it
+
+Continue interacting with a live browser session after scraping. Execute code or send natural-language prompts to control the page — click buttons, fill forms, navigate, and extract dynamic content.
+
+### Preferred SDK method
+
+`firecrawl.interact(jobId, args)`
+
+### Example
+
+```javascript
+const result = await firecrawl.scrape("https://www.amazon.com", { formats: ["markdown"] });
+const scrapeId = result.metadata?.scrapeId;
+
+await firecrawl.interact(scrapeId, { prompt: "Search for iPhone 16 Pro Max" });
+const response = await firecrawl.interact(scrapeId, {
+  prompt: "Click on the first result and tell me the price",
+});
+console.log(response.output);
+
+await firecrawl.stopInteraction(scrapeId);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `jobId` | `string` | Scrape job ID. Required (first positional argument). Obtained from `result.metadata.scrapeId` of a previous scrape. |
+| `code` | `string` | Code to execute in the browser session. One of `code` or `prompt` is required. |
+| `prompt` | `string` | Natural-language instruction for the browser agent. One of `code` or `prompt` is required. |
+| `language` | `"python" \| "node" \| "bash"` | Language for code execution. Defaults to `"node"`. |
+| `timeout` | `number` | Execution timeout in seconds (1-300). |
+| `origin` | `string` | Origin identifier. |
+
+Call `firecrawl.stopInteraction(jobId)` to end the browser session when done.
+
+## Notes
+
+- **camelCase parameters**: All options use camelCase (e.g. `onlyMainContent`, `includeTags`, `scrapeOptions`).
+- **Zod schema inference**: When using `{ type: "json", schema: zodSchema }` in `formats`, TypeScript narrows the `json` return type to `z.infer<typeof zodSchema>`.
+- **SearchData structure**: Access results via `results.web`, `results.news`, `results.images`, or `results.developer`. Accessing `results.data` throws an error.
+- **Timeout arithmetic**: The SDK adds 5000ms to the provided timeout for the HTTP request. For interact, timeout is in seconds (converted to ms internally).
+- **Deprecated aliases**: `scrapeExecute` -> `interact`, `stopInteractiveBrowser` / `deleteScrapeBrowser` -> `stopInteraction`, `scrapeUrl` -> `scrape`.
+
+## Source Of Truth
+
+- SDK source: `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`, `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
+- OpenAPI spec: `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/python.mdx
+++ b/agent-quickstart/python.mdx
@@ -1,0 +1,186 @@
+---
+title: "Python Agent Quickstart"
+description: "Canonical Firecrawl Python quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Python Agent Quickstart
+
+Canonical quickstart for external agents integrating with Firecrawl via the Python SDK. Generated from SDK source and the OpenAPI spec.
+
+## Install
+
+```bash
+pip install firecrawl-py
+```
+
+## Authenticate
+
+```python
+from firecrawl import Firecrawl
+
+firecrawl = Firecrawl(api_key="fc-YOUR_API_KEY")
+```
+
+Or use the `FIRECRAWL_API_KEY` environment variable:
+
+```python
+firecrawl = Firecrawl()
+```
+
+Constructor parameters:
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `api_key` | `str` | `None` | API key. Falls back to `FIRECRAWL_API_KEY` env var, then keyless free tier (rate-limited per IP). |
+| `api_url` | `str` | `"https://api.firecrawl.dev"` | Base API URL. |
+| `timeout` | `float` | `None` | Default request timeout in seconds. |
+| `max_retries` | `int` | `3` | Max retries for failed requests. |
+| `backoff_factor` | `float` | `0.5` | Exponential backoff factor for retries. |
+
+An async client is also available: `from firecrawl import AsyncFirecrawl`.
+
+## When To Use What
+
+- **`search`**: Start with a query and discover relevant pages. Returns URLs, titles, descriptions, and optionally scraped content.
+- **`scrape`**: You already have a URL and want structured page content — markdown, HTML, screenshots, JSON extraction, etc.
+- **`interact`**: The page needs post-scrape browser actions — clicking, typing, executing code, or natural-language browser instructions.
+
+## Search
+
+### Why use it
+
+Discover web pages matching a query. Optionally scrape each result for full content in one call.
+
+### Preferred SDK method
+
+`firecrawl.search(query, **kwargs)`
+
+### Example
+
+```python
+from firecrawl import Firecrawl
+
+firecrawl = Firecrawl(api_key="fc-YOUR_API_KEY")
+results = firecrawl.search("firecrawl web scraping", limit=5)
+
+for result in results.web:
+    print(result.title, result.url)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `str` | Search query. Required (first positional argument). |
+| `limit` | `int` | Max number of results per source type. Default `5`. |
+| `sources` | `list[str \| Source]` | Result sources: `"web"`, `"news"`, `"images"`. Defaults to `["web"]`. |
+| `categories` | `list[str \| Category]` | Narrow results: `"github"`, `"research"`, `"pdf"`, `"developer"`. |
+| `include_domains` | `list[str]` | Restrict to these domains. Mutually exclusive with `exclude_domains`. |
+| `exclude_domains` | `list[str]` | Exclude these domains. Mutually exclusive with `include_domains`. |
+| `tbs` | `str` | Time-based filter: `"qdr:h"` (hour), `"qdr:d"` (day), `"qdr:w"` (week), `"qdr:m"` (month), `"qdr:y"` (year), or custom date ranges. |
+| `location` | `str` | Location string for geo-targeted results (e.g. `"San Francisco,California,United States"`). |
+| `ignore_invalid_urls` | `bool` | Skip invalid URLs. Useful when piping results to other Firecrawl endpoints. |
+| `timeout` | `int` | Timeout in milliseconds. Default `300000`. |
+| `highlights` | `bool` | Generate query-relevant highlights. Defaults to `true` server-side. Set `False` for raw descriptions. |
+| `scrape_options` | `ScrapeOptions` | Scrape each result page. Same parameters as the scrape endpoint below. |
+| `enterprise` | `list[str]` | Enterprise options: `["zdr"]` for zero data retention, `["anon"]` for anonymized search. |
+| `threat_protection` | `ThreatProtectionOptions` | Per-request threat protection override. |
+| `integration` | `str` | Integration identifier for attribution. |
+
+Results are grouped by source: `results.web`, `results.news`, `results.images`, `results.developer`.
+
+## Scrape
+
+### Why use it
+
+Extract structured content from a single URL — markdown, HTML, screenshots, JSON extraction, audio, video, and more.
+
+### Preferred SDK method
+
+`firecrawl.scrape(url, **kwargs)`
+
+### Example
+
+```python
+result = firecrawl.scrape("https://example.com", formats=["markdown", "links"])
+print(result.markdown)
+print(result.links)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `str` | URL to scrape. Required (first positional argument). |
+| `formats` | `list[FormatOption]` | Output formats. Strings: `"markdown"`, `"html"`, `"rawHtml"` (or `"raw_html"`), `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"` (or `"change_tracking"`), `"json"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`. Or format objects like `JsonFormat`, `QuestionFormat`, `HighlightsFormat`. |
+| `headers` | `dict[str, str]` | Custom HTTP headers. Use for cookies, auth tokens, user-agent. |
+| `include_tags` | `list[str]` | Only include content from these HTML tags. |
+| `exclude_tags` | `list[str]` | Exclude content from these HTML tags. |
+| `only_main_content` | `bool` | Extract only main content, excluding headers/navs/footers. |
+| `timeout` | `int` | Timeout in milliseconds. Min `1000`, max `300000`. Default `60000`. |
+| `wait_for` | `int` | Additional wait in milliseconds before scraping. Use for JS-rendered content. |
+| `mobile` | `bool` | Emulate a mobile device. |
+| `parsers` | `list` | Parser config: `["pdf"]` or `[PDFParser(mode="fast" \| "auto" \| "ocr", max_pages=N)]`. |
+| `actions` | `list` | Browser actions before scraping: `WaitAction`, `ScreenshotAction`, `ClickAction`, `WriteAction`, `PressAction`, `ScrollAction`, `ScrapeAction`, `ExecuteJavascriptAction`, `PDFAction`. |
+| `location` | `Location` | Location settings: `Location(country="US", languages=["en-US"])`. |
+| `skip_tls_verification` | `bool` | Skip TLS certificate verification. |
+| `remove_base64_images` | `bool` | Remove base64 images from markdown output. |
+| `fast_mode` | `bool` | Faster scrape with reduced accuracy. |
+| `block_ads` | `bool` | Block ads and cookie popups. |
+| `proxy` | `str` | Proxy tier: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. |
+| `max_age` | `int` | Max age in ms of cached content. `0` bypasses cache. Default `172800000` (2 days). |
+| `store_in_cache` | `bool` | Store result in Firecrawl cache. |
+| `lockdown` | `bool` | Serve only cached results, never make outbound requests. |
+| `threat_protection` | `ThreatProtectionOptions` | Per-request threat protection override. |
+| `profile` | `dict` | Persistent browser profile: `{"name": "my-profile", "saveChanges": True}`. |
+| `audit_metadata` | `AuditMetadata` | User attribution for SIEM logging: `AuditMetadata(username="user")`. |
+| `integration` | `str` | Integration identifier. |
+
+## Interact
+
+### Why use it
+
+Continue interacting with a live browser session after scraping. Execute code or send natural-language prompts to control the page — click buttons, fill forms, navigate, and extract dynamic content.
+
+### Preferred SDK method
+
+`firecrawl.interact(job_id, code=None, *, prompt=None, language="node", timeout=None)`
+
+### Example
+
+```python
+result = firecrawl.scrape("https://www.amazon.com", formats=["markdown"])
+scrape_id = result.metadata.scrape_id
+
+firecrawl.interact(scrape_id, prompt="Search for iPhone 16 Pro Max")
+response = firecrawl.interact(scrape_id, prompt="Click on the first result and tell me the price")
+print(response.output)
+
+firecrawl.stop_interaction(scrape_id)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `str` | Scrape job ID. Required (first positional argument). Obtained from `result.metadata.scrape_id` of a previous scrape. |
+| `code` | `str` | Code to execute in the browser session. One of `code` or `prompt` is required. Second positional argument. |
+| `prompt` | `str` | Natural-language instruction for the browser agent. One of `code` or `prompt` is required. Keyword-only. |
+| `language` | `"python" \| "node" \| "bash"` | Language for code execution. Defaults to `"node"`. Keyword-only. |
+| `timeout` | `int` | Execution timeout in seconds (1-300). Keyword-only. |
+| `origin` | `str` | Origin identifier. Keyword-only. |
+
+Call `firecrawl.stop_interaction(job_id)` to end the browser session when done.
+
+## Notes
+
+- **snake_case parameters**: All parameters use snake_case (e.g. `only_main_content`, `include_tags`, `scrape_options`). The SDK converts to camelCase for the API.
+- **Format string aliases**: Both camelCase and snake_case format strings are accepted (e.g. `"rawHtml"` and `"raw_html"` both work).
+- **SearchData structure**: Access results via `results.web`, `results.news`, `results.images`, or `results.developer`. Accessing `results.data` raises `AttributeError`.
+- **Pydantic models**: Return types (`Document`, `SearchData`, `BrowserExecuteResponse`) are Pydantic models with attribute-style access.
+- **Deprecated aliases**: `FirecrawlApp` -> `Firecrawl`, `scrape_execute` -> `interact`, `stop_interactive_browser` / `delete_scrape_browser` -> `stop_interaction`, `scrape_url` -> `scrape`.
+
+## Source Of Truth
+
+- SDK source: `firecrawl/apps/python-sdk/firecrawl/v2/client.py`, `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
+- OpenAPI spec: `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/rust.mdx
+++ b/agent-quickstart/rust.mdx
@@ -1,0 +1,220 @@
+---
+title: "Rust Agent Quickstart"
+description: "Canonical Firecrawl Rust quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Rust Agent Quickstart
+
+Canonical quickstart for external agents integrating with Firecrawl via the Rust SDK. Generated from SDK source and the OpenAPI spec.
+
+## Install
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+firecrawl = "2"
+tokio = { version = "1", features = ["full"] }
+```
+
+## Authenticate
+
+```rust
+use firecrawl::Client;
+
+let client = Client::new("fc-YOUR_API_KEY")?;
+```
+
+For self-hosted instances:
+
+```rust
+let client = Client::new_selfhosted("https://your-instance.com", Some("fc-YOUR_API_KEY"))?;
+```
+
+Pass `None::<&str>` as the API key for keyless free tier (rate-limited per IP).
+
+## When To Use What
+
+- **`search`**: Start with a query and discover relevant pages. Returns URLs, titles, descriptions, and optionally scraped content.
+- **`scrape`**: You already have a URL and want structured page content — markdown, HTML, screenshots, JSON extraction, etc.
+- **`interact`**: The page needs post-scrape browser actions — clicking, typing, executing code, or natural-language browser instructions.
+
+## Search
+
+### Why use it
+
+Discover web pages matching a query. Optionally scrape each result for full content in one call.
+
+### Preferred SDK method
+
+`client.search(query, options).await`
+
+### Example
+
+```rust
+use firecrawl::{Client, SearchOptions};
+
+let client = Client::new("fc-YOUR_API_KEY")?;
+let response = client.search("firecrawl web scraping", SearchOptions {
+    limit: Some(5),
+    ..Default::default()
+}).await?;
+
+if let Some(web_results) = response.data.web {
+    for result in web_results {
+        println!("{:?}", result);
+    }
+}
+```
+
+### Parameters
+
+`SearchOptions` fields (all `Option`, default `None`):
+
+| Parameter | Type | Description |
+|---|---|---|
+| `limit` | `Option<u32>` | Max results. Default `5`, max `20`. |
+| `sources` | `Option<Vec<SearchSource>>` | Result sources: `Web`, `News`, `Images`. |
+| `categories` | `Option<Vec<SearchCategory>>` | Narrow results: `Github`, `Research`, `Pdf`. |
+| `include_domains` | `Option<Vec<String>>` | Restrict to these domains. |
+| `exclude_domains` | `Option<Vec<String>>` | Exclude these domains. |
+| `tbs` | `Option<String>` | Time-based filter (e.g. `"qdr:d"` for past day). |
+| `location` | `Option<String>` | Location string for geo-targeted results. |
+| `ignore_invalid_urls` | `Option<bool>` | Skip invalid URLs in results. |
+| `timeout` | `Option<u32>` | Timeout in milliseconds. |
+| `highlights` | `Option<bool>` | Generate query-relevant highlights. Defaults to `true`. |
+| `scrape_options` | `Option<ScrapeOptions>` | Scrape each result page. Same struct as the scrape parameters below. |
+| `integration` | `Option<String>` | Integration identifier. |
+| `origin` | `Option<String>` | Origin identifier. Auto-set to `"rust-sdk@{version}"`. |
+
+There is also a convenience method `client.search_and_scrape(query, limit).await` that returns `Vec<Document>` directly.
+
+## Scrape
+
+### Why use it
+
+Extract structured content from a single URL — markdown, HTML, screenshots, JSON extraction, audio, video, and more.
+
+### Preferred SDK method
+
+`client.scrape(url, options).await`
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, Format};
+
+let client = Client::new("fc-YOUR_API_KEY")?;
+let document = client.scrape("https://example.com", ScrapeOptions {
+    formats: Some(vec![Format::Markdown, Format::Links]),
+    ..Default::default()
+}).await?;
+
+if let Some(md) = &document.markdown {
+    println!("{}", md);
+}
+```
+
+### Parameters
+
+`ScrapeOptions` fields (all `Option`, default `None`):
+
+| Parameter | Type | Description |
+|---|---|---|
+| `formats` | `Option<Vec<Format>>` | Output formats: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `ChangeTracking`, `Json`, `Attributes`, `Branding`, `Product`, `Menu`, `Audio`, `Video`, or data-carrying variants `Question(...)`, `Highlights(...)`, `Query(...)`. |
+| `headers` | `Option<HashMap<String, String>>` | Custom HTTP headers. |
+| `include_tags` | `Option<Vec<String>>` | Only include content from these HTML tags. |
+| `exclude_tags` | `Option<Vec<String>>` | Exclude content from these HTML tags. |
+| `only_main_content` | `Option<bool>` | Extract only main content, excluding headers/navs/footers. |
+| `timeout` | `Option<u32>` | Timeout in milliseconds. |
+| `wait_for` | `Option<u32>` | Additional wait in ms before scraping. |
+| `mobile` | `Option<bool>` | Emulate a mobile device. |
+| `parsers` | `Option<Vec<ParserConfig>>` | Parser config for files like PDFs. |
+| `actions` | `Option<Vec<Action>>` | Browser actions before scraping. |
+| `location` | `Option<LocationConfig>` | Location settings for proxy and language. |
+| `skip_tls_verification` | `Option<bool>` | Skip TLS certificate verification. |
+| `remove_base64_images` | `Option<bool>` | Remove base64 images from markdown. |
+| `fast_mode` | `Option<bool>` | Faster scrape with reduced accuracy. |
+| `block_ads` | `Option<bool>` | Block ads and cookie popups. |
+| `proxy` | `Option<ProxyType>` | Proxy tier: `Basic`, `Stealth`, `Enhanced`, `Auto`. |
+| `max_age` | `Option<u32>` | Max cache age in seconds. |
+| `min_age` | `Option<u32>` | Cache-only mode, min age in seconds. |
+| `store_in_cache` | `Option<bool>` | Store result in Firecrawl cache. |
+| `lockdown` | `Option<bool>` | Serve only cached results. |
+| `redact_pii` | `Option<bool>` | Redact PII from content. Serialized as `"redactPII"`. |
+| `audit_metadata` | `Option<AuditMetadata>` | User attribution for SIEM logging. |
+| `profile` | `Option<ProfileConfig>` | Persistent browser profile. |
+| `integration` | `Option<String>` | Integration identifier. |
+| `json_options` | `Option<JsonOptions>` | JSON extraction config: `schema`, `system_prompt`, `prompt`. |
+| `screenshot_options` | `Option<ScreenshotOptions>` | Screenshot config: `full_page`, `quality`, `viewport`. |
+| `change_tracking_options` | `Option<ChangeTrackingOptions>` | Change tracking config. |
+| `attribute_selectors` | `Option<Vec<AttributeSelector>>` | CSS attribute selectors. |
+| `origin` | `Option<String>` | Origin identifier. Auto-set to `"rust-sdk@{version}"`. |
+
+There is also `client.scrape_with_schema(url, schema, prompt).await` for JSON extraction convenience.
+
+## Interact
+
+### Why use it
+
+Continue interacting with a live browser session after scraping. Execute code or send natural-language prompts to control the page — click buttons, fill forms, navigate, and extract dynamic content.
+
+### Preferred SDK method
+
+`client.interact(job_id, options).await`
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, ScrapeExecuteOptions, Format};
+
+let client = Client::new("fc-YOUR_API_KEY")?;
+
+let document = client.scrape("https://www.amazon.com", ScrapeOptions {
+    formats: Some(vec![Format::Markdown]),
+    ..Default::default()
+}).await?;
+
+// Get the scrape ID from the document metadata
+let scrape_id = "scrape-id-from-metadata";
+
+let response = client.interact(scrape_id, ScrapeExecuteOptions {
+    prompt: Some("Search for iPhone 16 Pro Max".to_string()),
+    ..Default::default()
+}).await?;
+
+if let Some(output) = &response.output {
+    println!("{}", output);
+}
+
+client.stop_interaction(scrape_id).await?;
+```
+
+### Parameters
+
+`ScrapeExecuteOptions` fields:
+
+| Parameter | Type | Description |
+|---|---|---|
+| `code` | `Option<String>` | Code to execute in the browser session. One of `code` or `prompt` is required. |
+| `prompt` | `Option<String>` | Natural-language instruction for the browser agent. One of `code` or `prompt` is required. |
+| `language` | `Option<ScrapeExecuteLanguage>` | Runtime: `Python`, `Node`, `Bash`. Defaults to `Node`. |
+| `timeout` | `Option<u32>` | Execution timeout in seconds. |
+| `origin` | `Option<String>` | Origin identifier. Auto-set to `"rust-sdk@{version}"`. |
+
+Call `client.stop_interaction(job_id).await` to end the browser session when done.
+
+## Notes
+
+- **Struct literal construction**: All options use `..Default::default()` for unset fields. No builder pattern.
+- **`impl Into<Option<T>>` pattern**: `scrape()` and `search()` accept `None` directly or a bare options struct — no need to wrap in `Some(...)`.
+- **`impl AsRef<str>` parameters**: `url`, `query`, and `job_id` accept `&str`, `String`, or any `AsRef<str>` type.
+- **serde camelCase**: All fields serialize to camelCase JSON. `redact_pii` has a manual rename to `"redactPII"`.
+- **Format enum variants with data**: `Question(QuestionFormat)`, `Highlights(HighlightsFormat)`, and `Query(QueryFormat)` carry payloads and serialize as JSON objects with a `"type"` discriminator.
+- **All methods are async** and require a tokio runtime.
+- **Deprecated aliases**: `scrape_execute` -> `interact`, `stop_interactive_browser` / `delete_scrape_browser` -> `stop_interaction`.
+
+## Source Of Truth
+
+- SDK source: `firecrawl/apps/rust-sdk/src/v2/client.rs`, `firecrawl/apps/rust-sdk/src/v2/scrape.rs`, `firecrawl/apps/rust-sdk/src/v2/search.rs`
+- OpenAPI spec: `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs.json
+++ b/docs.json
@@ -615,6 +615,16 @@
                     ]
                   },
                   {
+                    "group": "Agent Quickstarts",
+                    "pages": [
+                      "agent-quickstart/node",
+                      "agent-quickstart/python",
+                      "agent-quickstart/rust",
+                      "agent-quickstart/java",
+                      "agent-quickstart/elixir"
+                    ]
+                  },
+                  {
                     "group": "AI Tools",
                     "pages": [
                       "sdks/cli",


### PR DESCRIPTION
## Summary

- Adds canonical agent quickstart docs for **Node.js**, **Python**, **Rust**, **Java**, and **Elixir** in `agent-quickstart/`
- Each file covers `search`, `scrape`, and `interact` with every confirmed SDK parameter, short descriptions, and realistic examples
- Generated from SDK source code and the OpenAPI spec (`v2-openapi.json`), not from existing docs
- Adds an "Agent Quickstarts" navigation group to the "Build with AI" tab in `docs.json`

## What each file includes

- Install command and auth pattern
- "When to use what" decision guide (search vs scrape vs interact)
- For each endpoint: why to use it, preferred SDK method name, working example, and a full parameter table
- Language-specific notes (naming conventions, deprecated aliases, SDK quirks)
- Source of truth references

## Language-specific highlights

- **Node.js / Python / Rust**: Document both `code` and `prompt` for interact
- **Java / Elixir**: Document that interact only supports `code` (no `prompt`)
- **Elixir**: Uses OpenAPI-generated function names (`search_and_scrape`, `scrape_and_extract_from_url`, `interact_with_scrape_browser_session`)
- **Rust**: Documents struct literal construction with `..Default::default()`
- **Java**: Documents builder pattern and `CompletableFuture` async variants

## Test plan

- [ ] Verify each `.mdx` file renders cleanly in Mintlify
- [ ] Confirm the "Agent Quickstarts" group appears in the "Build with AI" tab navigation
- [ ] Spot-check parameter tables against SDK source for accuracy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fr6Ntt6fFQwso5EmBudTeT)_