### PR TITLE
docs: match developer search docs to the actual wire

### DIFF
--- a/api-reference/endpoint/developer-search.mdx
+++ b/api-reference/endpoint/developer-search.mdx
@@ -26,9 +26,9 @@ Because each filter only applies to one half, a filter that cannot match any req
 
 The seven repository filters — `language` (such as `Rust`), `topic` (such as `async`), `license` (such as `MIT`), `min_stars`, `max_stars`, `archived`, and `fork` — describe a code repository. Most documentation pages in the index come from a crawled website with no repository behind it, and no repository fact can admit or exclude such a page.
 
-A request that sends one of these filters and no `sources` scope therefore gets no `doc` results. Its response holds repository evidence only: the `issue`, `pull_request`, and `readme` types. The `coverage` map reports `doc` as `unavailable`, because the documentation half of the index never ran. This is the design, not an index fault.
+A request that sends one of these filters and no `sources` scope therefore gets no `doc` results. Its response holds repository evidence only: the `issue`, `pull_request`, and `readme` types, because the documentation half of the index never ran. This is the design, not an index fault.
 
-To keep documentation results, drop the repository filters. You can also scope the documentation half with `sources`, then read `coverage` to confirm that the `doc` type answered.
+To keep documentation results, drop the repository filters. You can also scope the documentation half with `sources`, then read the `sources` echo in the response to confirm the id is indexed.
 
 <CodeGroup>
 
@@ -87,11 +87,5 @@ To confirm an id resolves, pass it and read the `sources` array the response add
 }
 ```
 
-## Reading `coverage`
-
-`coverage` reports the outcome for each result type, one of `ok`, `degraded`, `unavailable`, or `skipped`. Check it when a result type you expected is missing:
-
-- `skipped` means your `types` value did not ask for that type
-- `degraded` or `unavailable` means the gap came from the index or from a filter, not from the query. A repository filter is one such cause, as [how the repository filters scope a search](#how-the-repository-filters-scope-a-search) describes
 
 For a workflow overview, see the [Developer Index guide](/features/developer).

--- a/features/developer.mdx
+++ b/features/developer.mdx
@@ -31,7 +31,7 @@ npx skills add firecrawl/skills@firecrawl-developer-index
 
 Send a natural-language question and get back ranked developer results with the passages that matched. This is the path to reach for when you want developer sources only, with the result type, repository, and documentation source filters available.
 
-A developer search costs 2 credits per 10 results, rounded up (1–10 results = 2 credits, 11–20 = 4 credits, and so on). No API key is needed to get started; send one for higher rate limits. Keyless requests are accepted from ordinary network connections only — traffic from VPNs, proxies, and hosting-provider IPs receives a `403` and needs an API key.
+A developer search costs 2 credits per 10 results, rounded up (1–10 results = 2 credits, 11–20 = 4 credits, and so on). No API key is needed to get started; send one for higher rate limits.
 
 <CodeGroup>
 

--- a/features/developer.mdx
+++ b/features/developer.mdx
@@ -31,7 +31,7 @@ npx skills add firecrawl/skills@firecrawl-developer-index
 
 Send a natural-language question and get back ranked developer results with the passages that matched. This is the path to reach for when you want developer sources only, with the result type, repository, and documentation source filters available.
 
-A developer search costs 2 credits per 10 results, rounded up (1–10 results = 2 credits, 11–20 = 4 credits, and so on). No API key is needed to get started; send one for higher rate limits.
+A developer search costs 2 credits per 10 results, rounded up (1–10 results = 2 credits, 11–20 = 4 credits, and so on). No API key is needed to get started; add one for higher rate limits.
 
 <CodeGroup>
 

--- a/features/developer.mdx
+++ b/features/developer.mdx
@@ -31,7 +31,7 @@ npx skills add firecrawl/skills@firecrawl-developer-index
 
 Send a natural-language question and get back ranked developer results with the passages that matched. This is the path to reach for when you want developer sources only, with the result type, repository, and documentation source filters available.
 
-A developer search costs 2 credits per 10 results, rounded up (1–10 results = 2 credits, 11–20 = 4 credits, and so on). No API key is needed to get started; send one for higher rate limits.
+A developer search costs 2 credits per 10 results, rounded up (1–10 results = 2 credits, 11–20 = 4 credits, and so on). No API key is needed to get started; send one for higher rate limits. Keyless requests are accepted from ordinary network connections only — traffic from VPNs, proxies, and hosting-provider IPs receives a `403` and needs an API key.
 
 <CodeGroup>
 
@@ -59,9 +59,9 @@ curl -X POST https://api.firecrawl.dev/v2/search/developer \
   }'
 ```
 
-Each result carries a stable `id` such as `issue:owner/repo#123`, a `type` of `doc`, `issue`, `pull_request`, or `readme`, a `url`, and its matched `passages` in markdown, so tables and code blocks survive. `title` is frequently absent on `doc` results, where the source page carries no usable title, so fall back to `url` rather than assuming the field is present.
+Each result carries a stable `id` such as `issue:owner/repo#123`, a `url`, and its matched `passages` in markdown, so tables and code blocks survive. The artifact kind is encoded in the `id` prefix: `doc:`, `issue:`, `pull_request:`, or `readme:`. `title` is frequently absent on `doc` results, where the source page carries no usable title, so fall back to `url` rather than assuming the field is present.
 
-Alongside the results, `coverage` reports the outcome for each result type and `reranked` reports whether the ranked list went through the reranking stage. Check `coverage` when a result type you expected is missing: `skipped` means your `types` value did not ask for that type, while `degraded` or `unavailable` means the gap came from the index or from a filter, not from the query.
+When you scope a search with `sources` or `repos`, the response echoes them back with an `indexed` flag per entry, so you can distinguish an id that is not in the index from a query that simply found nothing. See the [developer search reference](/api-reference/endpoint/developer-search) for the echo shape.
 
 Optional filters narrow the search:
 
@@ -71,7 +71,7 @@ Optional filters narrow the search:
 - `skills` set to `only` limits the search to indexed agent-skill files
 - `language`, `topic`, `license`, `min_stars`, `max_stars`, `archived`, and `fork` filter on repository attributes, such as `language=Rust`, `topic=async`, or `license=MIT`
 
-Those seven filters describe a code repository, so sending one without a `sources` scope returns no `doc` results and reports `doc` as `unavailable` in `coverage`. Read [how the repository filters scope a search](/api-reference/endpoint/developer-search#how-the-repository-filters-scope-a-search) before you send one.
+Those seven filters describe a code repository, so sending one without a `sources` scope returns no `doc` results. Read [how the repository filters scope a search](/api-reference/endpoint/developer-search#how-the-repository-filters-scope-a-search) before you send one.
 
 See the [developer search reference](/api-reference/endpoint/developer-search) for every filter's type and bounds, how `repos` and `sources` scope a search, and the full response schema.
 


### PR DESCRIPTION
Verified against live production responses (both the gateway `/v2/search/developer` and the service directly):

- **Removed `type` from the documented result shape** — the wire doesn't carry it; the artifact kind is the `id` prefix (`doc:`, `issue:`, `pull_request:`, `readme:`). ⚠️ The launch blog also claims a `type` field — same discrepancy.
- **Removed `coverage` and `reranked`** — both are internal (`#[serde(skip)]`, metrics/canonical logs only), never serialized.
- Kept the `sources`/`repos` echo docs — verified real (`{source, indexed}` when the param is sent).
- Added the keyless suspicious-IP/VPN 403 note to prevent "your example doesn't work" support noise.

Wire truth (live probe): result keys = `id, url, title, passages, license`.