### PR TITLE
docs(parse): snippet-based CodeGroups for pages and blocks examples

### DIFF
--- a/features/parse.mdx
+++ b/features/parse.mdx
@@ -8,6 +8,13 @@ version: "v2"
 sidebarTitle: "Parse"
 ---
 
+import ParsePagesPython from "/snippets/v2/parse/pages/python.mdx";
+import ParsePagesNode from "/snippets/v2/parse/pages/js.mdx";
+import ParsePagesCURL from "/snippets/v2/parse/pages/curl.mdx";
+import ParseBlocksPython from "/snippets/v2/parse/blocks/python.mdx";
+import ParseBlocksNode from "/snippets/v2/parse/blocks/js.mdx";
+import ParseBlocksCURL from "/snippets/v2/parse/blocks/curl.mdx";
+
 Parse converts documents into clean, LLM-ready data. Upload a file to
 [`/parse`](/api-reference/endpoint/parse) — or point [`/scrape`](/features/scrape)
 at a public document URL — and get back markdown, per-page content, typed
@@ -101,12 +108,15 @@ carries a `pages` array with the physical per-page markdown — useful when you
 need to know which page content came from, or to process pages independently.
 No additional cost.
 
-```bash cURL
-curl -X POST https://api.firecrawl.dev/v2/parse \
-  -H 'Authorization: Bearer YOUR_API_KEY' \
-  -F 'file=@./report.pdf' \
-  -F 'options={"parsers":[{"type":"pdf","pages":true}]};type=application/json'
-```
+<CodeGroup>
+
+  <ParsePagesPython />
+
+  <ParsePagesNode />
+
+  <ParsePagesCURL />
+
+</CodeGroup>
 
 ```json
 "pages": [
@@ -127,12 +137,15 @@ overlays, or auditing what a document contains. No additional cost.
   <img src="/images/pdf-blocks-overlay.png" alt="A parsed PDF page with colored bounding boxes overlaid on each detected layout block: title, text, section headers, table, figure, caption, page footer, and page number" />
 </Frame>
 
-```bash cURL
-curl -X POST https://api.firecrawl.dev/v2/parse \
-  -H 'Authorization: Bearer YOUR_API_KEY' \
-  -F 'file=@./report.pdf' \
-  -F 'options={"parsers":[{"type":"pdf","blocks":true}]};type=application/json'
-```
+<CodeGroup>
+
+  <ParseBlocksPython />
+
+  <ParseBlocksNode />
+
+  <ParseBlocksCURL />
+
+</CodeGroup>
 
 ```json
 "blocks": [

--- a/features/parse.mdx
+++ b/features/parse.mdx
@@ -14,6 +14,9 @@ import ParsePagesCURL from "/snippets/v2/parse/pages/curl.mdx";
 import ParseBlocksPython from "/snippets/v2/parse/blocks/python.mdx";
 import ParseBlocksNode from "/snippets/v2/parse/blocks/js.mdx";
 import ParseBlocksCURL from "/snippets/v2/parse/blocks/curl.mdx";
+import ParseJsonPython from "/snippets/v2/parse/json/python.mdx";
+import ParseJsonNode from "/snippets/v2/parse/json/js.mdx";
+import ParseJsonCURL from "/snippets/v2/parse/json/curl.mdx";
 
 Parse converts documents into clean, LLM-ready data. Upload a file to
 [`/parse`](/api-reference/endpoint/parse) — or point [`/scrape`](/features/scrape)
@@ -207,12 +210,15 @@ def ground(doc, quote: str):
 
 Pass a JSON schema or prompt to extract structured data directly from the document:
 
-```bash cURL
-curl -X POST https://api.firecrawl.dev/v2/parse \
-  -H 'Authorization: Bearer YOUR_API_KEY' \
-  -F 'file=@./invoice.pdf' \
-  -F 'options={"formats":[{"type":"json","schema":{"type":"object","properties":{"total":{"type":"number"},"vendor":{"type":"string"}}}}]};type=application/json'
-```
+<CodeGroup>
+
+  <ParseJsonPython />
+
+  <ParseJsonNode />
+
+  <ParseJsonCURL />
+
+</CodeGroup>
 
 ## PDF options
 

--- a/features/parse.mdx
+++ b/features/parse.mdx
@@ -17,6 +17,8 @@ import ParseBlocksCURL from "/snippets/v2/parse/blocks/curl.mdx";
 import ParseJsonPython from "/snippets/v2/parse/json/python.mdx";
 import ParseJsonNode from "/snippets/v2/parse/json/js.mdx";
 import ParseJsonCURL from "/snippets/v2/parse/json/curl.mdx";
+import ParseGroundingPython from "/snippets/v2/parse/grounding/python.mdx";
+import ParseGroundingNode from "/snippets/v2/parse/grounding/js.mdx";
 
 Parse converts documents into clean, LLM-ready data. Upload a file to
 [`/parse`](/api-reference/endpoint/parse) — or point [`/scrape`](/features/scrape)
@@ -196,15 +198,13 @@ quoted text in the markdown, find the block whose span covers that offset,
 and you have the page number and bounding box — without ever asking a
 language model for coordinates.
 
-```python Python
-def ground(doc, quote: str):
-    start = doc["markdown"].find(quote)
-    for page in doc["blocks"]:
-        for block in page["items"]:
-            span = block["markdownSpan"]
-            if span and span[0] <= start < span[1]:
-                return page["pageNumber"], block["bbox"]
-```
+<CodeGroup>
+
+  <ParseGroundingPython />
+
+  <ParseGroundingNode />
+
+</CodeGroup>
 
 ## Structured JSON output
 

--- a/snippets/v2/parse/blocks/curl.mdx
+++ b/snippets/v2/parse/blocks/curl.mdx
@@ -1,0 +1,6 @@
+```bash cURL
+curl -X POST https://api.firecrawl.dev/v2/parse \
+  -H 'Authorization: Bearer YOUR_API_KEY' \
+  -F 'file=@./report.pdf' \
+  -F 'options={"parsers":[{"type":"pdf","blocks":true}]};type=application/json'
+```

--- a/snippets/v2/parse/blocks/js.mdx
+++ b/snippets/v2/parse/blocks/js.mdx
@@ -1,0 +1,17 @@
+```js Node
+import { Firecrawl } from "firecrawl";
+import fs from "node:fs";
+
+const firecrawl = new Firecrawl({ apiKey: "fc-YOUR-API-KEY" });
+
+const doc = await firecrawl.parse(
+  { data: fs.readFileSync("./report.pdf"), filename: "report.pdf" },
+  { parsers: [{ type: "pdf", blocks: true }] },
+);
+
+for (const page of doc.blocks) {
+  for (const block of page.items) {
+    console.log(page.pageNumber, block.type, block.bbox);
+  }
+}
+```

--- a/snippets/v2/parse/blocks/python.mdx
+++ b/snippets/v2/parse/blocks/python.mdx
@@ -1,0 +1,15 @@
+```python Python
+from firecrawl import Firecrawl
+from firecrawl.v2.types import ScrapeOptions
+
+firecrawl = Firecrawl(api_key="fc-YOUR-API-KEY")
+
+doc = firecrawl.parse(
+    "./report.pdf",
+    options=ScrapeOptions(parsers=[{"type": "pdf", "blocks": True}]),
+)
+
+for page in doc.blocks:
+    for block in page.items:
+        print(page.page_number, block.type, block.bbox)
+```

--- a/snippets/v2/parse/grounding/js.mdx
+++ b/snippets/v2/parse/grounding/js.mdx
@@ -1,0 +1,13 @@
+```js Node
+function ground(doc, quote) {
+  const start = doc.markdown.indexOf(quote);
+  for (const page of doc.blocks) {
+    for (const block of page.items) {
+      const span = block.markdownSpan;
+      if (span && span[0] <= start && start < span[1]) {
+        return { pageNumber: page.pageNumber, bbox: block.bbox };
+      }
+    }
+  }
+}
+```

--- a/snippets/v2/parse/grounding/python.mdx
+++ b/snippets/v2/parse/grounding/python.mdx
@@ -1,0 +1,9 @@
+```python Python
+def ground(doc, quote: str):
+    start = doc["markdown"].find(quote)
+    for page in doc["blocks"]:
+        for block in page["items"]:
+            span = block["markdownSpan"]
+            if span and span[0] <= start < span[1]:
+                return page["pageNumber"], block["bbox"]
+```

--- a/snippets/v2/parse/json/curl.mdx
+++ b/snippets/v2/parse/json/curl.mdx
@@ -1,0 +1,6 @@
+```bash cURL
+curl -X POST https://api.firecrawl.dev/v2/parse \
+  -H 'Authorization: Bearer YOUR_API_KEY' \
+  -F 'file=@./invoice.pdf' \
+  -F 'options={"formats":[{"type":"json","schema":{"type":"object","properties":{"total":{"type":"number"},"vendor":{"type":"string"}}}}]};type=application/json'
+```

--- a/snippets/v2/parse/json/js.mdx
+++ b/snippets/v2/parse/json/js.mdx
@@ -1,0 +1,19 @@
+```js Node
+import { Firecrawl } from "firecrawl";
+import fs from "node:fs";
+import { z } from "zod";
+
+const firecrawl = new Firecrawl({ apiKey: "fc-YOUR-API-KEY" });
+
+const schema = z.object({
+  vendor: z.string(),
+  total: z.number(),
+});
+
+const doc = await firecrawl.parse(
+  { data: fs.readFileSync("./invoice.pdf"), filename: "invoice.pdf" },
+  { formats: [{ type: "json", schema }] },
+);
+
+console.log(doc.json);
+```

--- a/snippets/v2/parse/json/python.mdx
+++ b/snippets/v2/parse/json/python.mdx
@@ -1,0 +1,21 @@
+```python Python
+from firecrawl import Firecrawl
+from firecrawl.v2.types import ScrapeOptions
+from pydantic import BaseModel
+
+firecrawl = Firecrawl(api_key="fc-YOUR-API-KEY")
+
+class Invoice(BaseModel):
+    vendor: str
+    total: float
+
+doc = firecrawl.parse(
+    "./invoice.pdf",
+    options=ScrapeOptions(formats=[{
+        "type": "json",
+        "schema": Invoice.model_json_schema(),
+    }]),
+)
+
+print(doc.json)
+```

--- a/snippets/v2/parse/pages/curl.mdx
+++ b/snippets/v2/parse/pages/curl.mdx
@@ -1,0 +1,6 @@
+```bash cURL
+curl -X POST https://api.firecrawl.dev/v2/parse \
+  -H 'Authorization: Bearer YOUR_API_KEY' \
+  -F 'file=@./report.pdf' \
+  -F 'options={"parsers":[{"type":"pdf","pages":true}]};type=application/json'
+```

--- a/snippets/v2/parse/pages/js.mdx
+++ b/snippets/v2/parse/pages/js.mdx
@@ -1,0 +1,15 @@
+```js Node
+import { Firecrawl } from "firecrawl";
+import fs from "node:fs";
+
+const firecrawl = new Firecrawl({ apiKey: "fc-YOUR-API-KEY" });
+
+const doc = await firecrawl.parse(
+  { data: fs.readFileSync("./report.pdf"), filename: "report.pdf" },
+  { parsers: [{ type: "pdf", pages: true }] },
+);
+
+for (const page of doc.pages) {
+  console.log(page.pageNumber, page.markdown.slice(0, 80));
+}
+```

--- a/snippets/v2/parse/pages/python.mdx
+++ b/snippets/v2/parse/pages/python.mdx
@@ -1,0 +1,14 @@
+```python Python
+from firecrawl import Firecrawl
+from firecrawl.v2.types import ScrapeOptions
+
+firecrawl = Firecrawl(api_key="fc-YOUR-API-KEY")
+
+doc = firecrawl.parse(
+    "./report.pdf",
+    options=ScrapeOptions(parsers=[{"type": "pdf", "pages": True}]),
+)
+
+for page in doc.pages:
+    print(page.page_number, page.markdown[:80])
+```


### PR DESCRIPTION
Follow-up to #1281: converts the pages/blocks examples from inline cURL-only blocks to the house snippet pattern — per-language files under `snippets/v2/parse/{pages,blocks}/` imported into Python / Node / cURL CodeGroups.

Each SDK example also shows consuming the result (iterating `doc.pages` / `doc.blocks[].items`), not just making the request.

Note: the SDK examples use the `pages`/`blocks` parser options that are landing in the current SDK release — merge alongside/after that release ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)