### PR TITLE
Rename the Running Locally sidebar entry to Contributor Setup

### DIFF
--- a/contributing/guide.mdx
+++ b/contributing/guide.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Run Firecrawl locally for development"
-sidebarTitle: "Running Locally"
+sidebarTitle: "Contributor Setup"
 description: "Set up the Firecrawl API development environment, verify a local scrape, and run the source-owned test harness before contributing."
 og:title: "Run Firecrawl locally for development | Firecrawl"
 og:description: "Set up the Firecrawl API development environment, verify a local scrape, and run the source-owned test harness before contributing."

--- a/contributing/guide.mdx
+++ b/contributing/guide.mdx
@@ -1,8 +1,8 @@
 ---
-title: "Run Firecrawl locally for development"
+title: "Contributor setup for Firecrawl"
 sidebarTitle: "Contributor Setup"
 description: "Set up the Firecrawl API development environment, verify a local scrape, and run the source-owned test harness before contributing."
-og:title: "Run Firecrawl locally for development | Firecrawl"
+og:title: "Contributor setup for Firecrawl | Firecrawl"
 og:description: "Set up the Firecrawl API development environment, verify a local scrape, and run the source-owned test harness before contributing."
 ---
 

--- a/contributing/open-source-or-cloud.mdx
+++ b/contributing/open-source-or-cloud.mdx
@@ -10,7 +10,7 @@ Choose open source when you need source or infrastructure control. Choose Firecr
 
 <Note>
   Running Firecrawl for product development and operating a self-hosted
-  deployment are different jobs. Use [Running Locally](/contributing/guide)
+  deployment are different jobs. Use [Contributor Setup](/contributing/guide)
   when you are changing Firecrawl code. Use the [self-hosting
   guide](/contributing/self-host) when you want an API running on infrastructure
   you control.
@@ -49,7 +49,7 @@ Choose open source when you need source or infrastructure control. Choose Firecr
 ## Start with the path you chose
 
 - **Self-host Firecrawl:** follow the [Docker Compose self-hosting guide](/contributing/self-host) from a pinned release to one verified scrape.
-- **Change Firecrawl code:** use [Running Locally](/contributing/guide) for the contributor development environment.
+- **Change Firecrawl code:** use [Contributor Setup](/contributing/guide) for the development environment.
 - **Use Firecrawl Cloud:** [create an account](https://firecrawl.dev) and follow the [quickstart](/quickstart).
 
 Open source keeps the core engine inspectable and adaptable. Firecrawl Cloud funds that work while giving builders a managed path with additional product and infrastructure capabilities.

--- a/contributing/self-host.mdx
+++ b/contributing/self-host.mdx
@@ -197,7 +197,7 @@ These are infrastructure decisions. No single `.env` switch makes the stack prod
 
 - **Still evaluating?** Keep the API on a trusted network and run `docker compose down` when you are finished.
 - **Adding an open-source capability?** Use [Self-hosted feature support](#self-hosted-feature-support) to find the required provider or service, then test that path on its own.
-- **Changing Firecrawl code?** Switch to [Running Locally](/contributing/guide) for the contributor development environment.
+- **Changing Firecrawl code?** Switch to [Contributor Setup](/contributing/guide) for the development environment.
 - **Connecting a client?** Point the [Firecrawl CLI](/sdks/cli#connect-the-cli-to-self-hosted-firecrawl) or [local MCP server](/mcp-server/local#connect-mcp-to-self-hosted-firecrawl) at your verified API URL.
 - **Moving to Kubernetes?** Start with the versioned Kubernetes or Helm references linked from [`SELF_HOST.md`](https://github.com/firecrawl/firecrawl/blob/main/SELF_HOST.md), then make the production decisions above explicit for your platform.
 - **Want managed infrastructure or Cloud-only capabilities?** Compare [Open Source vs Cloud](/contributing/open-source-or-cloud).


### PR DESCRIPTION
## Why

`Running Locally` and `Self-hosting` both describe running Firecrawl locally, so the sidebar gives readers no way to tell them apart. Someone who wants to run Firecrawl on their own box reasonably clicks **Running Locally** and lands in the contributor toolchain (Node 22, pnpm 11.4.0, hand-installed Redis, Go 1.23, Rust) when the Docker Compose path on the self-hosting page was what they wanted.

The real difference between the two pages is the audience, not the mechanism: one is for changing Firecrawl code, the other for running a pinned release. `Contributor Setup` says that in two words, which is about all a sidebar scan affords.

## What changed

- `contributing/guide.mdx`: `sidebarTitle` is now `Contributor Setup`, and `title` / `og:title` follow it as `Contributor setup for Firecrawl` so the page heading and the nav entry agree.
- Three inbound links in `contributing/open-source-or-cloud.mdx` and `contributing/self-host.mdx` updated to match, dropping a now-redundant "contributor" in the surrounding sentence.

`Self-hosting` keeps its title: it matches [`SELF_HOST.md`](https://github.com/firecrawl/firecrawl/blob/main/SELF_HOST.md) and it is the term people search for.

## Scope

`description`, `og:description`, and the URL are unchanged, so there is no link impact; the title change is a rename of the same page rather than a new route. Localized copies under `es/`, `fr/`, `ja/`, `pt-BR/`, and `zh/` are untouched per `CLAUDE.md`; the translation pipeline owns them.