### PR TITLE
docs(research): remove GitHub history from Research Index

### DIFF
--- a/features/developer.mdx
+++ b/features/developer.mdx
@@ -20,6 +20,10 @@ npx skills add firecrawl/skills@firecrawl-developer-index
 ```
 </Note>
 
+## How this relates to the Research Index
+
+The [Research Index](/features/research) is a separate index. Literature work (paper abstracts from PubMed, bioRxiv, medRxiv, and arXiv) goes there. This page is the developer index only.
+
 ## Endpoints
 
 | Task | Endpoint |

--- a/features/developer.mdx
+++ b/features/developer.mdx
@@ -20,10 +20,6 @@ npx skills add firecrawl/skills@firecrawl-developer-index
 ```
 </Note>
 
-## How this relates to the Research Index
-
-The [Research Index](/features/research) is a separate index. Literature work (paper abstracts from PubMed, bioRxiv, medRxiv, and arXiv) goes there. This page is the developer index only.
-
 ## Endpoints
 
 | Task | Endpoint |

--- a/features/research.mdx
+++ b/features/research.mdx
@@ -34,7 +34,7 @@ Firecrawl has two things named "research", and they are not the same feature:
 | Can it expand by citations | Yes — `GET /search/research/papers/{id}/similar` | No |
 | Endpoint | `GET /search/research/papers` | `POST /search` |
 
-Use the Research Index when you are doing literature work: finding papers, reading them, and following citations. Use [`categories: ["research"]`](/features/search#search-categories) when you want ordinary web pages that happen to live on academic domains. Use the [Developer Index](/features/developer) for issues, merged pull requests, READMEs, and curated documentation.
+Use the Research Index when you are doing literature work: finding papers, reading them, and following citations. Use [`categories: ["research"]`](/features/search#search-categories) when you want ordinary web pages that happen to live on academic domains.
 
 ## Endpoints
 

--- a/features/research.mdx
+++ b/features/research.mdx
@@ -34,11 +34,7 @@ Firecrawl has two things named "research", and they are not the same feature:
 | Can it expand by citations | Yes — `GET /search/research/papers/{id}/similar` | No |
 | Endpoint | `GET /search/research/papers` | `POST /search` |
 
-Use the Research Index when you are doing literature work: finding papers, reading them, and following citations. Use [`categories: ["research"]`](/features/search#search-categories) when you want ordinary web pages that happen to live on academic domains.
-
-## How this relates to the Developer Index
-
-The [Developer Index](/features/developer) is a separate index. Coding questions (issues, merged pull requests, READMEs, and curated documentation) go there. This page is the paper index only.
+Use the Research Index when you are doing literature work: finding papers, reading them, and following citations. Use [`categories: ["research"]`](/features/search#search-categories) when you want ordinary web pages that happen to live on academic domains. Use the [Developer Index](/features/developer) for issues, merged pull requests, READMEs, and curated documentation.
 
 ## Endpoints
 

--- a/features/research.mdx
+++ b/features/research.mdx
@@ -36,6 +36,10 @@ Firecrawl has two things named "research", and they are not the same feature:
 
 Use the Research Index when you are doing literature work: finding papers, reading them, and following citations. Use [`categories: ["research"]`](/features/search#search-categories) when you want ordinary web pages that happen to live on academic domains.
 
+## How this relates to the Developer Index
+
+The [Developer Index](/features/developer) is a separate index. Coding questions (issues, merged pull requests, READMEs, and curated documentation) go there. This page is the paper index only.
+
 ## Endpoints
 
 | Task | Endpoint |
@@ -287,7 +291,3 @@ Modes:
 - `similar`: co-citation and bibliographic-coupling neighborhood
 - `citers`: papers that cite the seed
 - `references`: papers cited by the seed
-
-## Search GitHub history
-
-Issues, merged pull requests, and repository READMEs now live in the [Developer Index](/features/developer), which ranks them with the matched passages and adds curated documentation sources alongside them. Use [`GET` or `POST /search/developer`](/api-reference/endpoint/developer-search), or `/search` with `categories: ["developer"]`.


### PR DESCRIPTION
## Why

The Research Index feature page documented issue, pull request, and README search. That does not belong on the paper index. Removing it keeps Research Index papers-only.

## Summary

- Delete the GitHub history section from `/features/research`.
- Do not mention the Developer Index on that page.
- Leave `/features/developer` and the `/api-reference/endpoint/research-github-search` → `/api-reference/endpoint/developer-search` redirect unchanged.
- English source only. Locale files are untouched.

## Test plan

- [ ] Open `/features/research`. Confirm there is no "Search GitHub history" heading and no Developer Index link.
- [ ] Confirm `/features/developer` is unchanged.
- [ ] Confirm `/api-reference/endpoint/research-github-search` still 308-redirects to `/api-reference/endpoint/developer-search`.
- [ ] Confirm locale research pages were not modified.