### PR TITLE
Add agent quickstart docs for all SDK languages

### DIFF
--- a/agent-quickstart/elixir.mdx
+++ b/agent-quickstart/elixir.mdx
@@ -1,0 +1,247 @@
+---
+title: "Elixir Agent Quickstart"
+description: "Canonical Firecrawl Elixir quickstart for external agents using search, scrape, and interact."
+og:title: "Elixir Agent Quickstart | Firecrawl"
+og:description: "Canonical Firecrawl Elixir quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Elixir Agent Quickstart
+
+Canonical quickstart for external agents integrating with Firecrawl using the Elixir SDK. Generated from SDK source and OpenAPI spec.
+
+## Install
+
+Add to your `mix.exs` dependencies:
+
+```elixir
+defp deps do
+  [
+    {:firecrawl, "~> 1.9"}
+  ]
+end
+```
+
+Then run:
+
+```bash
+mix deps.get
+```
+
+## Authenticate
+
+Configure the API key in your application config:
+
+```elixir
+# config/config.exs
+config :firecrawl, api_key: "fc-YOUR_API_KEY"
+```
+
+Or pass the API key per-call via the `opts` keyword list:
+
+```elixir
+Firecrawl.scrape_and_extract_from_url([url: "https://example.com"],
+  api_key: "fc-YOUR_API_KEY"
+)
+```
+
+The API key is sent as a Bearer token. A nil or empty key falls back to the keyless free tier (rate-limited per IP).
+
+You can also override the base URL per-call:
+
+```elixir
+Firecrawl.scrape_and_extract_from_url([url: "https://example.com"],
+  base_url: "https://your-instance.example.com/v2"
+)
+```
+
+## When To Use What
+
+- **`search_and_scrape`**: You start with a query and need to discover relevant URLs and their content. Use when you don't have a specific URL yet.
+- **`scrape_and_extract_from_url`**: You already have a URL and want its page content as markdown, HTML, or structured JSON. Use for targeted extraction.
+- **`interact_with_scrape_browser_session`**: The page needs clicks, form fills, or other browser actions after an initial scrape. Use for multi-step browser automation.
+
+## Search
+
+### Why use it
+
+Search the web for a query and optionally scrape the results. Returns structured results grouped by source type (web, news, images). Use this when you need to discover relevant pages before extracting content.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.search_and_scrape(params, opts \\ [])
+```
+
+Bang variant `search_and_scrape!/2` raises on error instead of returning `{:error, ...}`.
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.search_and_scrape(
+  query: "firecrawl web scraping API",
+  limit: 5,
+  scrape_options: [formats: ["markdown"]]
+)
+
+# response is a %Req.Response{} with JSON body
+for result <- response.body["data"]["web"] || [] do
+  IO.puts("#{result["title"]} #{result["url"]}")
+  IO.puts(result["markdown"])
+end
+```
+
+### Parameters
+
+All parameters are passed as a keyword list. Required parameters are marked.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `:string` | **Required.** The search query string. |
+| `sources` | `list(any)` | Sources to search: `"web"`, `"news"`, `"images"`. Default: `["web"]`. |
+| `categories` | `list(any)` | Narrow results by category. |
+| `include_domains` | `list(string)` | Restrict results to these domains. |
+| `exclude_domains` | `list(string)` | Exclude results from these domains. |
+| `limit` | `:integer` | Max results per source type. |
+| `tbs` | `:string` | Time-based filter. `"qdr:d"` (day), `"qdr:w"` (week), etc. |
+| `location` | `:string` | Geographic location for results. |
+| `country` | `:string` | ISO country code for geo-targeting. |
+| `timeout` | `:integer` | Timeout in milliseconds. |
+| `highlights` | `:boolean` | Generate query-relevant highlights. Default: `true`. |
+| `ignore_invalid_urls` | `:boolean` | Exclude invalid URLs. |
+| `scrape_options` | `:keyword_list` | Scrape options applied to each result. |
+| `enterprise` | `list(string)` | Enterprise options: `["zdr"]`, `["anon"]`. |
+
+## Scrape
+
+### Why use it
+
+Scrape a single URL and get its content as markdown, HTML, screenshots, structured JSON, or other formats. The primary tool for extracting page content when you already know the URL.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.scrape_and_extract_from_url(params, opts \\ [])
+```
+
+Bang variant `scrape_and_extract_from_url!/2` raises on error.
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown", "links"],
+  only_main_content: true
+)
+
+doc = response.body["data"]
+IO.puts(doc["markdown"])
+IO.inspect(doc["links"])
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `:string` | **Required.** The URL to scrape. |
+| `formats` | `list(any)` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`. Default: `["markdown"]`. |
+| `only_main_content` | `:boolean` | Only return main content. Default: `true`. |
+| `include_tags` | `list(string)` | HTML tags to include. |
+| `exclude_tags` | `list(string)` | HTML tags to exclude. |
+| `headers` | `:any` | Custom HTTP headers. |
+| `timeout` | `:integer` | Timeout in milliseconds. Default: `60000`. Range: 1000-300000. |
+| `wait_for` | `:integer` | Delay in ms before fetching. |
+| `mobile` | `:boolean` | Emulate a mobile device. |
+| `parsers` | `list(any)` | Parser config (e.g. PDF). |
+| `actions` | `list(any)` | Browser actions before grabbing content. |
+| `location` | `:keyword_list` | Location settings. Default country: `"US"`. |
+| `skip_tls_verification` | `:boolean` | Skip TLS verification. |
+| `remove_base64_images` | `:boolean` | Remove base64 images from markdown. |
+| `block_ads` | `:boolean` | Block ads and cookie popups. |
+| `proxy` | `:basic \| :enhanced \| :auto` | Proxy type. Pass as atoms. |
+| `max_age` | `:integer` | Use cached result if younger (ms). Default: 2 days. |
+| `min_age` | `:integer` | Cache-only mode with minimum age (ms). |
+| `store_in_cache` | `:boolean` | Store result in cache. |
+| `lockdown` | `:boolean` | Serve only cached results. |
+| `redact_pii` | `:boolean` | Redact PII. |
+| `profile` | `:keyword_list` | Browser profile: `[name: "my-profile"]`. |
+| `audit_metadata` | `:keyword_list` | SIEM attribution: `[username: "user@example.com"]`. |
+| `zero_data_retention` | `:boolean` | Enable zero data retention. |
+
+## Interact
+
+### Why use it
+
+Execute code in the browser session created by a prior scrape. Use this for multi-step workflows: scrape a page first to get a job ID, then interact with the live browser to click buttons, fill forms, or run JavaScript.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.interact_with_scrape_browser_session(job_id, params, opts \\ [])
+```
+
+Bang variant `interact_with_scrape_browser_session!/3` raises on error.
+
+### Example
+
+```elixir
+# First scrape to get a session
+{:ok, scrape_response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown"]
+)
+job_id = scrape_response.body["data"]["metadata"]["jobId"]
+
+# Execute code in the browser
+{:ok, result} = Firecrawl.interact_with_scrape_browser_session(job_id,
+  code: "document.querySelector('button.load-more').click();",
+  language: :node,
+  timeout: 30
+)
+
+IO.puts(result.body["stdout"])
+
+# Stop the session when done
+Firecrawl.stop_interactive_scrape_browser_session(job_id)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `String.t()` | **Required.** First positional argument. The scrape job ID from a prior scrape. |
+| `code` | `:string` | **Required.** Code to execute in the browser sandbox. |
+| `language` | `:python \| :node \| :bash` | Language for code execution. Pass as atom. |
+| `timeout` | `:integer` | Execution timeout in seconds. |
+
+The response body includes:
+
+| Field | Type | Description |
+|---|---|---|
+| `"success"` | `boolean` | Whether execution succeeded. |
+| `"stdout"` | `string \| null` | Standard output from code execution. |
+| `"result"` | `string \| null` | Alias for stdout. |
+| `"stderr"` | `string \| null` | Standard error output. |
+| `"exitCode"` | `integer \| null` | Exit code of executed process. |
+| `"killed"` | `boolean` | Whether process was killed due to timeout. |
+| `"liveViewUrl"` | `string \| null` | Read-only live view of the browser. |
+| `"interactiveLiveViewUrl"` | `string \| null` | Interactive live view. |
+
+Call `Firecrawl.stop_interactive_scrape_browser_session(job_id)` to end the session.
+
+## Notes
+
+- The Elixir SDK is **auto-generated from the OpenAPI spec** via `mix run generate.exs`. Function names match the OpenAPI operation IDs converted to snake_case.
+- Function names are longer than other SDKs because they follow the OpenAPI operation IDs: `scrape_and_extract_from_url` (not `scrape`), `search_and_scrape` (not `search`), `interact_with_scrape_browser_session` (not `interact`).
+- All parameters use **snake_case** in Elixir. The SDK converts to camelCase for the API wire format.
+- Enum values are passed as **atoms**: `proxy: :auto`, `language: :node`.
+- All functions return `{:ok, %Req.Response{}}` or `{:error, exception}`. Use bang variants (`!`) to raise instead.
+- HTTP 4xx/5xx responses are wrapped in `Firecrawl.Error` with `status` and `body` fields.
+- Parameters are validated at runtime via NimbleOptions. Invalid params return `{:error, %NimbleOptions.ValidationError{}}`.
+- The Elixir SDK's `interact_with_scrape_browser_session` does not support a `prompt` parameter (unlike Node.js, Python, and Rust). Use `code` with the appropriate language.
+- There are **no deprecated aliases** in the Elixir SDK.
+
+## Source Of Truth
+
+- SDK: `firecrawl/apps/elixir-sdk/lib/firecrawl.ex`
+- OpenAPI: `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/java.mdx
+++ b/agent-quickstart/java.mdx
@@ -1,0 +1,263 @@
+---
+title: "Java Agent Quickstart"
+description: "Canonical Firecrawl Java quickstart for external agents using search, scrape, and interact."
+og:title: "Java Agent Quickstart | Firecrawl"
+og:description: "Canonical Firecrawl Java quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Java Agent Quickstart
+
+Canonical quickstart for external agents integrating with Firecrawl using the Java SDK. Generated from SDK source and OpenAPI spec.
+
+## Install
+
+Maven:
+
+```xml
+<dependency>
+  <groupId>com.firecrawl</groupId>
+  <artifactId>firecrawl-java</artifactId>
+  <version>1.15.0</version>
+</dependency>
+```
+
+Gradle:
+
+```groovy
+implementation 'com.firecrawl:firecrawl-java:1.15.0'
+```
+
+Requires Java 11+.
+
+## Authenticate
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+
+FirecrawlClient firecrawl = FirecrawlClient.builder()
+    .apiKey("fc-YOUR_API_KEY")
+    .build();
+```
+
+The API key resolves in this order:
+
+1. Value passed via `builder().apiKey(...)`
+2. `FIRECRAWL_API_KEY` environment variable
+3. `firecrawl.apiKey` Java system property
+4. Keyless free tier (rate-limited per IP; only scrape, search, and interact available)
+
+Convenience factory from environment:
+
+```java
+FirecrawlClient firecrawl = FirecrawlClient.fromEnv();
+```
+
+## When To Use What
+
+- **`search`**: You start with a query and need to discover relevant URLs and their content. Use when you don't have a specific URL yet.
+- **`scrape`**: You already have a URL and want its page content as markdown, HTML, or structured JSON. Use for targeted extraction.
+- **`interact`**: The page needs clicks, form fills, or other browser actions after an initial scrape. Use for multi-step browser automation.
+
+## Search
+
+### Why use it
+
+Search the web for a query and optionally scrape the results. Returns structured results grouped by source type (web, news, images). Use this when you need to discover relevant pages before extracting content.
+
+### Preferred SDK method
+
+```java
+firecrawl.search(query, options)
+```
+
+### Example
+
+```java
+import com.firecrawl.models.SearchOptions;
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.SearchData;
+
+SearchData results = firecrawl.search("firecrawl web scraping API",
+    SearchOptions.builder()
+        .limit(5)
+        .scrapeOptions(ScrapeOptions.builder()
+            .formats(List.of("markdown"))
+            .build())
+        .build());
+
+for (var result : results.getWeb()) {
+    System.out.println(result.get("title") + " " + result.get("url"));
+    System.out.println(result.get("markdown"));
+}
+```
+
+Async variant:
+
+```java
+CompletableFuture<SearchData> future = firecrawl.searchAsync("query",
+    SearchOptions.builder().limit(5).build());
+```
+
+### Parameters
+
+`SearchOptions` fields (all nullable, builder pattern):
+
+| Parameter | Type | Description |
+|---|---|---|
+| `sources` | `List<Object>` | Sources: `"web"`, `"news"`, `"images"`. Default: `["web"]`. |
+| `categories` | `List<Object>` | Categories: `"github"`, `"research"`, `"pdf"`. |
+| `includeDomains` | `List<String>` | Restrict results to these domains. |
+| `excludeDomains` | `List<String>` | Exclude results from these domains. |
+| `limit` | `Integer` | Max results per source type. Default: `10`. |
+| `tbs` | `String` | Time-based filter. `"qdr:d"` (day), `"qdr:w"` (week), etc. |
+| `location` | `String` | Geographic location for results (e.g. `"US"`). |
+| `ignoreInvalidURLs` | `Boolean` | Exclude invalid URLs. Default: `false`. |
+| `timeout` | `Integer` | Timeout in milliseconds. Default: `60000`. |
+| `highlights` | `Boolean` | Generate query-relevant highlights. Default: `true`. |
+| `scrapeOptions` | `ScrapeOptions` | Scrape options applied to each result. |
+
+## Scrape
+
+### Why use it
+
+Scrape a single URL and get its content as markdown, HTML, screenshots, structured JSON, or other formats. The primary tool for extracting page content when you already know the URL.
+
+### Preferred SDK method
+
+```java
+firecrawl.scrape(url, options)
+```
+
+### Example
+
+```java
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.Document;
+
+Document doc = firecrawl.scrape("https://example.com",
+    ScrapeOptions.builder()
+        .formats(List.of("markdown", "links"))
+        .onlyMainContent(true)
+        .build());
+
+System.out.println(doc.getMarkdown());
+System.out.println(doc.getLinks());
+```
+
+Simple scrape without options:
+
+```java
+Document doc = firecrawl.scrape("https://example.com");
+```
+
+### Parameters
+
+`ScrapeOptions` fields (all nullable, builder pattern):
+
+| Parameter | Type | Description |
+|---|---|---|
+| `formats` | `List<Object>` | Output formats. Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"screenshot"`, `"json"`, `"audio"`, `"video"`. Objects for advanced formats (JsonFormat, QuestionFormat, HighlightsFormat). Default: `["markdown"]`. |
+| `onlyMainContent` | `Boolean` | Only return main content. Default: `true`. |
+| `includeTags` | `List<String>` | HTML tags to include. |
+| `excludeTags` | `List<String>` | HTML tags to exclude. |
+| `headers` | `Map<String, String>` | Custom HTTP headers. |
+| `timeout` | `Integer` | Timeout in milliseconds. Default: `60000`. Range: 1000-300000. |
+| `waitFor` | `Integer` | Delay in ms before fetching. Default: `0`. |
+| `mobile` | `Boolean` | Emulate a mobile device. Default: `false`. |
+| `parsers` | `List<Object>` | Parser config (e.g. PDF with `maxPages`, `pages`, `blocks`, `pageMarkers`). |
+| `actions` | `List<Map<String, Object>>` | Browser actions before grabbing content. |
+| `location` | `LocationConfig` | Location settings: `LocationConfig.builder().country("US").languages(List.of("en")).build()`. |
+| `skipTlsVerification` | `Boolean` | Skip TLS verification. Default: `true`. |
+| `removeBase64Images` | `Boolean` | Remove base64 images. Default: `true`. |
+| `blockAds` | `Boolean` | Block ads and cookie popups. Default: `true`. |
+| `proxy` | `String` | Proxy type: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. Default: `"auto"`. |
+| `maxAge` | `Long` | Use cached result if younger (ms). Default: `172800000` (2 days). |
+| `storeInCache` | `Boolean` | Store result in cache. Default: `true`. |
+| `lockdown` | `Boolean` | Serve only cached results. Default: `false`. |
+| `redactPII` | `Boolean` | Redact PII. |
+| `auditMetadata` | `AuditMetadata` | SIEM attribution. |
+
+## Interact
+
+### Why use it
+
+Execute code in the browser session created by a prior scrape. Use this for multi-step workflows: scrape a page first to get a job ID, then interact with the live browser to click buttons, fill forms, or run JavaScript.
+
+### Preferred SDK method
+
+```java
+firecrawl.interact(jobId, code)
+firecrawl.interact(jobId, code, language, timeout)
+```
+
+### Example
+
+```java
+import com.firecrawl.models.BrowserExecuteResponse;
+
+// First scrape to get a session
+Document doc = firecrawl.scrape("https://example.com");
+String jobId = (String) doc.getMetadata().get("jobId");
+
+// Execute code in the browser
+BrowserExecuteResponse result = firecrawl.interact(
+    jobId,
+    "document.querySelector('button.load-more').click();",
+    "node",
+    30
+);
+
+System.out.println(result.getStdout());
+
+// Stop the session when done
+firecrawl.stopInteractiveBrowser(jobId);
+```
+
+Async variant:
+
+```java
+CompletableFuture<BrowserExecuteResponse> future = firecrawl.interactAsync(
+    jobId, code, "node", 30);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `jobId` | `String` | **Required.** The scrape job ID from a prior scrape. |
+| `code` | `String` | **Required.** Code to execute in the browser sandbox. |
+| `language` | `String` | Language: `"python"`, `"node"`, `"bash"`. Default: `"node"`. |
+| `timeout` | `Integer` | Execution timeout in seconds (1-300). Default: `30`. |
+| `origin` | `String` | Optional origin tag for attribution. |
+
+The response (`BrowserExecuteResponse`) includes:
+
+| Field | Type | Description |
+|---|---|---|
+| `success` | `boolean` | Whether execution succeeded. |
+| `stdout` | `String` | Standard output from code execution. |
+| `result` | `String` | Alias for stdout. |
+| `stderr` | `String` | Standard error output. |
+| `exitCode` | `Integer` | Exit code of executed process. |
+| `killed` | `boolean` | Whether process was killed due to timeout. |
+| `liveViewUrl` | `String` | Read-only live view of the browser. |
+| `interactiveLiveViewUrl` | `String` | Interactive live view. |
+
+Call `firecrawl.stopInteractiveBrowser(jobId)` to end the session.
+
+## Notes
+
+- All parameter names use **camelCase** (e.g. `onlyMainContent`, `scrapeOptions`), consistent with Java conventions.
+- Java lacks default parameter values, so the SDK uses **method overloading**: `interact(jobId, code)` delegates to `interact(jobId, code, null, null)`.
+- Every sync method has an `*Async` variant returning `CompletableFuture<T>`.
+- Options use the **builder pattern**: `ScrapeOptions.builder().formats(...).build()`.
+- All option fields are reference types (`Boolean`, `Integer`, `Long`); `null` means "omit from request".
+- The Java SDK's `interact` method does not support the `prompt` parameter (unlike Node.js, Python, and Rust). Use `code` with the appropriate language.
+- **Deprecated aliases:**
+  - `scrapeExecute(jobId, code, ...)` → use `interact(jobId, code, ...)`
+  - `deleteScrapeBrowser(jobId)` → use `stopInteractiveBrowser(jobId)`
+
+## Source Of Truth
+
+- SDK: `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`, `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/ScrapeOptions.java`, `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/SearchOptions.java`
+- OpenAPI: `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/node.mdx
+++ b/agent-quickstart/node.mdx
@@ -1,0 +1,247 @@
+---
+title: "Node.js Agent Quickstart"
+description: "Canonical Firecrawl Node.js quickstart for external agents using search, scrape, and interact."
+og:title: "Node.js Agent Quickstart | Firecrawl"
+og:description: "Canonical Firecrawl Node.js quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Node.js Agent Quickstart
+
+Canonical quickstart for external agents integrating with Firecrawl using the Node.js/TypeScript SDK. Generated from SDK source and OpenAPI spec.
+
+## Install
+
+```bash
+npm install @mendable/firecrawl-js
+```
+
+## Authenticate
+
+```typescript
+import Firecrawl from "@mendable/firecrawl-js";
+
+const firecrawl = new Firecrawl("fc-YOUR_API_KEY");
+```
+
+The API key resolves in this order:
+
+1. Value passed to the constructor
+2. `FIRECRAWL_API_KEY` environment variable
+3. Keyless free tier (rate-limited per IP; only scrape, search, and interact available)
+
+You can also pass an options object:
+
+```typescript
+const firecrawl = new Firecrawl({
+  apiKey: "fc-YOUR_API_KEY",
+  apiUrl: "https://api.firecrawl.dev",
+  timeoutMs: 60000,
+  maxRetries: 3,
+  backoffFactor: 0.5,
+});
+```
+
+## When To Use What
+
+- **`search`**: You start with a query and need to discover relevant URLs and their content. Use when you don't have a specific URL yet.
+- **`scrape`**: You already have a URL and want its page content as markdown, HTML, or structured JSON. Use for targeted extraction.
+- **`interact`**: The page needs clicks, form fills, or other browser actions after an initial scrape. Use for multi-step browser automation.
+
+## Search
+
+### Why use it
+
+Search the web for a query and optionally scrape the results. Returns structured results grouped by source type (web, news, images). Use this when you need to discover relevant pages before extracting content.
+
+### Preferred SDK method
+
+```typescript
+firecrawl.search(query, options?)
+```
+
+### Example
+
+```typescript
+const results = await firecrawl.search("firecrawl web scraping API", {
+  limit: 5,
+  scrapeOptions: {
+    formats: ["markdown"],
+  },
+});
+
+// Results are grouped by source type
+for (const result of results.web ?? []) {
+  console.log(result.title, result.url);
+  console.log(result.markdown); // available when scrapeOptions is set
+}
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `string` | **Required.** The search query string. |
+| `sources` | `Array<"web" \| "news" \| "images">` | Which result sets to return. Default: `["web"]`. |
+| `categories` | `Array<"github" \| "research" \| "pdf" \| "developer">` | Narrow results by category. `"research"` is a domain filter, not the paper index. |
+| `includeDomains` | `string[]` | Restrict results to these domains. Cannot combine with `excludeDomains`. |
+| `excludeDomains` | `string[]` | Exclude results from these domains. Cannot combine with `includeDomains`. |
+| `limit` | `number` | Max results per source type. Default: `10`. |
+| `tbs` | `string` | Time-based filter. `"qdr:h"` (hour), `"qdr:d"` (day), `"qdr:w"` (week), `"qdr:m"` (month), `"qdr:y"` (year), or custom range `"cdr:1,cd_min:MM/DD/YYYY,cd_max:MM/DD/YYYY"`. |
+| `location` | `string` | Geographic location for results (e.g. `"San Francisco,California,United States"`). |
+| `ignoreInvalidURLs` | `boolean` | Exclude URLs invalid for other Firecrawl endpoints. Default: `false`. |
+| `timeout` | `number` | Timeout in milliseconds. Default: `60000`. |
+| `highlights` | `boolean` | Generate query-relevant highlights. Default: `true`. |
+| `scrapeOptions` | `ScrapeOptions` | Options applied to each result's scrape. Pass this to get full page content (markdown, HTML, etc.) in results. |
+| `enterprise` | `Array<"default" \| "anon" \| "zdr">` | Enterprise options. `"zdr"` = zero data retention, `"anon"` = anonymized. |
+| `threatProtection` | `ThreatProtectionOptions` | Per-request threat protection override (enterprise). |
+
+## Scrape
+
+### Why use it
+
+Scrape a single URL and get its content as markdown, HTML, screenshots, structured JSON, or other formats. The primary tool for extracting page content when you already know the URL.
+
+### Preferred SDK method
+
+```typescript
+firecrawl.scrape(url, options?)
+```
+
+### Example
+
+```typescript
+const doc = await firecrawl.scrape("https://example.com", {
+  formats: ["markdown", "links"],
+  onlyMainContent: true,
+});
+
+console.log(doc.markdown);
+console.log(doc.links);
+```
+
+Extract structured data with a schema:
+
+```typescript
+import { z } from "zod";
+
+const doc = await firecrawl.scrape("https://example.com/pricing", {
+  formats: [{ type: "json", schema: z.object({ plans: z.array(z.object({ name: z.string(), price: z.number() })) }) }],
+});
+
+console.log(doc.json); // typed as { plans: { name: string; price: number }[] }
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `string` | **Required.** The URL to scrape. |
+| `formats` | `FormatOption[]` | Output formats. String values: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`. Objects: `{ type: "json", schema, prompt }`, `{ type: "screenshot", fullPage, quality, viewport }`, `{ type: "question", question }`, `{ type: "highlights", query }`, `{ type: "changeTracking", modes, schema, prompt, tag }`, `{ type: "attributes", selectors }`. Default: `["markdown"]`. |
+| `onlyMainContent` | `boolean` | Only return main content, excluding headers/navs/footers. Default: `true`. |
+| `includeTags` | `string[]` | HTML tags to include in output. |
+| `excludeTags` | `string[]` | HTML tags to exclude from output. |
+| `headers` | `Record<string, string>` | Custom HTTP headers to send with the request. |
+| `timeout` | `number` | Timeout in milliseconds. Default: `60000`. Range: 1000-300000. |
+| `waitFor` | `number` | Delay in ms before fetching content, in addition to smart wait. Default: `0`. |
+| `mobile` | `boolean` | Emulate a mobile device. Default: `false`. |
+| `parsers` | `Array<string \| PDFParser>` | Parser config. PDF parser options: `{ type: "pdf", mode: "fast"\|"auto"\|"ocr", maxPages, pages, blocks, pageMarkers }`. |
+| `actions` | `ActionOption[]` | Browser actions to perform before grabbing content: `wait`, `click`, `write`, `press`, `scroll`, `scrape`, `executeJavascript`, `screenshot`, `pdf`. |
+| `location` | `LocationConfig` | Location settings. `{ country: "US", languages: ["en"] }`. Uses appropriate proxy, emulates language/timezone. |
+| `skipTlsVerification` | `boolean` | Skip TLS certificate verification. Default: `true`. |
+| `removeBase64Images` | `boolean` | Remove base64-encoded images from markdown. Default: `true`. |
+| `fastMode` | `boolean` | Use fast mode (less accurate). |
+| `blockAds` | `boolean` | Block ads and cookie popups. Default: `true`. |
+| `proxy` | `"basic" \| "stealth" \| "enhanced" \| "auto"` | Proxy type. Basic = fast, enhanced = advanced anti-bot, auto = basic with enhanced fallback. Default: `"auto"`. |
+| `maxAge` | `number` | Use cached result if younger than this value (ms). Speeds scrapes by up to 500%. Default: `172800000` (2 days). |
+| `minAge` | `number` | Only check cache, never trigger fresh scrape. Value in ms specifies minimum age. |
+| `storeInCache` | `boolean` | Store result in Firecrawl cache. Default: `true`. |
+| `lockdown` | `boolean` | Serve only cached results, never make outbound request. Default: `false`. |
+| `redactPII` | `boolean \| RedactPIIOptions` | Redact personally identifiable information. Pass `true` for defaults or `{ mode: "accurate"\|"aggressive"\|"fast", entities: [...], replaceStyle: "tag"\|"mask"\|"remove" }`. |
+| `profile` | `{ name: string, saveChanges?: boolean }` | Persistent browser storage profile. Same name shares state across sessions. |
+| `auditMetadata` | `{ username: string }` | User attribution for SIEM logging. |
+| `threatProtection` | `ThreatProtectionOptions` | Per-request threat protection override (enterprise). |
+
+## Interact
+
+### Why use it
+
+Execute code or natural-language prompts in the browser session created by a prior scrape. Use this for multi-step workflows: scrape a page first to get a `jobId`, then interact with the live browser to click buttons, fill forms, or run JavaScript.
+
+### Preferred SDK method
+
+```typescript
+firecrawl.interact(jobId, args)
+```
+
+### Example
+
+```typescript
+// First scrape to get a session
+const doc = await firecrawl.scrape("https://example.com", {
+  formats: ["markdown"],
+});
+const jobId = doc.metadata?.jobId;
+
+// Execute code in the browser
+const result = await firecrawl.interact(jobId, {
+  code: "document.querySelector('button.load-more').click();",
+  language: "node",
+  timeout: 30,
+});
+
+console.log(result.stdout);
+
+// Or use a natural-language prompt
+const agentResult = await firecrawl.interact(jobId, {
+  prompt: "Click the 'Load More' button and wait for new content",
+});
+
+console.log(agentResult.output);
+
+// Stop the session when done
+await firecrawl.stopInteraction(jobId);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `jobId` | `string` | **Required.** The scrape job ID from a prior scrape. |
+| `code` | `string` | Code to execute in the browser sandbox. Provide either `code` or `prompt`. |
+| `prompt` | `string` | Natural-language instruction for the browser agent. Provide either `code` or `prompt`. |
+| `language` | `"python" \| "node" \| "bash"` | Language for code execution. Default: `"node"`. |
+| `timeout` | `number` | Execution timeout in seconds (1-300). Default: `30`. |
+
+The response includes:
+
+| Field | Type | Description |
+|---|---|---|
+| `success` | `boolean` | Whether execution succeeded. |
+| `output` | `string \| null` | Agent's response (only when using `prompt`). |
+| `stdout` | `string \| null` | Standard output from code execution. |
+| `stderr` | `string \| null` | Standard error output. |
+| `exitCode` | `number \| null` | Exit code of executed process. |
+| `killed` | `boolean` | Whether process was killed due to timeout. |
+| `liveViewUrl` | `string \| null` | Read-only live view of the browser. |
+| `interactiveLiveViewUrl` | `string \| null` | Interactive live view where viewers can control the browser. |
+
+Call `firecrawl.stopInteraction(jobId)` to end the session when done.
+
+## Notes
+
+- All parameter names use **camelCase** (e.g. `onlyMainContent`, `scrapeOptions`).
+- The SDK supports Zod schemas for type-safe JSON extraction via the `json` format. Pass a Zod schema as `{ type: "json", schema: z.object({...}) }` and `doc.json` will be typed.
+- The default export `Firecrawl` class extends the v2 client and adds a `.v1` accessor for backward compatibility.
+- **Deprecated aliases for interact:**
+  - `scrapeExecute(jobId, args)` → use `interact(jobId, args)`
+  - `stopInteractiveBrowser(jobId)` → use `stopInteraction(jobId)`
+  - `deleteScrapeBrowser(jobId)` → use `stopInteraction(jobId)`
+- **Deprecated aliases for other methods:**
+  - `scrapeUrl()` → `scrape()`
+  - `crawlUrl()` → `crawl()`
+  - `mapUrl()` → `map()`
+
+## Source Of Truth
+
+- SDK: `firecrawl/apps/js-sdk/firecrawl/src/index.ts`, `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`, `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
+- OpenAPI: `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/python.mdx
+++ b/agent-quickstart/python.mdx
@@ -1,0 +1,270 @@
+---
+title: "Python Agent Quickstart"
+description: "Canonical Firecrawl Python quickstart for external agents using search, scrape, and interact."
+og:title: "Python Agent Quickstart | Firecrawl"
+og:description: "Canonical Firecrawl Python quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Python Agent Quickstart
+
+Canonical quickstart for external agents integrating with Firecrawl using the Python SDK. Generated from SDK source and OpenAPI spec.
+
+## Install
+
+```bash
+pip install firecrawl-py
+```
+
+## Authenticate
+
+```python
+from firecrawl import Firecrawl
+
+firecrawl = Firecrawl(api_key="fc-YOUR_API_KEY")
+```
+
+The API key resolves in this order:
+
+1. Value passed as `api_key`
+2. `FIRECRAWL_API_KEY` environment variable
+3. Keyless free tier (rate-limited per IP; only scrape, search, and interact available)
+
+Constructor parameters:
+
+```python
+firecrawl = Firecrawl(
+    api_key="fc-YOUR_API_KEY",
+    api_url="https://api.firecrawl.dev",
+    timeout=60.0,
+    max_retries=3,
+    backoff_factor=0.5,
+)
+```
+
+An async client is also available:
+
+```python
+from firecrawl import AsyncFirecrawl
+
+firecrawl = AsyncFirecrawl(api_key="fc-YOUR_API_KEY")
+```
+
+## When To Use What
+
+- **`search`**: You start with a query and need to discover relevant URLs and their content. Use when you don't have a specific URL yet.
+- **`scrape`**: You already have a URL and want its page content as markdown, HTML, or structured JSON. Use for targeted extraction.
+- **`interact`**: The page needs clicks, form fills, or other browser actions after an initial scrape. Use for multi-step browser automation.
+
+## Search
+
+### Why use it
+
+Search the web for a query and optionally scrape the results. Returns structured results grouped by source type (web, news, images). Use this when you need to discover relevant pages before extracting content.
+
+### Preferred SDK method
+
+```python
+firecrawl.search(query, **options)
+```
+
+### Example
+
+```python
+results = firecrawl.search(
+    "firecrawl web scraping API",
+    limit=5,
+    scrape_options={"formats": ["markdown"]},
+)
+
+for result in results.web or []:
+    print(result.title, result.url)
+    print(result.markdown)  # available when scrape_options is set
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `str` | **Required.** The search query string. |
+| `sources` | `list[str]` | Which result sets to return: `"web"`, `"news"`, `"images"`. Default: `["web"]`. |
+| `categories` | `list[str]` | Narrow results by category: `"github"`, `"research"`, `"pdf"`, `"developer"`. |
+| `include_domains` | `list[str]` | Restrict results to these domains. Cannot combine with `exclude_domains`. |
+| `exclude_domains` | `list[str]` | Exclude results from these domains. Cannot combine with `include_domains`. |
+| `limit` | `int` | Max results per source type. Default: `5`. |
+| `tbs` | `str` | Time-based filter. `"qdr:h"` (hour), `"qdr:d"` (day), `"qdr:w"` (week), `"qdr:m"` (month), `"qdr:y"` (year), or custom range `"cdr:1,cd_min:MM/DD/YYYY,cd_max:MM/DD/YYYY"`. |
+| `location` | `str` | Geographic location for results. |
+| `ignore_invalid_urls` | `bool` | Exclude URLs invalid for other Firecrawl endpoints. Default: `false`. |
+| `timeout` | `int` | Timeout in milliseconds. Default: `300000`. |
+| `highlights` | `bool` | Generate query-relevant highlights. Default: `true`. |
+| `scrape_options` | `ScrapeOptions` | Options applied to each result's scrape. Pass this to get full page content in results. |
+| `enterprise` | `list[str]` | Enterprise options: `"zdr"` (zero data retention), `"anon"` (anonymized). |
+| `threat_protection` | `ThreatProtectionOptions` | Per-request threat protection override (enterprise). |
+
+**Return type:** `SearchData` with `.web`, `.news`, `.images` properties. Accessing `.data` raises `AttributeError` with a migration message.
+
+## Scrape
+
+### Why use it
+
+Scrape a single URL and get its content as markdown, HTML, screenshots, structured JSON, or other formats. The primary tool for extracting page content when you already know the URL.
+
+### Preferred SDK method
+
+```python
+firecrawl.scrape(url, **options)
+```
+
+### Example
+
+```python
+doc = firecrawl.scrape(
+    "https://example.com",
+    formats=["markdown", "links"],
+    only_main_content=True,
+)
+
+print(doc.markdown)
+print(doc.links)
+```
+
+Extract structured data:
+
+```python
+doc = firecrawl.scrape(
+    "https://example.com/pricing",
+    formats=[{
+        "type": "json",
+        "schema": {
+            "type": "object",
+            "properties": {
+                "plans": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "price": {"type": "number"},
+                        },
+                    },
+                },
+            },
+        },
+    }],
+)
+
+print(doc.json)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `str` | **Required.** The URL to scrape. |
+| `formats` | `list` | Output formats. String values: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`. Objects: `{"type": "json", "schema": ..., "prompt": ...}`, `{"type": "screenshot", "fullPage": ..., "quality": ..., "viewport": ...}`, `{"type": "question", "question": ...}`, `{"type": "highlights", "query": ...}`. Default: `["markdown"]`. |
+| `only_main_content` | `bool` | Only return main content, excluding headers/navs/footers. Default: `true`. |
+| `include_tags` | `list[str]` | HTML tags to include in output. |
+| `exclude_tags` | `list[str]` | HTML tags to exclude from output. |
+| `headers` | `dict[str, str]` | Custom HTTP headers to send with the request. |
+| `timeout` | `int` | Timeout in milliseconds. Default: `60000`. Range: 1000-300000. |
+| `wait_for` | `int` | Delay in ms before fetching content. Default: `0`. |
+| `mobile` | `bool` | Emulate a mobile device. Default: `false`. |
+| `parsers` | `list` | Parser config. PDF: `{"type": "pdf", "mode": "fast"\|"auto"\|"ocr", "maxPages": ..., "pages": ..., "blocks": ..., "pageMarkers": ...}`. |
+| `actions` | `list` | Browser actions before grabbing content: `WaitAction`, `ClickAction`, `WriteAction`, `PressAction`, `ScrollAction`, `ScrapeAction`, `ExecuteJavascriptAction`, `ScreenshotAction`, `PDFAction`. |
+| `location` | `Location` | Location settings. `Location(country="US", languages=["en"])`. |
+| `skip_tls_verification` | `bool` | Skip TLS certificate verification. Default: `true`. |
+| `remove_base64_images` | `bool` | Remove base64-encoded images from markdown. Default: `true`. |
+| `fast_mode` | `bool` | Use fast mode (less accurate). |
+| `block_ads` | `bool` | Block ads and cookie popups. Default: `true`. |
+| `proxy` | `str` | Proxy type: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. Default: `"auto"`. |
+| `max_age` | `int` | Use cached result if younger than this value (ms). Default: `172800000` (2 days). |
+| `store_in_cache` | `bool` | Store result in Firecrawl cache. Default: `true`. |
+| `lockdown` | `bool` | Serve only cached results. Default: `false`. |
+| `redact_pii` | `bool \| RedactPIIOptions` | Redact PII. Pass `True` for defaults or an options object with `mode`, `entities`, `replace_style`. |
+| `profile` | `dict` | Persistent browser storage profile. `{"name": "my-profile", "saveChanges": True}`. |
+| `audit_metadata` | `AuditMetadata` | User attribution for SIEM logging. `AuditMetadata(username="user@example.com")`. |
+| `threat_protection` | `ThreatProtectionOptions` | Per-request threat protection override (enterprise). |
+
+## Interact
+
+### Why use it
+
+Execute code or natural-language prompts in the browser session created by a prior scrape. Use this for multi-step workflows: scrape a page first to get a `job_id`, then interact with the live browser to click buttons, fill forms, or run JavaScript.
+
+### Preferred SDK method
+
+```python
+firecrawl.interact(job_id, code=None, *, prompt=None, language="node", timeout=None)
+```
+
+### Example
+
+```python
+# First scrape to get a session
+doc = firecrawl.scrape("https://example.com", formats=["markdown"])
+job_id = doc.metadata.get("jobId")
+
+# Execute code in the browser
+result = firecrawl.interact(
+    job_id,
+    code="document.querySelector('button.load-more').click();",
+    language="node",
+    timeout=30,
+)
+
+print(result.stdout)
+
+# Or use a natural-language prompt
+agent_result = firecrawl.interact(
+    job_id,
+    prompt="Click the 'Load More' button and wait for new content",
+)
+
+print(agent_result.output)
+
+# Stop the session when done
+firecrawl.stop_interaction(job_id)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `str` | **Required.** The scrape job ID from a prior scrape. |
+| `code` | `str` | Code to execute in the browser sandbox. Provide either `code` or `prompt`. |
+| `prompt` | `str` | Natural-language instruction for the browser agent. Provide either `code` or `prompt`. |
+| `language` | `"python" \| "node" \| "bash"` | Language for code execution. Default: `"node"`. |
+| `timeout` | `int` | Execution timeout in seconds (1-300). |
+
+The response includes:
+
+| Field | Type | Description |
+|---|---|---|
+| `success` | `bool` | Whether execution succeeded. |
+| `output` | `str \| None` | Agent's response (only when using `prompt`). |
+| `stdout` | `str \| None` | Standard output from code execution. |
+| `stderr` | `str \| None` | Standard error output. |
+| `exit_code` | `int \| None` | Exit code of executed process. |
+| `killed` | `bool` | Whether process was killed due to timeout. |
+| `live_view_url` | `str \| None` | Read-only live view of the browser. |
+| `interactive_live_view_url` | `str \| None` | Interactive live view. |
+
+Call `firecrawl.stop_interaction(job_id)` to end the session when done.
+
+## Notes
+
+- All parameter names use **snake_case** (e.g. `only_main_content`, `scrape_options`). The SDK converts these to camelCase for the API.
+- `SearchData` returns results via `.web`, `.news`, `.images` properties. The old `.data` accessor is removed and raises a helpful error.
+- **Deprecated aliases for interact:**
+  - `scrape_execute(job_id, ...)` → use `interact(job_id, ...)`
+  - `stop_interactive_browser(job_id)` → use `stop_interaction(job_id)`
+  - `delete_scrape_browser(job_id)` → use `stop_interaction(job_id)`
+- **Deprecated aliases for other methods:**
+  - `scrape_url()` → `scrape()`
+  - `crawl_url()` → `crawl()`
+  - `map_url()` → `map()`
+- The class `FirecrawlApp` is an alias for `Firecrawl`. Use `Firecrawl` for new code.
+
+## Source Of Truth
+
+- SDK: `firecrawl/apps/python-sdk/firecrawl/client.py`, `firecrawl/apps/python-sdk/firecrawl/v2/client.py`, `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
+- OpenAPI: `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/rust.mdx
+++ b/agent-quickstart/rust.mdx
@@ -1,0 +1,283 @@
+---
+title: "Rust Agent Quickstart"
+description: "Canonical Firecrawl Rust quickstart for external agents using search, scrape, and interact."
+og:title: "Rust Agent Quickstart | Firecrawl"
+og:description: "Canonical Firecrawl Rust quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Rust Agent Quickstart
+
+Canonical quickstart for external agents integrating with Firecrawl using the Rust SDK. Generated from SDK source and OpenAPI spec.
+
+## Install
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+firecrawl = "2.16.0"
+tokio = { version = "1", features = ["full"] }
+```
+
+## Authenticate
+
+```rust
+use firecrawl::Client;
+
+let firecrawl = Client::new("fc-YOUR_API_KEY")?;
+```
+
+For self-hosted instances:
+
+```rust
+let firecrawl = Client::new_selfhosted(
+    "https://your-instance.example.com",
+    Some("fc-YOUR_API_KEY"),
+)?;
+```
+
+Pass `None` as the API key for the keyless free tier (rate-limited per IP; only scrape, search, and interact available).
+
+## When To Use What
+
+- **`search`**: You start with a query and need to discover relevant URLs and their content. Use when you don't have a specific URL yet.
+- **`scrape`**: You already have a URL and want its page content as markdown, HTML, or structured JSON. Use for targeted extraction.
+- **`interact`**: The page needs clicks, form fills, or other browser actions after an initial scrape. Use for multi-step browser automation.
+
+## Search
+
+### Why use it
+
+Search the web for a query and optionally scrape the results. Returns structured results grouped by source type (web, news, images). Use this when you need to discover relevant pages before extracting content.
+
+### Preferred SDK method
+
+```rust
+firecrawl.search(query, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, SearchOptions, ScrapeOptions, Format};
+
+let firecrawl = Client::new("fc-YOUR_API_KEY")?;
+
+let response = firecrawl.search("firecrawl web scraping API", SearchOptions {
+    limit: Some(5),
+    scrape_options: Some(ScrapeOptions {
+        formats: Some(vec![Format::Markdown]),
+        ..Default::default()
+    }),
+    ..Default::default()
+}).await?;
+
+if let Some(web_results) = response.data.web {
+    for result in web_results {
+        // result is SearchResultOrDocument enum
+        println!("{:?}", result);
+    }
+}
+```
+
+### Parameters
+
+`SearchOptions` fields (all `Option`, default `None`):
+
+| Parameter | Type | Description |
+|---|---|---|
+| `limit` | `Option<u32>` | Max results per source type. Default: `5`, max: `20`. |
+| `sources` | `Option<Vec<SearchSource>>` | Sources: `Web`, `News`, `Images`. Default: `[Web]`. |
+| `categories` | `Option<Vec<SearchCategory>>` | Categories: `Github`, `Research`, `Pdf`. |
+| `include_domains` | `Option<Vec<String>>` | Restrict results to these domains. Cannot combine with `exclude_domains`. |
+| `exclude_domains` | `Option<Vec<String>>` | Exclude results from these domains. |
+| `tbs` | `Option<String>` | Time-based filter. `"qdr:d"` (day), `"qdr:w"` (week), etc. |
+| `location` | `Option<String>` | Geographic location for results. |
+| `ignore_invalid_urls` | `Option<bool>` | Exclude invalid URLs from results. |
+| `timeout` | `Option<u32>` | Timeout in milliseconds. |
+| `highlights` | `Option<bool>` | Generate query-relevant highlights. Default: `true` (server-side). |
+| `scrape_options` | `Option<ScrapeOptions>` | Scrape options applied to each result. |
+
+A convenience wrapper `search_and_scrape(query, limit)` returns only `Vec<Document>` results.
+
+## Scrape
+
+### Why use it
+
+Scrape a single URL and get its content as markdown, HTML, screenshots, structured JSON, or other formats. The primary tool for extracting page content when you already know the URL.
+
+### Preferred SDK method
+
+```rust
+firecrawl.scrape(url, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, Format};
+
+let firecrawl = Client::new("fc-YOUR_API_KEY")?;
+
+let doc = firecrawl.scrape("https://example.com", ScrapeOptions {
+    formats: Some(vec![Format::Markdown, Format::Links]),
+    only_main_content: Some(true),
+    ..Default::default()
+}).await?;
+
+println!("{}", doc.markdown.unwrap_or_default());
+println!("{:?}", doc.links);
+```
+
+Extract structured data with a JSON schema:
+
+```rust
+use serde_json::json;
+
+let result = firecrawl.scrape_with_schema(
+    "https://example.com/pricing",
+    json!({
+        "type": "object",
+        "properties": {
+            "plans": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "price": {"type": "number"}
+                    }
+                }
+            }
+        }
+    }),
+    Some("Extract pricing plans"),
+).await?;
+
+println!("{}", result);
+```
+
+### Parameters
+
+`ScrapeOptions` fields (all `Option`, default `None`):
+
+| Parameter | Type | Description |
+|---|---|---|
+| `formats` | `Option<Vec<Format>>` | Output formats. Enum variants: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `ChangeTracking`, `Json`, `Attributes`, `Branding`, `Product`, `Menu`, `Audio`, `Video`, `Question(QuestionFormat)`, `Highlights(HighlightsFormat)`. Default: `[Markdown]`. |
+| `only_main_content` | `Option<bool>` | Only return main content. Default: `true`. |
+| `include_tags` | `Option<Vec<String>>` | HTML tags to include. |
+| `exclude_tags` | `Option<Vec<String>>` | HTML tags to exclude. |
+| `headers` | `Option<HashMap<String, String>>` | Custom HTTP headers. |
+| `timeout` | `Option<u32>` | Timeout in milliseconds. Default: `60000`. |
+| `wait_for` | `Option<u32>` | Delay in ms before fetching. Default: `0`. |
+| `mobile` | `Option<bool>` | Emulate a mobile device. Default: `false`. |
+| `parsers` | `Option<Vec<ParserConfig>>` | Parser configs (e.g. PDF). |
+| `actions` | `Option<Vec<Action>>` | Browser actions before grabbing content. |
+| `location` | `Option<LocationConfig>` | Location settings: `{ country, languages }`. |
+| `skip_tls_verification` | `Option<bool>` | Skip TLS verification. Default: `true`. |
+| `remove_base64_images` | `Option<bool>` | Remove base64 images. Default: `true`. |
+| `fast_mode` | `Option<bool>` | Use fast mode (less accurate). |
+| `block_ads` | `Option<bool>` | Block ads and cookie popups. Default: `true`. |
+| `proxy` | `Option<ProxyType>` | Proxy type: `Basic`, `Stealth`, `Enhanced`, `Auto`. Default: `Auto`. |
+| `max_age` | `Option<u32>` | Use cached result if younger (seconds). |
+| `min_age` | `Option<u32>` | Only check cache, never trigger fresh scrape. |
+| `store_in_cache` | `Option<bool>` | Store result in cache. Default: `true`. |
+| `lockdown` | `Option<bool>` | Serve only cached results. Default: `false`. |
+| `redact_pii` | `Option<bool>` | Redact PII. |
+| `profile` | `Option<ProfileConfig>` | Browser profile: `{ name, save_changes }`. |
+| `audit_metadata` | `Option<AuditMetadata>` | SIEM attribution: `{ username }`. |
+| `json_options` | `Option<JsonOptions>` | JSON extraction config: `{ schema, system_prompt, prompt }`. |
+| `screenshot_options` | `Option<ScreenshotOptions>` | Screenshot config: `{ full_page, quality, viewport }`. |
+| `change_tracking_options` | `Option<ChangeTrackingOptions>` | Change tracking: `{ modes, schema, prompt, tag }`. |
+| `attribute_selectors` | `Option<Vec<AttributeSelector>>` | Attribute extraction: `{ selector, attribute }`. |
+
+## Interact
+
+### Why use it
+
+Execute code or natural-language prompts in the browser session created by a prior scrape. Use this for multi-step workflows: scrape a page first to get a job ID, then interact with the live browser.
+
+### Preferred SDK method
+
+```rust
+firecrawl.interact(job_id, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, ScrapeExecuteOptions, Format};
+
+let firecrawl = Client::new("fc-YOUR_API_KEY")?;
+
+// First scrape to get a session
+let doc = firecrawl.scrape("https://example.com", ScrapeOptions {
+    formats: Some(vec![Format::Markdown]),
+    ..Default::default()
+}).await?;
+
+// Execute code in the browser
+let result = firecrawl.interact("job-id-from-scrape", ScrapeExecuteOptions {
+    code: Some("document.querySelector('button').click();".into()),
+    language: Some(ScrapeExecuteLanguage::Node),
+    timeout: Some(30),
+    ..Default::default()
+}).await?;
+
+println!("{:?}", result.stdout);
+
+// Or use a natural-language prompt
+let agent_result = firecrawl.interact("job-id-from-scrape", ScrapeExecuteOptions {
+    prompt: Some("Click the 'Load More' button".into()),
+    ..Default::default()
+}).await?;
+
+println!("{:?}", agent_result.output);
+
+// Stop the session when done
+firecrawl.stop_interaction("job-id-from-scrape").await?;
+```
+
+### Parameters
+
+`ScrapeExecuteOptions` fields (all `Option`, default `None`):
+
+| Parameter | Type | Description |
+|---|---|---|
+| `code` | `Option<String>` | Code to execute in the browser sandbox. Provide either `code` or `prompt`. |
+| `prompt` | `Option<String>` | Natural-language instruction for the browser agent. Provide either `code` or `prompt`. |
+| `language` | `Option<ScrapeExecuteLanguage>` | Runtime: `Python`, `Node`, `Bash`. Default: `Node`. |
+| `timeout` | `Option<u32>` | Execution timeout in seconds. |
+
+The response (`ScrapeExecuteResponse`) includes:
+
+| Field | Type | Description |
+|---|---|---|
+| `success` | `bool` | Whether execution succeeded. |
+| `output` | `Option<String>` | Agent's response (only when using `prompt`). |
+| `stdout` | `Option<String>` | Standard output from code execution. |
+| `stderr` | `Option<String>` | Standard error output. |
+| `exit_code` | `Option<i32>` | Exit code of executed process. |
+| `killed` | `Option<bool>` | Whether process was killed due to timeout. |
+| `live_view_url` | `Option<String>` | Read-only live view of the browser. |
+| `interactive_live_view_url` | `Option<String>` | Interactive live view. |
+
+Call `firecrawl.stop_interaction(job_id).await?` to end the session.
+
+## Notes
+
+- All struct fields use **snake_case** in Rust. Serialization to the API uses camelCase via serde `rename_all`.
+- Exception: `redact_pii` serializes to `redactPII` (all-caps acronym).
+- All options structs derive `Default`. Use struct update syntax: `ScrapeOptions { formats: Some(...), ..Default::default() }`.
+- Method parameters accept `impl AsRef<str>` for ergonomic string handling.
+- All methods are `async` and require a Tokio runtime.
+- All public types are re-exported from the crate root: `use firecrawl::{Client, ScrapeOptions, ...}`.
+- **Deprecated aliases:**
+  - `scrape_execute()` → use `interact()`
+  - `stop_interactive_browser()` → use `stop_interaction()`
+  - `delete_scrape_browser()` → use `stop_interaction()`
+
+## Source Of Truth
+
+- SDK: `firecrawl/apps/rust-sdk/src/client.rs`, `firecrawl/apps/rust-sdk/src/scrape.rs`, `firecrawl/apps/rust-sdk/src/search.rs`
+- OpenAPI: `firecrawl-docs/api-reference/v2-openapi.json`


### PR DESCRIPTION
## Summary

- Adds one canonical agent quickstart file per SDK language in `agent-quickstart/`: **Node.js**, **Python**, **Rust**, **Java**, and **Elixir**
- Each file covers the three core endpoints: **search**, **scrape**, and **interact**
- Every file includes: install instructions, auth patterns, "when to use what" guide, preferred SDK method names, working examples, complete parameter tables with descriptions and defaults, deprecated alias migration notes, and language-specific caveats
- All content sourced from SDK source code (primary) and the OpenAPI spec (secondary) — no invented parameters or defaults

## Details

Each quickstart follows a consistent structure:
1. Install / Authenticate
2. When To Use What (search vs scrape vs interact)
3. Per-endpoint sections with why, method name, example, and full parameter table
4. Notes on language-specific conventions (naming, patterns, deprecated aliases)
5. Source of truth references

Language-specific highlights:
- **Node.js**: Documents Zod schema integration for type-safe JSON extraction, camelCase conventions
- **Python**: Documents snake_case parameter naming, `SearchData` migration (`.web`/`.news`/`.images` instead of `.data`)
- **Rust**: Documents struct update syntax with `Default`, `impl AsRef<str>` ergonomics, async/Tokio requirement
- **Java**: Documents builder pattern, method overloading for defaults, `CompletableFuture` async variants
- **Elixir**: Documents auto-generated OpenAPI function names, keyword list params, atom enum values, bang variants

Notable cross-language differences documented:
- `prompt` parameter for interact is available in Node.js, Python, and Rust but **not** in Java or Elixir
- Search `limit` default varies: 5 (Python), 10 (OpenAPI/Node.js/Java), 20 max (Rust)
- Elixir function names follow OpenAPI operation IDs (`scrape_and_extract_from_url` vs `scrape`)

## Test plan

- [ ] Verify each `.mdx` file renders cleanly as a Mintlify docs page
- [ ] Confirm parameter tables match current SDK source
- [ ] Check code examples for syntax correctness
- [ ] Validate frontmatter fields

---
_Generated by [Claude Code](https://claude.ai/code/session_01XLVntFz7ZBVLfi68APQMHG)_