### PR TITLE
docs: add agent quickstart files for all SDK languages

### DIFF
--- a/agent-quickstart/elixir.mdx
+++ b/agent-quickstart/elixir.mdx
@@ -1,0 +1,189 @@
+---
+title: "Elixir Agent Quickstart"
+description: "Canonical Firecrawl Elixir quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Elixir Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`:firecrawl` **1.9.2**) and the v2 OpenAPI spec. The Elixir client is auto-generated from the OpenAPI spec; function names match the spec operation IDs.
+
+## Install
+
+Add to `mix.exs`:
+
+```elixir
+defp deps do
+  [
+    {:firecrawl, "~> 1.9"}
+  ]
+end
+```
+
+## Authenticate
+
+```elixir
+# config/runtime.exs or config.exs
+config :firecrawl, api_key: System.get_env("FIRECRAWL_API_KEY")
+
+# Or pass api_key per call:
+{:ok, res} = Firecrawl.search_and_scrape(
+  [query: "site:docs.firecrawl.dev webhook retries"],
+  api_key: "fc-your-api-key"
+)
+```
+
+There is no client struct. The SDK builds a `Req` client per request. Configuration is global (via `config :firecrawl`) or per-request (via the trailing `opts` keyword list).
+
+## When To Use What
+
+- `search`: use when you start with a query and need discovery.
+- `scrape`: use when you already have a URL and want page content.
+- `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:` in the query.
+
+### Preferred SDK method
+
+`Firecrawl.search_and_scrape(params \\ [], opts \\ [])`
+
+### Example
+
+```elixir
+{:ok, res} = Firecrawl.search_and_scrape(
+  query: "site:docs.firecrawl.dev webhook retries",
+  sources: [:web],
+  limit: 5,
+  scrape_options: [
+    formats: ["markdown"],
+    only_main_content: true
+  ]
+)
+```
+
+### Parameters
+
+- `query` — string (required). The search query. Use `site:example.com` to limit to a domain.
+- `sources` — list of atoms/strings. Values: `:web`, `:news`, `:images`.
+- `categories` — list of atoms/strings. Values: `:github`, `:research`, `:pdf`.
+- `include_domains` — list of strings. Restrict results to these domains.
+- `exclude_domains` — list of strings. Exclude results from these domains.
+- `limit` — integer. Max number of results.
+- `tbs` — string. Time-based filter (e.g. `"qdr:d"`, `"qdr:w"`, `"qdr:m"`).
+- `location` — string. Localized search results.
+- `country` — string. ISO 3166-1 alpha-2 code (e.g. `"US"`).
+- `ignore_invalid_urls` — boolean. Drop URLs that cannot be scraped.
+- `timeout` — integer. Request timeout in milliseconds.
+- `highlights` — boolean. Generate query-relevant highlights.
+- `enterprise` — list of strings. Enterprise ZDR options: `["zdr"]` for end-to-end, `["anon"]` for anonymized.
+- `scrape_options` — keyword list. Scrape each search result (see Scrape parameters).
+
+## Scrape
+
+### Why use it
+
+Get structured content from a URL in one or more formats.
+
+### Preferred SDK method
+
+`Firecrawl.scrape_and_extract_from_url(params \\ [], opts \\ [])`
+
+### Example
+
+```elixir
+{:ok, res} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com/pricing",
+  formats: [
+    "markdown",
+    %{type: "json", prompt: "Extract plan names and prices."}
+  ],
+  only_main_content: true
+)
+```
+
+### Parameters
+
+- `url` — string (required). The URL to scrape.
+- `formats` — list of format strings or format maps. Output formats.
+  - Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"branding"`, `"audio"`, `"video"`
+  - Maps: `%{type: "json", prompt: ..., schema: ...}`, `%{type: "question", question: ...}`, `%{type: "highlights", query: ...}`, `%{type: "screenshot", fullPage: ..., quality: ..., viewport: ...}`, `%{type: "changeTracking", modes: [...], tag: ...}`, `%{type: "attributes", selectors: [%{selector: ..., attribute: ...}]}`
+- `headers` — map. Custom HTTP headers.
+- `include_tags` — list of strings. Only include these HTML tags.
+- `exclude_tags` — list of strings. Exclude these HTML tags.
+- `only_main_content` — boolean. Strip nav, footer, and boilerplate.
+- `timeout` — integer. Timeout in milliseconds. Default 60000, max 300000.
+- `wait_for` — integer. Wait for page render in milliseconds.
+- `mobile` — boolean. Use mobile viewport.
+- `parsers` — list. Parser configuration (e.g. `["pdf"]` or `[%{type: "pdf", mode: "auto", maxPages: 5}]`).
+- `actions` — list of action maps. Browser actions before scraping.
+  - Types: `wait` (`milliseconds` or `selector`), `click` (`selector`, optional `all`), `write` (`text`), `press` (`key`), `scroll` (`direction`), `screenshot`, `scrape`, `executeJavascript` (`script`), `pdf`
+- `location` — keyword list with `country:` and `languages:`. Geo or language-aware scraping.
+- `skip_tls_verification` — boolean. Skip TLS verification.
+- `remove_base64_images` — boolean. Drop base64 images from markdown.
+- `block_ads` — boolean. Block ads and cookie popups.
+- `proxy` — atom. `:basic`, `:enhanced`, or `:auto`.
+- `max_age` — integer. Serve cached data up to this age in milliseconds.
+- `min_age` — integer. Serve cached data only if at least this old in milliseconds.
+- `store_in_cache` — boolean. Cache the result.
+- `lockdown` — boolean. Serve only cached results; never make outbound requests.
+- `redact_pii` — boolean. Redact personally identifiable information.
+- `audit_metadata` — keyword list with `username:`. User attribution for SIEM logging.
+- `profile` — keyword list with `name:` and optional `save_changes:`. Persistent browser profile.
+- `zero_data_retention` — boolean. Enable zero data retention.
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job — run code in the browser. The Elixir SDK exposes code-based interactions only (no `prompt` parameter).
+
+### Preferred SDK method
+
+`Firecrawl.interact_with_scrape_browser_session(job_id, params \\ [], opts \\ [])`
+
+### Example
+
+```elixir
+{:ok, scrape_res} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown"]
+)
+job_id = get_in(scrape_res.body, ["data", "metadata", "scrapeId"])
+
+{:ok, res} = Firecrawl.interact_with_scrape_browser_session(
+  job_id,
+  code: "console.log(await page.title());",
+  language: :node,
+  timeout: 60
+)
+
+# When done:
+{:ok, _} = Firecrawl.stop_interactive_scrape_browser_session(job_id)
+```
+
+### Parameters
+
+- `job_id` — string (required, first argument). Scrape job ID.
+- `code` — string (required). Code to execute in the browser session.
+- `language` — atom. `:python`, `:node`, or `:bash`.
+- `timeout` — integer. Execution timeout in seconds.
+
+Stop the session with `Firecrawl.stop_interactive_scrape_browser_session(job_id)`.
+
+## Notes
+
+- The Elixir SDK is auto-generated from the OpenAPI spec. Function names come directly from spec operation IDs.
+- Every function has a bang (`!`) variant (e.g. `search_and_scrape!`) that raises on error instead of returning `{:error, _}`.
+- Snake_case parameter keys are automatically converted to camelCase JSON keys.
+- Atoms for enum values (`:basic`, `:node`) are converted to strings before sending.
+- Parameters are validated at call time using NimbleOptions.
+- No client struct — a fresh `Req` client is created per request.
+
+## Source Of Truth
+
+- `firecrawl/apps/elixir-sdk/mix.exs`
+- `firecrawl/apps/elixir-sdk/lib/firecrawl.ex`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/java.mdx
+++ b/agent-quickstart/java.mdx
@@ -1,0 +1,215 @@
+---
+title: "Java Agent Quickstart"
+description: "Canonical Firecrawl Java quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Java Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`firecrawl-java` **1.15.0**) and the v2 OpenAPI spec.
+
+## Install
+
+Maven:
+
+```xml
+<dependency>
+  <groupId>com.firecrawl</groupId>
+  <artifactId>firecrawl-java</artifactId>
+  <version>1.15.0</version>
+</dependency>
+```
+
+Gradle:
+
+```gradle
+implementation("com.firecrawl:firecrawl-java:1.15.0")
+```
+
+## Authenticate
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey(System.getenv("FIRECRAWL_API_KEY"))
+    .build();
+
+// Or from environment:
+// FirecrawlClient client = FirecrawlClient.fromEnv();
+```
+
+## When To Use What
+
+- `search`: use when you start with a query and need discovery.
+- `scrape`: use when you already have a URL and want page content.
+- `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:` in the query.
+
+### Preferred SDK method
+
+`client.search(query)` or `client.search(query, options)` → `SearchData`
+
+### Example
+
+```java
+import com.firecrawl.models.SearchOptions;
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.SearchData;
+
+SearchData results = client.search(
+    "site:docs.firecrawl.dev webhook retries",
+    SearchOptions.builder()
+        .sources(List.of("web"))
+        .limit(5)
+        .scrapeOptions(
+            ScrapeOptions.builder()
+                .formats(List.of("markdown"))
+                .onlyMainContent(true)
+                .build()
+        )
+        .build()
+);
+
+// Results are in results.getWeb(), results.getNews(), results.getImages()
+```
+
+Note: `SearchData` result buckets (`getWeb()`, `getNews()`, `getImages()`) return `List<Map<String, Object>>` and may be null.
+
+### Parameters
+
+- `query` — String (required). The search query. Use `site:example.com` to limit to a domain.
+- `options.sources` — `List<Object>`. Values: `"web"`, `"news"`, `"images"`.
+- `options.categories` — `List<Object>`. Values: `"github"`, `"research"`, `"pdf"`.
+- `options.includeDomains` — `List<String>`. Restrict results to these domains.
+- `options.excludeDomains` — `List<String>`. Exclude results from these domains.
+- `options.limit` — Integer. Max number of results.
+- `options.tbs` — String. Time-based filter (e.g. `"qdr:d"`, `"qdr:w"`, `"qdr:m"`).
+- `options.location` — String. Localized search results.
+- `options.ignoreInvalidURLs` — Boolean. Drop URLs that cannot be scraped.
+- `options.timeout` — Integer. Request timeout in milliseconds.
+- `options.highlights` — Boolean. Generate query-relevant highlights. Defaults to `true`.
+- `options.scrapeOptions` — `ScrapeOptions`. Scrape each search result (see Scrape parameters).
+
+## Scrape
+
+### Why use it
+
+Get structured content from a URL in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url)` or `client.scrape(url, options)` → `Document`
+
+### Example
+
+```java
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.JsonFormat;
+import com.firecrawl.models.Document;
+
+Document doc = client.scrape(
+    "https://example.com/pricing",
+    ScrapeOptions.builder()
+        .formats(List.of(
+            "markdown",
+            JsonFormat.builder().prompt("Extract plan names and prices.").build()
+        ))
+        .onlyMainContent(true)
+        .build()
+);
+
+System.out.println(doc.getMarkdown());
+System.out.println(doc.getJson());
+```
+
+### Parameters
+
+- `url` — String (required). The URL to scrape.
+- `options.formats` — `List<Object>`. Output formats.
+  - Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"attributes"`, `"branding"`, `"audio"`, `"video"`
+  - Objects: `JsonFormat.builder().prompt(...).schema(...).build()`, `QuestionFormat.builder().question(...).build()`, `HighlightsFormat.builder().query(...).build()`
+- `options.headers` — `Map<String, String>`. Custom HTTP headers.
+- `options.includeTags` — `List<String>`. Only include these HTML tags.
+- `options.excludeTags` — `List<String>`. Exclude these HTML tags.
+- `options.onlyMainContent` — Boolean. Strip nav, footer, and boilerplate.
+- `options.timeout` — Integer. Timeout in milliseconds.
+- `options.waitFor` — Integer. Wait for page render in milliseconds.
+- `options.mobile` — Boolean. Use mobile viewport.
+- `options.parsers` — `List<Object>`. Parser configuration (e.g. `"pdf"` or `PdfParser.builder().mode("auto").maxPages(5).build()`).
+- `options.actions` — `List<Map<String, Object>>`. Browser actions before scraping.
+  - Types: `wait` (`milliseconds` or `selector`), `click` (`selector`), `write` (`text`), `press` (`key`), `scroll` (`direction`), `screenshot`, `scrape`, `executeJavascript` (`script`), `pdf`
+- `options.location` — `LocationConfig`. Fields: `country`, `languages`.
+- `options.skipTlsVerification` — Boolean. Skip TLS verification.
+- `options.removeBase64Images` — Boolean. Drop base64 images from markdown.
+- `options.blockAds` — Boolean. Block ads and cookie popups.
+- `options.proxy` — String. `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`, or custom proxy URL.
+- `options.maxAge` — Long. Serve cached data up to this age in milliseconds.
+- `options.storeInCache` — Boolean. Cache the result.
+- `options.lockdown` — Boolean. Serve only cached results; never make outbound requests.
+- `options.redactPII` — Boolean. Redact personally identifiable information.
+- `options.auditMetadata` — `AuditMetadata`. User attribution for SIEM logging. Field: `username` (required).
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job — run code in the browser. The Java SDK exposes code-based interactions only (no `prompt` parameter).
+
+### Preferred SDK method
+
+- `client.interact(jobId, code)` — uses default language `"node"`
+- `client.interact(jobId, code, language, timeout)` — explicit language and timeout
+
+### Example
+
+```java
+import com.firecrawl.models.BrowserExecuteResponse;
+
+Document doc = client.scrape(
+    "https://example.com",
+    ScrapeOptions.builder().formats(List.of("markdown")).build()
+);
+String jobId = (String) doc.getMetadata().get("scrapeId");
+
+BrowserExecuteResponse result = client.interact(
+    jobId,
+    "console.log(await page.title());",
+    "node",
+    60
+);
+
+System.out.println(result.getStdout());
+
+// When done:
+client.stopInteractiveBrowser(jobId);
+```
+
+### Parameters
+
+- `jobId` — String (required). Scrape job ID.
+- `code` — String (required). Code to execute in the browser session.
+- `language` — String. `"python"`, `"node"`, or `"bash"`. Defaults to `"node"`.
+- `timeout` — Integer. Execution timeout in seconds (1–300). Null uses API default (30 seconds).
+
+Stop the session with `client.stopInteractiveBrowser(jobId)`.
+
+## Notes
+
+- Deprecated aliases: `scrapeExecute` → `interact`; `deleteScrapeBrowser` → `stopInteractiveBrowser`.
+- The Java SDK does not support `prompt`-based interact — only code execution.
+- All options use the builder pattern: `ScrapeOptions.builder()...build()`.
+- Async variants are available: `scrapeAsync()`, `searchAsync()`, `interactAsync()`.
+- Search result items are returned as `Map<String, Object>` (untyped).
+
+## Source Of Truth
+
+- `firecrawl/apps/java-sdk/build.gradle.kts`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/ScrapeOptions.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/SearchOptions.java`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/node.mdx
+++ b/agent-quickstart/node.mdx
@@ -1,0 +1,186 @@
+---
+title: "Node.js Agent Quickstart"
+description: "Canonical Firecrawl Node.js quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Node.js Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`firecrawl` **4.35.0**) and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+```bash
+npm install firecrawl
+```
+
+Requires Node.js >= 22.
+
+## Authenticate
+
+```ts
+import { Firecrawl } from "firecrawl";
+
+const client = new Firecrawl({
+  apiKey: process.env.FIRECRAWL_API_KEY,
+  // apiUrl: "https://api.firecrawl.dev" // optional; falls back to FIRECRAWL_API_URL env var
+});
+```
+
+## When To Use What
+
+- `search`: use when you start with a query and need discovery.
+- `scrape`: use when you already have a URL and want page content.
+- `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:` in the query.
+
+### Preferred SDK method
+
+`client.search(query, options?)` → `Promise<SearchData>`
+
+### Example
+
+```ts
+const results = await client.search("site:docs.firecrawl.dev webhook retries", {
+  sources: ["web"],
+  limit: 5,
+  scrapeOptions: {
+    formats: ["markdown"],
+    onlyMainContent: true
+  }
+});
+
+for (const item of results.web ?? []) {
+  console.log(item.url, item.title);
+}
+```
+
+**Wrong turn to avoid:** `search()` does not return `{ data: [...] }`. Access `result.web`, `result.news`, or `result.images`.
+
+### Parameters
+
+- `query` — string (required). The search query. Use `site:example.com` to limit to a domain.
+- `options.sources` — array of `"web"` | `"news"` | `"images"`. Controls which result buckets are populated.
+- `options.categories` — array of `"github"` | `"research"` | `"pdf"` | `"developer"`. Narrows web results by category.
+- `options.includeDomains` — string array. Restrict results to these domains. Mutually exclusive with `excludeDomains`.
+- `options.excludeDomains` — string array. Exclude results from these domains. Mutually exclusive with `includeDomains`.
+- `options.limit` — number. Max number of results.
+- `options.tbs` — string. Time-based filter (e.g. `"qdr:d"` past day, `"qdr:w"` past week, `"qdr:m"` past month).
+- `options.location` — string. Localized search results (e.g. `"San Francisco,California,United States"`).
+- `options.ignoreInvalidURLs` — boolean. Drop URLs that cannot be scraped.
+- `options.timeout` — number. Request timeout in milliseconds.
+- `options.highlights` — boolean. Generate query-relevant highlights. Defaults to `true`.
+- `options.scrapeOptions` — `ScrapeOptions`. Scrape each search result with these options (see Scrape parameters).
+- `options.enterprise` — array of `"default"` | `"anon"` | `"zdr"`. Enterprise zero-data-retention options.
+
+## Scrape
+
+### Why use it
+
+Get structured content from a URL in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, options?)` → `Promise<Document>`
+
+### Example
+
+```ts
+const doc = await client.scrape("https://example.com/pricing", {
+  formats: [
+    "markdown",
+    { type: "json", prompt: "Extract plan names and prices." }
+  ],
+  onlyMainContent: true
+});
+
+console.log(doc.markdown);
+console.log(doc.json);
+```
+
+### Parameters
+
+- `url` — string (required). The URL to scrape.
+- `options.formats` — array of format strings or format objects. Output formats to request.
+  - Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`
+  - Objects: `{ type: "json", prompt?, schema? }`, `{ type: "question", question }`, `{ type: "highlights", query }`, `{ type: "screenshot", fullPage?, quality?, viewport? }`, `{ type: "changeTracking", modes: ("git-diff" | "json")[], schema?, prompt?, tag? }`, `{ type: "attributes", selectors: [{ selector, attribute }] }`
+  - Note: plain string `"json"` is rejected by the SDK — use a `{ type: "json" }` object.
+- `options.headers` — `Record<string, string>`. Custom HTTP headers.
+- `options.includeTags` — string array. Only include these HTML tags.
+- `options.excludeTags` — string array. Exclude these HTML tags.
+- `options.onlyMainContent` — boolean. Strip nav, footer, and boilerplate.
+- `options.timeout` — number. Server-side timeout in milliseconds.
+- `options.waitFor` — number. Wait for page render in milliseconds.
+- `options.mobile` — boolean. Use mobile viewport.
+- `options.parsers` — array. Parser configuration (e.g. `"pdf"` or `{ type: "pdf", mode: "fast" | "auto" | "ocr", maxPages? }`).
+- `options.actions` — array of action objects. Browser actions before scraping.
+  - Types: `wait` (`milliseconds` or `selector`), `click` (`selector`), `write` (`text`), `press` (`key`), `scroll` (`direction`: `"up"` | `"down"`), `screenshot`, `scrape`, `executeJavascript` (`script`), `pdf`
+- `options.location` — `{ country?, languages? }`. Geo or language-aware scraping.
+- `options.skipTlsVerification` — boolean. Skip TLS verification.
+- `options.removeBase64Images` — boolean. Drop base64 images from markdown.
+- `options.fastMode` — boolean. Faster scrapes with reduced fidelity.
+- `options.blockAds` — boolean. Block ads and cookie popups.
+- `options.proxy` — `"basic"` | `"stealth"` | `"enhanced"` | `"auto"` | custom URL string.
+- `options.maxAge` — number. Serve cached data up to this age in milliseconds. `0` to bypass cache.
+- `options.minAge` — number. Serve cached data only if at least this old in milliseconds.
+- `options.storeInCache` — boolean. Cache the result.
+- `options.lockdown` — boolean. Serve only cached results; never make outbound requests.
+- `options.redactPII` — boolean or `{ mode, entities, replaceStyle }`. Redact personally identifiable information.
+- `options.auditMetadata` — `{ username: string }`. User attribution for SIEM logging.
+- `options.profile` — `{ name: string, saveChanges?: boolean }`. Persistent browser profile across scrapes and interactions.
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job — run code or give natural-language instructions. Requires a `scrapeId` from a prior scrape. For flows beyond quick pre-scrape tweaks, prefer `interact` over scrape-time `actions`.
+
+### Preferred SDK method
+
+`client.interact(jobId, args)` → `Promise<ScrapeExecuteResponse>`
+
+### Example
+
+```ts
+const doc = await client.scrape("https://example.com", { formats: ["markdown"] });
+const jobId = doc.metadata?.scrapeId;
+if (!jobId) throw new Error("Missing scrapeId");
+
+const result = await client.interact(jobId, {
+  prompt: "Click the pricing tab and summarize the plans."
+});
+console.log(result.output);
+
+// When done:
+await client.stopInteraction(jobId);
+```
+
+### Parameters
+
+- `jobId` — string (required). Scrape job ID from `document.metadata.scrapeId`.
+- `args.code` — string. Code to execute in the browser session (e.g. Playwright `page` methods).
+- `args.prompt` — string. Natural-language instruction for the browser agent.
+- At least one of `code` or `prompt` must be non-empty.
+- `args.language` — `"python"` | `"node"` | `"bash"`. Runtime for code execution. Defaults to `"node"`.
+- `args.timeout` — number. Execution timeout in seconds.
+
+Stop the session with `client.stopInteraction(jobId)`.
+
+## Notes
+
+- Deprecated aliases: `scrapeExecute` → `interact`; `stopInteractiveBrowser` and `deleteScrapeBrowser` → `stopInteraction`.
+- The default `Firecrawl` export is the v2 client; v1 remains under `client.v1`.
+- Zod schemas passed to `formats` (for `json` or `changeTracking`) are converted to JSON Schema by the SDK.
+- Timeout units differ: `scrape` uses milliseconds, `interact` uses seconds.
+
+## Source Of Truth
+
+- `firecrawl/apps/js-sdk/firecrawl/package.json`
+- `firecrawl/apps/js-sdk/firecrawl/src/index.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/python.mdx
+++ b/agent-quickstart/python.mdx
@@ -1,0 +1,187 @@
+---
+title: "Python Agent Quickstart"
+description: "Canonical Firecrawl Python quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Python Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`firecrawl-py` **4.38.0**) and the v2 OpenAPI spec. Method names, parameters, and types match the v2 client.
+
+## Install
+
+```bash
+pip install firecrawl-py
+```
+
+## Authenticate
+
+```python
+import os
+from firecrawl import Firecrawl
+
+client = Firecrawl(api_key=os.environ.get("FIRECRAWL_API_KEY"))
+# client = Firecrawl(api_key="fc-...", api_url="https://api.firecrawl.dev")
+```
+
+## When To Use What
+
+- `search`: use when you start with a query and need discovery.
+- `scrape`: use when you already have a URL and want page content.
+- `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:` in the query.
+
+### Preferred SDK method
+
+`client.search(query, **options)` → `SearchData`
+
+### Example
+
+```python
+results = client.search(
+    "site:docs.firecrawl.dev webhook retries",
+    sources=["web"],
+    limit=5,
+    scrape_options=ScrapeOptions(
+        formats=["markdown"],
+        only_main_content=True,
+    ),
+)
+
+for item in results.web or []:
+    print(getattr(item, "url", None), getattr(item, "title", None))
+```
+
+**Wrong turn to avoid:** `search()` does not return `{ data: [...] }`. Access `result.web`, `result.news`, or `result.images`.
+
+### Parameters
+
+- `query` — str (required, positional). The search query. Use `site:example.com` to limit to a domain.
+- `sources` — list of `"web"` | `"news"` | `"images"`. Controls which result buckets are populated.
+- `categories` — list of `"github"` | `"research"` | `"pdf"` | `"developer"`. Narrows web results by category.
+- `include_domains` — list of str. Restrict results to these domains. Mutually exclusive with `exclude_domains`.
+- `exclude_domains` — list of str. Exclude results from these domains. Mutually exclusive with `include_domains`.
+- `limit` — int. Max number of results. Defaults to `5` in the SDK model.
+- `tbs` — str. Time-based filter (e.g. `"qdr:d"` past day, `"qdr:w"` past week, `"qdr:m"` past month).
+- `location` — str. Localized search results. Note: plain string here, not a `Location` object.
+- `ignore_invalid_urls` — bool. Drop URLs that cannot be scraped.
+- `timeout` — int. Request timeout in milliseconds. Defaults to `300000`.
+- `highlights` — bool. Generate query-relevant highlights. Defaults to `True`.
+- `scrape_options` — `ScrapeOptions`. Scrape each search result with these options (see Scrape parameters).
+- `enterprise` — list of str. Enterprise ZDR options: `["zdr"]` for end-to-end, `["anon"]` for anonymized.
+- `threat_protection` — `ThreatProtectionOptions`. Enterprise per-request threat protection override.
+
+## Scrape
+
+### Why use it
+
+Get structured content from a URL in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, **options)` → `Document`
+
+### Example
+
+```python
+doc = client.scrape(
+    "https://example.com/pricing",
+    formats=[
+        "markdown",
+        {"type": "json", "prompt": "Extract plan names and prices."},
+    ],
+    only_main_content=True,
+)
+
+print(doc.markdown)
+print(doc.json)
+```
+
+### Parameters
+
+- `url` — str (required, positional). The URL to scrape.
+- `formats` — list of format strings or format dicts. Output formats to request.
+  - Strings: `"markdown"`, `"html"`, `"rawHtml"` (or `"raw_html"`), `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"` (or `"change_tracking"`), `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`
+  - Dicts: `{"type": "json", "prompt": ..., "schema": ...}`, `{"type": "question", "question": ...}`, `{"type": "highlights", "query": ...}`, `{"type": "screenshot", "full_page": ..., "quality": ..., "viewport": ...}`, `{"type": "changeTracking", "modes": ["git-diff", "json"], "schema": ..., "prompt": ..., "tag": ...}`, `{"type": "attributes", "selectors": [{"selector": ..., "attribute": ...}]}`
+  - Note: use a dict for JSON extraction, not the plain string `"json"`.
+- `headers` — dict. Custom HTTP headers.
+- `include_tags` — list of str. Only include these HTML tags.
+- `exclude_tags` — list of str. Exclude these HTML tags.
+- `only_main_content` — bool. Strip nav, footer, and boilerplate.
+- `timeout` — int. Timeout in milliseconds.
+- `wait_for` — int. Wait for page render in milliseconds.
+- `mobile` — bool. Use mobile viewport.
+- `parsers` — list. Parser configuration (e.g. `["pdf"]` or `[{"type": "pdf", "mode": "auto", "max_pages": 5}]`).
+- `actions` — list of action dicts. Browser actions before scraping.
+  - Types: `wait` (`milliseconds` or `selector`), `click` (`selector`), `write` (`text`), `press` (`key`), `scroll` (`direction`: `"up"` | `"down"`), `screenshot`, `scrape`, `executeJavascript` (`script`), `pdf`
+- `location` — `Location` object or dict with `country` and `languages`. Geo or language-aware scraping.
+- `skip_tls_verification` — bool. Skip TLS verification.
+- `remove_base64_images` — bool. Drop base64 images from markdown.
+- `fast_mode` — bool. Faster scrapes with reduced fidelity.
+- `block_ads` — bool. Block ads and cookie popups.
+- `proxy` — str. `"basic"`, `"stealth"`, `"enhanced"`, or `"auto"`.
+- `max_age` — int. Serve cached data up to this age in milliseconds. `0` to bypass cache.
+- `store_in_cache` — bool. Cache the result.
+- `lockdown` — bool. Serve only cached results; never make outbound requests.
+- `audit_metadata` — `AuditMetadata` with `username: str`. User attribution for SIEM logging.
+- `profile` — dict with `name` and optional `save_changes`. Persistent browser profile.
+
+Additional fields on `ScrapeOptions` model (not direct kwargs on `.scrape()`):
+- `min_age` — int. Available when passing `ScrapeOptions` to `scrape_options` on search.
+- `redact_pii` — bool or `RedactPIIOptions`. Available on the model.
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job — run code or give natural-language instructions. Requires a `scrape_id` from a prior scrape.
+
+### Preferred SDK method
+
+`client.interact(job_id, code=None, *, prompt=None, language="node", timeout=None)`
+
+### Example
+
+```python
+doc = client.scrape("https://example.com", formats=["markdown"])
+job_id = doc.metadata.scrape_id if doc.metadata else None
+if not job_id:
+    raise RuntimeError("Missing scrape_id")
+
+result = client.interact(job_id, prompt="Click the pricing tab and summarize the plans.")
+print(result.output)
+
+# When done:
+client.stop_interaction(job_id)
+```
+
+### Parameters
+
+- `job_id` — str (required, positional). Scrape job ID from `document.metadata.scrape_id`.
+- `code` — str (optional, positional). Code to execute in the browser session.
+- `prompt` — str (keyword-only). Natural-language instruction for the browser agent.
+- At least one of `code` or `prompt` must be non-empty.
+- `language` — `"python"` | `"node"` | `"bash"`. Runtime for code execution. Defaults to `"node"`.
+- `timeout` — int. Execution timeout in seconds (1–300).
+
+Stop the session with `client.stop_interaction(job_id)`.
+
+## Notes
+
+- Deprecated aliases: `scrape_execute` → `interact`; `stop_interactive_browser` and `delete_scrape_browser` → `stop_interaction`.
+- The top-level `Firecrawl` client exposes v2 methods directly; v1 remains under `client.v1`.
+- All keyword arguments after `url`/`query` are keyword-only (enforced by `*`).
+- `prompt` on `interact` is keyword-only: use `client.interact(job_id, prompt="...")`.
+
+## Source Of Truth
+
+- `firecrawl/apps/python-sdk/pyproject.toml`
+- `firecrawl/apps/python-sdk/firecrawl/__init__.py`
+- `firecrawl/apps/python-sdk/firecrawl/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/rust.mdx
+++ b/agent-quickstart/rust.mdx
@@ -1,0 +1,215 @@
+---
+title: "Rust Agent Quickstart"
+description: "Canonical Firecrawl Rust quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Rust Agent Quickstart
+
+Canonical quickstart for external agents. Generated from SDK source (`firecrawl` crate **2.16.0**) and the v2 OpenAPI spec.
+
+## Install
+
+```toml
+# Cargo.toml
+[dependencies]
+firecrawl = "2.16"
+tokio = { version = "1", features = ["full"] }
+```
+
+## Authenticate
+
+```rust
+use firecrawl::Client;
+
+let client = Client::new("fc-your-api-key")?;
+// Self-hosted:
+// let client = Client::new_selfhosted("http://localhost:3002", Some("fc-your-api-key"))?;
+```
+
+## When To Use What
+
+- `search`: use when you start with a query and need discovery.
+- `scrape`: use when you already have a URL and want page content.
+- `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:` in the query.
+
+### Preferred SDK method
+
+`client.search(query, options)` → `Result<SearchResponse, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{Client, SearchOptions, ScrapeOptions, Format};
+
+let results = client
+    .search("site:docs.firecrawl.dev webhook retries", SearchOptions {
+        sources: Some(vec![SearchSource::Web]),
+        limit: Some(5),
+        scrape_options: Some(ScrapeOptions {
+            formats: Some(vec![Format::Markdown]),
+            only_main_content: Some(true),
+            ..Default::default()
+        }),
+        ..Default::default()
+    })
+    .await?;
+
+if let Some(web) = &results.data.web {
+    for item in web {
+        // item is SearchResultOrDocument::WebResult or SearchResultOrDocument::Document
+    }
+}
+```
+
+### Parameters
+
+- `query` — `impl AsRef<str>` (required). The search query. Use `site:example.com` to limit to a domain.
+- `options.sources` — `Vec<SearchSource>`. Values: `Web`, `News`, `Images`.
+- `options.categories` — `Vec<SearchCategory>`. Values: `Github`, `Research`, `Pdf`.
+- `options.include_domains` — `Vec<String>`. Restrict results to these domains.
+- `options.exclude_domains` — `Vec<String>`. Exclude results from these domains.
+- `options.limit` — `u32`. Max number of results.
+- `options.tbs` — `String`. Time-based filter (e.g. `"qdr:d"`, `"qdr:w"`, `"qdr:m"`).
+- `options.location` — `String`. Localized search results.
+- `options.ignore_invalid_urls` — `bool`. Drop URLs that cannot be scraped.
+- `options.timeout` — `u32`. Request timeout in milliseconds.
+- `options.highlights` — `bool`. Generate query-relevant highlights. Defaults to `true`.
+- `options.scrape_options` — `ScrapeOptions`. Scrape each search result (see Scrape parameters).
+
+## Scrape
+
+### Why use it
+
+Get structured content from a URL in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, options)` → `Result<Document, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, Format, JsonOptions};
+
+let doc = client
+    .scrape("https://example.com/pricing", ScrapeOptions {
+        formats: Some(vec![Format::Markdown, Format::Json]),
+        json_options: Some(JsonOptions {
+            prompt: Some("Extract plan names and prices.".to_string()),
+            ..Default::default()
+        }),
+        only_main_content: Some(true),
+        ..Default::default()
+    })
+    .await?;
+
+println!("{:?}", doc.markdown);
+println!("{:?}", doc.json);
+```
+
+### Parameters
+
+- `url` — `impl AsRef<str>` (required). The URL to scrape.
+- `options.formats` — `Vec<Format>`. Output formats.
+  - Simple: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `ChangeTracking`, `Json`, `Attributes`, `Branding`, `Product`, `Menu`, `Audio`, `Video`
+  - Parameterized: `Question(QuestionFormat)`, `Highlights(HighlightsFormat)`
+- `options.json_options` — `JsonOptions`. Fields: `schema`, `system_prompt`, `prompt`.
+- `options.screenshot_options` — `ScreenshotOptions`. Fields: `full_page`, `quality`, `viewport`.
+- `options.change_tracking_options` — `ChangeTrackingOptions`. Fields: `modes` (`GitDiff`, `Json`), `schema`, `prompt`, `tag`.
+- `options.attribute_selectors` — `Vec<AttributeSelector>`. Fields: `selector`, `attribute`.
+- `options.headers` — `HashMap<String, String>`. Custom HTTP headers.
+- `options.include_tags` — `Vec<String>`. Only include these HTML tags.
+- `options.exclude_tags` — `Vec<String>`. Exclude these HTML tags.
+- `options.only_main_content` — `bool`. Strip nav, footer, and boilerplate.
+- `options.timeout` — `u32`. Timeout in milliseconds.
+- `options.wait_for` — `u32`. Wait for page render in milliseconds.
+- `options.mobile` — `bool`. Use mobile viewport.
+- `options.parsers` — `Vec<ParserConfig>`. Parser configuration (e.g. `ParserConfig::Pdf { ... }`).
+- `options.actions` — `Vec<Action>`. Browser actions before scraping.
+  - Variants: `Wait`, `Screenshot`, `Click`, `Write`, `Press`, `Scroll`, `Scrape`, `ExecuteJavascript`, `Pdf`
+- `options.location` — `LocationConfig`. Fields: `country`, `languages`.
+- `options.skip_tls_verification` — `bool`. Skip TLS verification.
+- `options.remove_base64_images` — `bool`. Drop base64 images from markdown.
+- `options.fast_mode` — `bool`. Faster scrapes with reduced fidelity.
+- `options.block_ads` — `bool`. Block ads and cookie popups.
+- `options.proxy` — `ProxyType`. Values: `Basic`, `Stealth`, `Enhanced`, `Auto`.
+- `options.max_age` — `u32`. Serve cached data up to this age in milliseconds.
+- `options.min_age` — `u32`. Serve cached data only if at least this old in milliseconds.
+- `options.store_in_cache` — `bool`. Cache the result.
+- `options.lockdown` — `bool`. Serve only cached results; never make outbound requests.
+- `options.redact_pii` — `bool`. Redact personally identifiable information.
+- `options.audit_metadata` — `AuditMetadata`. User attribution for SIEM logging.
+- `options.profile` — `ProfileConfig`. Fields: `name`, `save_changes`.
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job — run code or give natural-language instructions. Requires a scrape job ID from a prior scrape.
+
+### Preferred SDK method
+
+`client.interact(job_id, options)` → `Result<ScrapeExecuteResponse, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, ScrapeExecuteOptions, Format};
+
+let doc = client
+    .scrape("https://example.com", ScrapeOptions {
+        formats: Some(vec![Format::Markdown]),
+        ..Default::default()
+    })
+    .await?;
+
+let job_id = doc.metadata
+    .as_ref()
+    .and_then(|m| m.scrape_id.as_deref())
+    .expect("Missing scrapeId");
+
+let result = client
+    .interact(job_id, ScrapeExecuteOptions {
+        prompt: Some("Click the pricing tab and summarize the plans.".to_string()),
+        ..Default::default()
+    })
+    .await?;
+
+// When done:
+client.stop_interaction(job_id).await?;
+```
+
+### Parameters
+
+- `job_id` — `impl AsRef<str>` (required). Scrape job ID.
+- `options.code` — `Option<String>`. Code to execute in the browser session.
+- `options.prompt` — `Option<String>`. Natural-language instruction for the browser agent.
+- At least one of `code` or `prompt` must be non-empty; otherwise returns `FirecrawlError::Misuse`.
+- `options.language` — `ScrapeExecuteLanguage`. Values: `Python`, `Node`, `Bash`. Defaults to `Node`.
+- `options.timeout` — `u32`. Execution timeout in seconds.
+
+Stop the session with `client.stop_interaction(job_id)`.
+
+## Notes
+
+- Deprecated aliases: `scrape_execute` → `interact`; `stop_interactive_browser` and `delete_scrape_browser` → `stop_interaction`.
+- All methods are `async` and require a Tokio runtime.
+- `ScrapeOptions`, `SearchOptions`, and `ScrapeExecuteOptions` all derive `Default`, enabling `..Default::default()`.
+- Options parameters accept `impl Into<Option<...>>` — pass `None`, a bare struct, or `Some(struct)`.
+- All types are re-exported at the crate root: `use firecrawl::Client`, `use firecrawl::ScrapeOptions`, etc.
+- Convenience helper: `search_and_scrape(query, limit)` calls search with default scrape options and returns `Vec<Document>`.
+
+## Source Of Truth
+
+- `firecrawl/apps/rust-sdk/Cargo.toml`
+- `firecrawl/apps/rust-sdk/src/lib.rs`
+- `firecrawl/apps/rust-sdk/src/client.rs`
+- `firecrawl/apps/rust-sdk/src/scrape.rs`
+- `firecrawl/apps/rust-sdk/src/search.rs`
+- `firecrawl-docs/api-reference/v2-openapi.json`


### PR DESCRIPTION
## Summary

- Adds one canonical agent quickstart document per SDK language in `agent-quickstart/`: Node.js, Python, Rust, Java, and Elixir
- Each file covers `search`, `scrape`, and `interact` with current SDK method signatures, realistic examples, and every confirmed parameter with short descriptions
- Generated from latest SDK source (JS 4.35.0, Python 4.38.0, Rust 2.16.0, Java 1.15.0, Elixir 1.9.2) cross-referenced against the v2 OpenAPI spec
- Includes recently added parameters: `lockdown`, `redactPII`, `auditMetadata`, `includeDomains`/`excludeDomains`, `highlights`, `enterprise`, `threatProtection`, and new format types (`product`, `menu`, `question`, `highlights`)
- Documents language-specific naming differences (camelCase vs snake_case vs Rust enums vs Elixir atoms) and SDK quirks (e.g. Java has code-only interact, Elixir uses OpenAPI-generated function names)

## Files added

| File | Language | SDK Version |
|------|----------|-------------|
| `agent-quickstart/node.mdx` | Node.js / TypeScript | 4.35.0 |
| `agent-quickstart/python.mdx` | Python | 4.38.0 |
| `agent-quickstart/rust.mdx` | Rust | 2.16.0 |
| `agent-quickstart/java.mdx` | Java | 1.15.0 |
| `agent-quickstart/elixir.mdx` | Elixir | 1.9.2 |

## Test plan

- [ ] Verify each `.mdx` file renders correctly as a Mintlify docs page
- [ ] Spot-check parameter lists against current SDK source for accuracy
- [ ] Confirm code examples are syntactically valid
- [ ] Add navigation entries in `docs.json` if these pages should appear in the sidebar

---
_Generated by [Claude Code](https://claude.ai/code/session_01Htdeu3ZdfYR4FjWD4XahKB)_