### PR TITLE
docs: pageMarkers PDF parser option

### DIFF
--- a/advanced-scraping-guide.mdx
+++ b/advanced-scraping-guide.mdx
@@ -195,7 +195,7 @@ These parameters control which parts of the page appear in the output. When `onl
 | `parsers` | `array` | `["pdf"]` | Controls PDF processing. `[]` to skip parsing and return base64 (1 credit flat). |
 
 ```json
-{ "type": "pdf", "mode": "fast" | "auto" | "ocr", "maxPages": 10, "pages": true, "blocks": true }
+{ "type": "pdf", "mode": "fast" | "auto" | "ocr", "maxPages": 10, "pages": true, "blocks": true, "pageMarkers": true }
 ```
 
 | Property | Type | Default | Description |
@@ -205,6 +205,7 @@ These parameters control which parts of the page appear in the output. When `onl
 | `maxPages` | `integer` | — | Cap the number of pages to parse. |
 | `pages` | `boolean` | `false` | Also return physical per-page markdown in the document's `pages` field. No additional cost. |
 | `blocks` | `boolean` | `false` | Also return per-page typed layout blocks (normalized bounding boxes, block types, reading order, markdown character spans) in the document's `blocks` field. No additional cost. |
+| `pageMarkers` | `boolean` | `false` | Annotate page breaks in the document markdown with `<!-- page N -->` markers (between pages only; numbering may skip pages merged across a break — see [Parse](/features/parse#page-markers-pdf)). No additional cost. |
 
 ### Actions
 

--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -7108,6 +7108,11 @@
                       "type": "boolean",
                       "default": false,
                       "description": "Include per-page typed layout blocks alongside the document markdown. Populates the `blocks` field on the document: typed blocks (title, section_header, text, table, formula, figure, caption, ...) with normalized bounding boxes, reading order, character-span links into the markdown, and per-block confidence. No additional cost."
+                    },
+                    "pageMarkers": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Annotate page breaks in the document markdown: pages are joined with `\\n\\n---\\n\\n<!-- page N -->\\n\\n`, where N is the 1-based physical page of the content that follows. Markers appear between pages only (no leading marker for page 1), and numbering may skip pages merged across a page break — use `pages: true` when every physical page is needed. No new response field; no additional cost."
                     }
                   },
                   "required": [
@@ -7280,6 +7285,11 @@
                       "type": "boolean",
                       "default": false,
                       "description": "Include per-page typed layout blocks alongside the document markdown. Populates the `blocks` field on the document: typed blocks (title, section_header, text, table, formula, figure, caption, ...) with normalized bounding boxes, reading order, character-span links into the markdown, and per-block confidence. No additional cost."
+                    },
+                    "pageMarkers": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Annotate page breaks in the document markdown: pages are joined with `\\n\\n---\\n\\n<!-- page N -->\\n\\n`, where N is the 1-based physical page of the content that follows. Markers appear between pages only (no leading marker for page 1), and numbering may skip pages merged across a page break — use `pages: true` when every physical page is needed. No new response field; no additional cost."
                     }
                   },
                   "required": [

--- a/features/parse.mdx
+++ b/features/parse.mdx
@@ -11,6 +11,9 @@ sidebarTitle: "Parse"
 import ParsePagesPython from "/snippets/v2/parse/pages/python.mdx";
 import ParsePagesNode from "/snippets/v2/parse/pages/js.mdx";
 import ParsePagesCURL from "/snippets/v2/parse/pages/curl.mdx";
+import ParsePageMarkersPython from "/snippets/v2/parse/page-markers/python.mdx";
+import ParsePageMarkersNode from "/snippets/v2/parse/page-markers/js.mdx";
+import ParsePageMarkersCURL from "/snippets/v2/parse/page-markers/curl.mdx";
 import ParseBlocksPython from "/snippets/v2/parse/blocks/python.mdx";
 import ParseBlocksNode from "/snippets/v2/parse/blocks/js.mdx";
 import ParseBlocksCURL from "/snippets/v2/parse/blocks/curl.mdx";
@@ -104,7 +107,9 @@ when the page count can't be determined.
 Beyond the document markdown, three outputs cover the cases where a single
 markdown string isn't enough: [per-page markdown](#per-page-markdown-pdf) and
 [layout blocks](#layout-blocks-pdf) for PDF documents, and
-[structured JSON](#structured-json-output) for every format.
+[structured JSON](#structured-json-output) for every format. And when all you
+need is page attribution *inside* the markdown itself,
+[page markers](#page-markers-pdf) annotate the page breaks in place.
 
 ## Per-page markdown (PDF)
 
@@ -129,6 +134,45 @@ No additional cost.
   { "pageNumber": 2, "markdown": "..." }
 ]
 ```
+
+## Page markers (PDF)
+
+Set `pageMarkers: true` on the [PDF parser](#pdf-options) and pages in the
+document `markdown` itself are joined with an HTML-comment marker naming the
+physical page that follows:
+
+```markdown
+...end of page 1
+
+---
+
+<!-- page 2 -->
+
+start of page 2...
+```
+
+There is no new response field — the markers travel inside the markdown, so
+any downstream pipeline that only handles a markdown string keeps per-page
+attribution. The comments are invisible when the markdown is rendered and
+trivial to split on (`<!-- page N -->`, 1-based). No additional cost.
+
+<CodeGroup>
+
+  <ParsePageMarkersPython />
+
+  <ParsePageMarkersNode />
+
+  <ParsePageMarkersCURL />
+
+</CodeGroup>
+
+<Note>
+Markers appear **between** pages only — there is no leading marker for page 1.
+Numbering may skip a page when the parser merges content across a page break
+(a table or sentence continuing onto the next page leaves no boundary to
+mark). Use [`pages: true`](#per-page-markdown-pdf) when you need every
+physical page separately; the two options compose.
+</Note>
 
 ## Layout blocks (PDF)
 
@@ -233,7 +277,8 @@ All PDF behavior is controlled through the `parsers` option — on `/parse` and
       "mode": "auto",
       "maxPages": 100,
       "pages": true,
-      "blocks": true
+      "blocks": true,
+      "pageMarkers": true
     }
   ]
 }
@@ -246,6 +291,7 @@ All PDF behavior is controlled through the `parsers` option — on `/parse` and
 | `maxPages` | `integer` | — | Cap the number of pages to parse. |
 | `pages` | `boolean` | `false` | Also return [per-page markdown](#per-page-markdown-pdf). No additional cost. |
 | `blocks` | `boolean` | `false` | Also return [layout blocks](#layout-blocks-pdf) with bounding boxes. No additional cost. |
+| `pageMarkers` | `boolean` | `false` | Annotate page breaks in the document markdown with [`<!-- page N -->` markers](#page-markers-pdf). No additional cost. |
 
 Passing `parsers: []` skips parsing entirely and returns the PDF as base64
 (1 credit flat).
@@ -288,7 +334,7 @@ optional `options` JSON part. `options` accepts a subset of scrape options:
 ## Considerations
 
 - Maximum file size is **50 MB** per request.
-- PDF parsing is billed at **1 credit per page**; the `pages` and `blocks` options add no cost.
+- PDF parsing is billed at **1 credit per page**; the `pages`, `blocks`, and `pageMarkers` options add no cost.
 - Parsing very large or scanned PDFs in `ocr` mode may take longer — increase `timeout` or use `maxPages` to bound the work.
 - For batches of files, call `/parse` per file in parallel; there is no batch upload variant.
 

--- a/snippets/v2/parse/page-markers/curl.mdx
+++ b/snippets/v2/parse/page-markers/curl.mdx
@@ -1,0 +1,6 @@
+```bash cURL
+curl -X POST https://api.firecrawl.dev/v2/parse \
+  -H 'Authorization: Bearer YOUR_API_KEY' \
+  -F 'file=@./report.pdf' \
+  -F 'options={"parsers":[{"type":"pdf","pageMarkers":true}]};type=application/json'
+```

--- a/snippets/v2/parse/page-markers/js.mdx
+++ b/snippets/v2/parse/page-markers/js.mdx
@@ -1,0 +1,20 @@
+```js Node
+import { Firecrawl } from "firecrawl";
+import fs from "node:fs";
+
+const firecrawl = new Firecrawl({ apiKey: "fc-YOUR-API-KEY" });
+
+const doc = await firecrawl.parse(
+  { data: fs.readFileSync("./report.pdf"), filename: "report.pdf" },
+  { parsers: [{ type: "pdf", pageMarkers: true }] },
+);
+
+console.log(doc.markdown);
+// ...end of page 1
+//
+// ---
+//
+// <!-- page 2 -->
+//
+// start of page 2...
+```

--- a/snippets/v2/parse/page-markers/python.mdx
+++ b/snippets/v2/parse/page-markers/python.mdx
@@ -1,0 +1,20 @@
+```python Python
+from firecrawl import Firecrawl
+from firecrawl.v2.types import ScrapeOptions
+
+firecrawl = Firecrawl(api_key="fc-YOUR-API-KEY")
+
+doc = firecrawl.parse(
+    "./report.pdf",
+    options=ScrapeOptions(parsers=[{"type": "pdf", "page_markers": True}]),
+)
+
+print(doc.markdown)
+# ...end of page 1
+#
+# ---
+#
+# <!-- page 2 -->
+#
+# start of page 2...
+```


### PR DESCRIPTION
## What

Documents the new `parsers: [{ "type": "pdf", "pageMarkers": true }]` option (API: firecrawl/firecrawl#4365, SDKs: firecrawl/firecrawl#4379, live in prod). When set, PDF pages in `document.markdown` are joined with `\n\n---\n\n<!-- page N -->\n\n`, giving per-paragraph page attribution inside the markdown itself — no new response field.

## Changes

- **features/parse.mdx** — new *Page markers (PDF)* section between per-page markdown and layout blocks, covering the format, the between-pages-only rule, and the skip-on-merge numbering caveat (with `pages: true` as the escape hatch); plus the options-table row, the options JSON example, the intro pointer, and the billing note (no additional cost).
- **snippets/v2/parse/page-markers/** — Python (`page_markers`), Node (`pageMarkers`), and cURL snippets mirroring the existing pages/blocks snippet sets, matching the merged SDK field names.
- **advanced-scraping-guide.mdx** — parser-options table row + example, linking to the Parse section.
- **api-reference/v2-openapi.json** — `pageMarkers` property on the pdf parser object in both `ParseOptions` and `ScrapeOptions` (both schemas verified to parse).

English pages only — ja/zh/pt-BR/fr/es are locadex-managed and will follow automatically.

## Verified against prod

The documented behavior matches a live run (15-page PDF): markers in the exact documented format, no leading marker for page 1, stitched pages skipped from numbering, and clean composition with `pages: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)