### PR TITLE
docs: add Browser Sandbox page to navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -192,6 +192,7 @@
                           "features/monitoring-web-scale"
                         ]
                       },
+                      "features/browser",
                       "features/interact"
                     ]
                   },


### PR DESCRIPTION
## Summary

Adds the existing `features/browser` page to the base English navigation beside `features/interact`. The page is live, but the missing entry keeps Browser Sandbox out of the sidebar, `sitemap.xml`, and `llms.txt`.

## Validation

- Parsed `docs.json` with Python.
- Passed `git diff --check`.
- Confirmed `/features/browser` returns 200 but is absent from the current `sitemap.xml` and `llms.txt`.

## Scope

This change adds one line to `docs.json`. Localized navigation entries and existing redirects remain unchanged.
