### PR TITLE
docs: overhaul agent endpoint reference, spark-2 default, trace/snapshot endpoints

### DIFF
--- a/advanced-scraping-guide.mdx
+++ b/advanced-scraping-guide.mdx
@@ -467,7 +467,7 @@ Use the `/v2/agent` endpoint for autonomous, multi-page data extraction. The age
 | `schema` | `object` | — | JSON schema to structure the extracted data. |
 | `maxCredits` | `number` | `2500` | Maximum credits the agent can spend. The dashboard supports up to 2,500; for higher limits, set this via the API (values above 2,500 are always billed as paid requests). |
 | `strictConstrainToURLs` | `boolean` | `false` | When `true`, the agent only visits the provided URLs. |
-| `model` | `string` | `"spark-1-pro"` | AI model to use. `"spark-1-pro"` (default, higher accuracy), `"spark-1-mini"` (60% cheaper than Pro) or `"spark-2"` (cheapest and fastest). |
+| `model` | `string` | `"spark-2"` | AI model to use. Spark 1 models are deprecated and currently route to `"spark-2"`. |
 
 <CodeGroup>
 

--- a/api-reference/endpoint/agent-delete.mdx
+++ b/api-reference/endpoint/agent-delete.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Cancel Agent'
 openapi: '/api-reference/v2-openapi.json DELETE /agent/{jobId}'
-hidden: true
 noindex: true
 
 ---

--- a/api-reference/endpoint/agent-get.mdx
+++ b/api-reference/endpoint/agent-get.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Get Agent Status'
 openapi: '/api-reference/v2-openapi.json GET /agent/{jobId}'
-hidden: true
 noindex: true
 
 ---

--- a/api-reference/endpoint/agent-snapshot.mdx
+++ b/api-reference/endpoint/agent-snapshot.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Get Agent Snapshot'
 openapi: '/api-reference/v2-openapi.json GET /agent/{jobId}/snapshots/{snapshotId}'
-hidden: true
 noindex: true
 
 ---

--- a/api-reference/endpoint/agent-snapshot.mdx
+++ b/api-reference/endpoint/agent-snapshot.mdx
@@ -5,4 +5,20 @@ noindex: true
 
 ---
 
+While an agent runs, it version-controls its output artifacts — the structured JSON result as it takes shape, plus any markdown, HTML, text, or screenshot artifacts it produces. Every change emits an `artifact.updated` [trace event](/api-reference/endpoint/agent-trace) referencing the new version by `snapshotId`. This endpoint fetches the full content of one such snapshot.
+
+## What it's for
+
+- **Partial results** — preview the agent's structured output before the run finishes. The JSON result artifact (`artifactId: "result"`) is snapshotted as it grows, so each `snapshotId` is a point-in-time view of the final `data`.
+- **Rendered artifacts** — fetch the content of non-JSON artifacts the agent produced, such as a markdown report or a screenshot of a page it visited.
+- **Run inspection** — pair with the trace to reconstruct exactly how the output evolved over the run.
+
+## How it works
+
+The `artifact.updated` event's `change` field tells you how the snapshot relates to the previous one: `init` (first version), `partial`, `append`, `modify`, or `update`. Each change gets a new `snapshotId` — fetch the latest one for the current state, or walk the history to diff versions.
+
+The `snapshot` field in the response is the artifact content as a string. For `json` artifacts it is JSON-encoded — parse it before use.
+
+<Note>Snapshots are recorded on Spark 2 runs — which is every new run. Jobs started on Spark 1 models before their retirement have no snapshots and return `400`.</Note>
+
 > Are you an AI agent that needs a Firecrawl API key? See [firecrawl.dev/agent-onboarding/SKILL.md](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for automated onboarding instructions.

--- a/api-reference/endpoint/agent-snapshot.mdx
+++ b/api-reference/endpoint/agent-snapshot.mdx
@@ -1,0 +1,9 @@
+---
+title: 'Get Agent Snapshot'
+openapi: '/api-reference/v2-openapi.json GET /agent/{jobId}/snapshots/{snapshotId}'
+hidden: true
+noindex: true
+
+---
+
+> Are you an AI agent that needs a Firecrawl API key? See [firecrawl.dev/agent-onboarding/SKILL.md](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for automated onboarding instructions.

--- a/api-reference/endpoint/agent-trace.mdx
+++ b/api-reference/endpoint/agent-trace.mdx
@@ -16,7 +16,7 @@ Every agent run records a canonical **execution trace**: an ordered stream of ev
 
 ## How it works
 
-Events are emitted by the run's agents — the `orchestrator`, its `subagent`s, and `browser` agents — and each event identifies its emitter in the `agent` field. Order events by `producerSequence` (per emitting agent). The `type` field discriminates the 13 event variants; see the response schema below for the full list and each variant's fields.
+Events are emitted by the run's agents — the `orchestrator` and its `subagent`s — and each event identifies its emitter in the `agent` field. Browser work happens inside an agent's own browser session and is reported through `browser.session.*` events, not by separate browser agents. Order events by `producerSequence` (per emitting agent). The `type` field discriminates the 13 event variants; see the response schema below for the full list and each variant's fields.
 
 `artifact.updated` events don't carry the artifact content itself — they reference it by `snapshotId`, which you fetch with the [snapshot endpoint](/api-reference/endpoint/agent-snapshot).
 

--- a/api-reference/endpoint/agent-trace.mdx
+++ b/api-reference/endpoint/agent-trace.mdx
@@ -5,4 +5,23 @@ noindex: true
 
 ---
 
+Every agent run records a canonical **execution trace**: an ordered stream of events describing everything the run did — which tools it called and what they returned, reasoning summaries, progress updates, browser sessions, and changes to its output artifacts. This is the same event stream that powers the live Activity view in the [Agent playground](https://www.firecrawl.dev/app/agent).
+
+## What it's for
+
+- **Debugging runs** — see the exact searches, scrapes, and extractions the agent performed, each tool's input (`tool_call.started`) and result (`tool_call.finished`), and where a run went wrong (`error.occurred`, and the terminal `run.finished` event's `outcome` and structured `error`).
+- **Live progress UIs** — poll the trace while a job is `processing` to show what the agent is doing in real time. `progress.reported` events carry the run's phase (`planning`, `working`, `finalizing`) with a human-readable message, and `reasoning.summary` events narrate the agent's thinking.
+- **Live browser view** — pass `?liveView=true` while a run is in flight to get `activeBrowserSessions`: the run's active browser sessions, each with a `liveViewUrl` you can embed to watch (or demo) the agent browsing.
+- **Cost tracking** — `creditsUsed` reports credits consumed so far, capped at the run's `maxCredits` if one was set.
+
+## How it works
+
+Events are emitted by the run's agents — the `orchestrator`, its `subagent`s, and `browser` agents — and each event identifies its emitter in the `agent` field. Order events by `producerSequence` (per emitting agent). The `type` field discriminates the 13 event variants; see the response schema below for the full list and each variant's fields.
+
+`artifact.updated` events don't carry the artifact content itself — they reference it by `snapshotId`, which you fetch with the [snapshot endpoint](/api-reference/endpoint/agent-snapshot).
+
+Events can continue to land for a moment after `run.finished` arrives, so if you're polling a live run, keep a short tail window open before rendering the final state.
+
+<Note>Traces are recorded on Spark 2 runs — which is every new run. Jobs started on Spark 1 models before their retirement have no trace and return `400`.</Note>
+
 > Are you an AI agent that needs a Firecrawl API key? See [firecrawl.dev/agent-onboarding/SKILL.md](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for automated onboarding instructions.

--- a/api-reference/endpoint/agent-trace.mdx
+++ b/api-reference/endpoint/agent-trace.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Get Agent Trace'
 openapi: '/api-reference/v2-openapi.json GET /agent/{jobId}/trace'
-hidden: true
 noindex: true
 
 ---

--- a/api-reference/endpoint/agent-trace.mdx
+++ b/api-reference/endpoint/agent-trace.mdx
@@ -1,0 +1,9 @@
+---
+title: 'Get Agent Trace'
+openapi: '/api-reference/v2-openapi.json GET /agent/{jobId}/trace'
+hidden: true
+noindex: true
+
+---
+
+> Are you an AI agent that needs a Firecrawl API key? See [firecrawl.dev/agent-onboarding/SKILL.md](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for automated onboarding instructions.

--- a/api-reference/endpoint/agent.mdx
+++ b/api-reference/endpoint/agent.mdx
@@ -1,7 +1,6 @@
 ---
 title: 'Agent'
 openapi: '/api-reference/v2-openapi.json POST /agent'
-hidden: true
 noindex: true
 
 ---

--- a/api-reference/endpoint/webhook-agent-action.mdx
+++ b/api-reference/endpoint/webhook-agent-action.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Agent Action"
 openapi: "/api-reference/webhooks-openapi.json webhook agentAction"
-hidden: true
 noindex: true
 
 ---

--- a/api-reference/endpoint/webhook-agent-cancelled.mdx
+++ b/api-reference/endpoint/webhook-agent-cancelled.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Agent Cancelled"
 openapi: "/api-reference/webhooks-openapi.json webhook agentCancelled"
-hidden: true
 noindex: true
 
 ---

--- a/api-reference/endpoint/webhook-agent-completed.mdx
+++ b/api-reference/endpoint/webhook-agent-completed.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Agent Completed"
 openapi: "/api-reference/webhooks-openapi.json webhook agentCompleted"
-hidden: true
 noindex: true
 
 ---

--- a/api-reference/endpoint/webhook-agent-failed.mdx
+++ b/api-reference/endpoint/webhook-agent-failed.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Agent Failed"
 openapi: "/api-reference/webhooks-openapi.json webhook agentFailed"
-hidden: true
 noindex: true
 
 ---

--- a/api-reference/endpoint/webhook-agent-started.mdx
+++ b/api-reference/endpoint/webhook-agent-started.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Agent Started"
 openapi: "/api-reference/webhooks-openapi.json webhook agentStarted"
-hidden: true
 noindex: true
 
 ---

--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -6282,7 +6282,6 @@
             "enum": [
               "orchestrator",
               "subagent",
-              "browser",
               "system"
             ]
           },
@@ -6292,7 +6291,7 @@
           "parentId": {
             "type": "string",
             "format": "uuid",
-            "description": "ID of the parent agent (present on subagent and browser agents)."
+            "description": "ID of the parent agent (present on subagents)."
           }
         }
       },
@@ -6609,7 +6608,7 @@
                 "enum": [
                   "agent.started"
                 ],
-                "description": "Emitted when an agent (orchestrator, subagent, or browser) starts."
+                "description": "Emitted when an agent (orchestrator or subagent) starts."
               }
             }
           },

--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -6393,6 +6393,7 @@
         "description": "A canonical execution event from an agent run. Every event carries the envelope fields schemaVersion, eventId, runId, occurredAt, producerSequence and agent; the type field discriminates the variant. usage.recorded events are internal and never exposed, and agent.started events omit the model field.",
         "oneOf": [
           {
+            "title": "run.started",
             "type": "object",
             "required": [
               "schemaVersion",
@@ -6441,6 +6442,7 @@
             }
           },
           {
+            "title": "run.cancel_requested",
             "type": "object",
             "required": [
               "schemaVersion",
@@ -6496,6 +6498,7 @@
             }
           },
           {
+            "title": "run.finished",
             "type": "object",
             "required": [
               "schemaVersion",
@@ -6565,6 +6568,7 @@
             }
           },
           {
+            "title": "agent.started",
             "type": "object",
             "required": [
               "schemaVersion",
@@ -6613,6 +6617,7 @@
             }
           },
           {
+            "title": "agent.finished",
             "type": "object",
             "required": [
               "schemaVersion",
@@ -6685,6 +6690,7 @@
             }
           },
           {
+            "title": "browser.session.started",
             "type": "object",
             "required": [
               "schemaVersion",
@@ -6737,6 +6743,7 @@
             }
           },
           {
+            "title": "browser.session.finished",
             "type": "object",
             "required": [
               "schemaVersion",
@@ -6793,6 +6800,7 @@
             }
           },
           {
+            "title": "progress.reported",
             "type": "object",
             "required": [
               "schemaVersion",
@@ -6854,6 +6862,7 @@
             }
           },
           {
+            "title": "reasoning.summary",
             "type": "object",
             "required": [
               "schemaVersion",
@@ -6906,6 +6915,7 @@
             }
           },
           {
+            "title": "tool_call.started",
             "type": "object",
             "required": [
               "schemaVersion",
@@ -6966,6 +6976,7 @@
             }
           },
           {
+            "title": "tool_call.finished",
             "type": "object",
             "required": [
               "schemaVersion",
@@ -7026,6 +7037,7 @@
             }
           },
           {
+            "title": "artifact.updated",
             "type": "object",
             "required": [
               "schemaVersion",
@@ -7078,6 +7090,7 @@
             }
           },
           {
+            "title": "error.occurred",
             "type": "object",
             "required": [
               "schemaVersion",

--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -2514,8 +2514,66 @@
                       "spark-1-mini",
                       "spark-1-pro"
                     ],
-                    "default": "spark-1-pro",
-                    "description": "The model to use for the agent task. spark-1-pro (default) offers higher accuracy for complex tasks. spark-1-mini is 60% cheaper than spark-1-pro. spark-2 is cheaper and faster than both Spark 1 models at comparable accuracy"
+                    "default": "spark-2",
+                    "description": "The model to use for the agent task. spark-2 is the default and the model every run executes on. The Spark 1 model names remain accepted for backwards compatibility but are deprecated and route to spark-2."
+                  },
+                  "effort": {
+                    "type": "string",
+                    "enum": [
+                      "low",
+                      "medium",
+                      "high"
+                    ],
+                    "description": "Reasoning budget for the agent task. Every run executes on spark-2, so effort can be sent with or without model."
+                  },
+                  "webhook": {
+                    "type": "object",
+                    "description": "A webhook specification object. Subscribes to agent lifecycle events (agent.started, agent.action, agent.completed, agent.failed, agent.cancelled).",
+                    "properties": {
+                      "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "The URL to send webhook events to."
+                      },
+                      "headers": {
+                        "type": "object",
+                        "description": "Headers to send to the webhook URL.",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      },
+                      "metadata": {
+                        "type": "object",
+                        "description": "Custom metadata that will be included in all webhook payloads for this agent job.",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      },
+                      "events": {
+                        "type": "array",
+                        "description": "The events to send to the webhook URL. Defaults to all events.",
+                        "items": {
+                          "type": "string",
+                          "enum": [
+                            "started",
+                            "action",
+                            "completed",
+                            "failed",
+                            "cancelled"
+                          ]
+                        },
+                        "default": [
+                          "started",
+                          "action",
+                          "completed",
+                          "failed",
+                          "cancelled"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "url"
+                    ]
                   },
                   "auditMetadata": {
                     "$ref": "#/components/schemas/AuditMetadata"
@@ -2551,6 +2609,22 @@
               }
             }
           },
+          "400": {
+            "description": "Bad request — the request body failed validation (for example an invalid JSON schema).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid JSON schema: ..."
+                    }
+                  }
+                }
+              }
+            }
+          },
           "402": {
             "description": "Payment required",
             "content": {
@@ -2567,6 +2641,22 @@
               }
             }
           },
+          "403": {
+            "description": "Forbidden — a provided URL is blocked by the team's threat protection policy.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "This URL (https://example.com) is blocked by your organization's threat protection policy (rule: blocklist). If you believe this is a mistake, contact your organization administrator to adjust the policy (e.g. whitelist the domain)."
+                    }
+                  }
+                }
+              }
+            }
+          },
           "429": {
             "description": "Too many requests",
             "content": {
@@ -2577,6 +2667,22 @@
                     "error": {
                       "type": "string",
                       "example": "Rate limit exceeded."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error — the agent service could not be reached.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "Failed to passthrough agent request."
                     }
                   }
                 }
@@ -2640,8 +2746,17 @@
                         "spark-1-pro",
                         "spark-1-mini"
                       ],
-                      "default": "spark-1-pro",
-                      "description": "Model preset used for the agent run"
+                      "default": "spark-2",
+                      "description": "Model preset used for the agent run. Every new run executes on spark-2; Spark 1 names only appear on legacy runs."
+                    },
+                    "effort": {
+                      "type": "string",
+                      "enum": [
+                        "low",
+                        "medium",
+                        "high"
+                      ],
+                      "description": "Reasoning budget used for the agent run (only present for runs that set effort)"
                     },
                     "error": {
                       "type": "string",
@@ -2653,6 +2768,38 @@
                     },
                     "creditsUsed": {
                       "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — the job ID is not a valid UUID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid job ID format. Job ID must be a valid UUID."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Agent job not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "Agent job not found"
                     }
                   }
                 }
@@ -2682,6 +2829,282 @@
                   "properties": {
                     "success": {
                       "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — the job ID is not a valid UUID.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid job ID format. Job ID must be a valid UUID."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Agent job not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "Agent job not found"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict — the agent job has already finished or has already been cancelled.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "Agent already finished"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agent/{jobId}/trace": {
+      "parameters": [
+        {
+          "name": "jobId",
+          "in": "path",
+          "description": "The ID of the agent job",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Get the execution trace of an agent job",
+        "operationId": "getAgentTrace",
+        "tags": [
+          "Agent"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "liveView",
+            "in": "query",
+            "description": "If \"true\", include the currently active browser sessions with live view URLs.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "true",
+                "false"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "id": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "events": {
+                      "type": "array",
+                      "description": "Canonical execution events for the run; order by producerSequence. artifact.updated events carry the snapshotId values used by the snapshots endpoint.",
+                      "items": {
+                        "$ref": "#/components/schemas/AgentTraceEvent"
+                      }
+                    },
+                    "creditsUsed": {
+                      "type": "number",
+                      "description": "Credits consumed so far, capped at maxCredits if one was set."
+                    },
+                    "activeBrowserSessions": {
+                      "type": "array",
+                      "description": "Currently active browser sessions (only present when liveView=true).",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "liveViewUrl": {
+                            "type": "string"
+                          },
+                          "viewport": {
+                            "type": "object",
+                            "properties": {
+                              "width": {
+                                "type": "number"
+                              },
+                              "height": {
+                                "type": "number"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — the job ID is not a valid UUID, or the job did not run on spark-2 (traces are only available for spark-2 agent jobs).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "Trace is only available for Spark 2 extracts"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Agent job not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "Agent job not found"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agent/{jobId}/snapshots/{snapshotId}": {
+      "parameters": [
+        {
+          "name": "jobId",
+          "in": "path",
+          "description": "The ID of the agent job",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        {
+          "name": "snapshotId",
+          "in": "path",
+          "description": "The ID of the snapshot, from an artifact.updated trace event",
+          "required": true,
+          "schema": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      ],
+      "get": {
+        "summary": "Get an output snapshot of an agent job",
+        "operationId": "getAgentSnapshot",
+        "tags": [
+          "Agent"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "id": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "snapshotId": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "snapshot": {
+                      "type": "string",
+                      "description": "The snapshot content as a JSON-encoded string — the agent's working output artifact at that point in the run."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — the job ID or snapshot ID is not a valid UUID, or the job did not run on spark-2 (snapshots are only available for spark-2 agent jobs).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "Snapshots are only available for Spark 2 extracts"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Agent job not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "Agent job not found"
                     }
                   }
                 }
@@ -5839,6 +6262,877 @@
             "maxLength": 1024,
             "description": "The username associated with the request."
           }
+        }
+      },
+      "AgentTraceAgent": {
+        "type": "object",
+        "description": "Identity of the agent that emitted the event.",
+        "required": [
+          "id",
+          "role",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "orchestrator",
+              "subagent",
+              "browser",
+              "system"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "parentId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID of the parent agent (present on subagent and browser agents)."
+          }
+        }
+      },
+      "AgentTraceError": {
+        "type": "object",
+        "description": "Structured error attached to terminal and error events.",
+        "required": [
+          "code",
+          "source",
+          "retryable",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "string",
+            "enum": [
+              "cancelled",
+              "credit_limit_reached",
+              "parent_finished",
+              "refused",
+              "internal"
+            ]
+          },
+          "source": {
+            "type": "string",
+            "enum": [
+              "agent",
+              "tool",
+              "billing",
+              "system"
+            ]
+          },
+          "retryable": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "AgentTraceArtifact": {
+        "type": "object",
+        "description": "Descriptor for a change to an output artifact.",
+        "required": [
+          "kind",
+          "artifactId",
+          "snapshotId",
+          "change"
+        ],
+        "properties": {
+          "kind": {
+            "type": "string",
+            "enum": [
+              "json",
+              "markdown",
+              "html",
+              "screenshot",
+              "text"
+            ]
+          },
+          "artifactId": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string",
+            "description": "Workspace path of the artifact, e.g. /workspace/data.json."
+          },
+          "snapshotId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Pass to GET /agent/{jobId}/snapshots/{snapshotId} to fetch this snapshot's content."
+          },
+          "change": {
+            "type": "string",
+            "enum": [
+              "init",
+              "partial",
+              "append",
+              "modify",
+              "update"
+            ]
+          },
+          "changedFields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "itemCount": {
+            "type": "integer"
+          },
+          "sourceToolCallId": {
+            "type": "string",
+            "description": "The tool call that produced this change, when applicable."
+          }
+        }
+      },
+      "AgentTraceEvent": {
+        "description": "A canonical execution event from an agent run. Every event carries the envelope fields schemaVersion, eventId, runId, occurredAt, producerSequence and agent; the type field discriminates the variant. usage.recorded events are internal and never exposed, and agent.started events omit the model field.",
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "schemaVersion",
+              "eventId",
+              "runId",
+              "occurredAt",
+              "producerSequence",
+              "agent",
+              "type"
+            ],
+            "properties": {
+              "schemaVersion": {
+                "type": "integer",
+                "enum": [
+                  1
+                ]
+              },
+              "eventId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Unique ID of this event."
+              },
+              "runId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "The agent job ID this event belongs to."
+              },
+              "occurredAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "producerSequence": {
+                "type": "integer",
+                "description": "Monotonic sequence number from the emitting agent; order events by it."
+              },
+              "agent": {
+                "$ref": "#/components/schemas/AgentTraceAgent"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "run.started"
+                ],
+                "description": "Emitted when the run starts."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "schemaVersion",
+              "eventId",
+              "runId",
+              "occurredAt",
+              "producerSequence",
+              "agent",
+              "type",
+              "reason"
+            ],
+            "properties": {
+              "schemaVersion": {
+                "type": "integer",
+                "enum": [
+                  1
+                ]
+              },
+              "eventId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Unique ID of this event."
+              },
+              "runId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "The agent job ID this event belongs to."
+              },
+              "occurredAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "producerSequence": {
+                "type": "integer",
+                "description": "Monotonic sequence number from the emitting agent; order events by it."
+              },
+              "agent": {
+                "$ref": "#/components/schemas/AgentTraceAgent"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "run.cancel_requested"
+                ],
+                "description": "Emitted when cancellation is requested (via DELETE /agent/{jobId})."
+              },
+              "reason": {
+                "type": "string",
+                "enum": [
+                  "user"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "schemaVersion",
+              "eventId",
+              "runId",
+              "occurredAt",
+              "producerSequence",
+              "agent",
+              "type",
+              "outcome",
+              "error"
+            ],
+            "properties": {
+              "schemaVersion": {
+                "type": "integer",
+                "enum": [
+                  1
+                ]
+              },
+              "eventId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Unique ID of this event."
+              },
+              "runId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "The agent job ID this event belongs to."
+              },
+              "occurredAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "producerSequence": {
+                "type": "integer",
+                "description": "Monotonic sequence number from the emitting agent; order events by it."
+              },
+              "agent": {
+                "$ref": "#/components/schemas/AgentTraceAgent"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "run.finished"
+                ],
+                "description": "Terminal event for the run."
+              },
+              "outcome": {
+                "type": "string",
+                "enum": [
+                  "succeeded",
+                  "failed",
+                  "cancelled",
+                  "refused",
+                  "credit_limit_reached"
+                ]
+              },
+              "error": {
+                "nullable": true,
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/AgentTraceError"
+                  }
+                ],
+                "description": "Null when outcome is succeeded; otherwise the structured error."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "schemaVersion",
+              "eventId",
+              "runId",
+              "occurredAt",
+              "producerSequence",
+              "agent",
+              "type"
+            ],
+            "properties": {
+              "schemaVersion": {
+                "type": "integer",
+                "enum": [
+                  1
+                ]
+              },
+              "eventId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Unique ID of this event."
+              },
+              "runId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "The agent job ID this event belongs to."
+              },
+              "occurredAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "producerSequence": {
+                "type": "integer",
+                "description": "Monotonic sequence number from the emitting agent; order events by it."
+              },
+              "agent": {
+                "$ref": "#/components/schemas/AgentTraceAgent"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "agent.started"
+                ],
+                "description": "Emitted when an agent (orchestrator, subagent, or browser) starts."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "schemaVersion",
+              "eventId",
+              "runId",
+              "occurredAt",
+              "producerSequence",
+              "agent",
+              "type",
+              "outcome",
+              "durationMs",
+              "error"
+            ],
+            "properties": {
+              "schemaVersion": {
+                "type": "integer",
+                "enum": [
+                  1
+                ]
+              },
+              "eventId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Unique ID of this event."
+              },
+              "runId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "The agent job ID this event belongs to."
+              },
+              "occurredAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "producerSequence": {
+                "type": "integer",
+                "description": "Monotonic sequence number from the emitting agent; order events by it."
+              },
+              "agent": {
+                "$ref": "#/components/schemas/AgentTraceAgent"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "agent.finished"
+                ],
+                "description": "Emitted when an agent finishes."
+              },
+              "outcome": {
+                "type": "string",
+                "enum": [
+                  "succeeded",
+                  "failed",
+                  "cancelled",
+                  "refused"
+                ]
+              },
+              "durationMs": {
+                "type": "integer"
+              },
+              "error": {
+                "nullable": true,
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/AgentTraceError"
+                  }
+                ],
+                "description": "Null when outcome is succeeded; otherwise the structured error."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "schemaVersion",
+              "eventId",
+              "runId",
+              "occurredAt",
+              "producerSequence",
+              "agent",
+              "type",
+              "sessionId"
+            ],
+            "properties": {
+              "schemaVersion": {
+                "type": "integer",
+                "enum": [
+                  1
+                ]
+              },
+              "eventId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Unique ID of this event."
+              },
+              "runId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "The agent job ID this event belongs to."
+              },
+              "occurredAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "producerSequence": {
+                "type": "integer",
+                "description": "Monotonic sequence number from the emitting agent; order events by it."
+              },
+              "agent": {
+                "$ref": "#/components/schemas/AgentTraceAgent"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "browser.session.started"
+                ],
+                "description": "Emitted when a browser session starts."
+              },
+              "sessionId": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "schemaVersion",
+              "eventId",
+              "runId",
+              "occurredAt",
+              "producerSequence",
+              "agent",
+              "type",
+              "sessionId",
+              "durationMs"
+            ],
+            "properties": {
+              "schemaVersion": {
+                "type": "integer",
+                "enum": [
+                  1
+                ]
+              },
+              "eventId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Unique ID of this event."
+              },
+              "runId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "The agent job ID this event belongs to."
+              },
+              "occurredAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "producerSequence": {
+                "type": "integer",
+                "description": "Monotonic sequence number from the emitting agent; order events by it."
+              },
+              "agent": {
+                "$ref": "#/components/schemas/AgentTraceAgent"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "browser.session.finished"
+                ],
+                "description": "Emitted when a browser session finishes."
+              },
+              "sessionId": {
+                "type": "string"
+              },
+              "durationMs": {
+                "type": "integer"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "schemaVersion",
+              "eventId",
+              "runId",
+              "occurredAt",
+              "producerSequence",
+              "agent",
+              "type",
+              "phase",
+              "message"
+            ],
+            "properties": {
+              "schemaVersion": {
+                "type": "integer",
+                "enum": [
+                  1
+                ]
+              },
+              "eventId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Unique ID of this event."
+              },
+              "runId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "The agent job ID this event belongs to."
+              },
+              "occurredAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "producerSequence": {
+                "type": "integer",
+                "description": "Monotonic sequence number from the emitting agent; order events by it."
+              },
+              "agent": {
+                "$ref": "#/components/schemas/AgentTraceAgent"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "progress.reported"
+                ],
+                "description": "Emitted when the orchestrator reports progress."
+              },
+              "phase": {
+                "type": "string",
+                "enum": [
+                  "planning",
+                  "working",
+                  "finalizing"
+                ]
+              },
+              "message": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "schemaVersion",
+              "eventId",
+              "runId",
+              "occurredAt",
+              "producerSequence",
+              "agent",
+              "type",
+              "text"
+            ],
+            "properties": {
+              "schemaVersion": {
+                "type": "integer",
+                "enum": [
+                  1
+                ]
+              },
+              "eventId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Unique ID of this event."
+              },
+              "runId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "The agent job ID this event belongs to."
+              },
+              "occurredAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "producerSequence": {
+                "type": "integer",
+                "description": "Monotonic sequence number from the emitting agent; order events by it."
+              },
+              "agent": {
+                "$ref": "#/components/schemas/AgentTraceAgent"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "reasoning.summary"
+                ],
+                "description": "A summary of the agent's reasoning."
+              },
+              "text": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "schemaVersion",
+              "eventId",
+              "runId",
+              "occurredAt",
+              "producerSequence",
+              "agent",
+              "type",
+              "toolCallId",
+              "toolName",
+              "parameters"
+            ],
+            "properties": {
+              "schemaVersion": {
+                "type": "integer",
+                "enum": [
+                  1
+                ]
+              },
+              "eventId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Unique ID of this event."
+              },
+              "runId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "The agent job ID this event belongs to."
+              },
+              "occurredAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "producerSequence": {
+                "type": "integer",
+                "description": "Monotonic sequence number from the emitting agent; order events by it."
+              },
+              "agent": {
+                "$ref": "#/components/schemas/AgentTraceAgent"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "tool_call.started"
+                ],
+                "description": "Emitted when a tool call starts."
+              },
+              "toolCallId": {
+                "type": "string"
+              },
+              "toolName": {
+                "type": "string"
+              },
+              "parameters": {
+                "description": "The input passed to the tool (arbitrary JSON)."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "schemaVersion",
+              "eventId",
+              "runId",
+              "occurredAt",
+              "producerSequence",
+              "agent",
+              "type",
+              "toolCallId",
+              "toolName",
+              "result"
+            ],
+            "properties": {
+              "schemaVersion": {
+                "type": "integer",
+                "enum": [
+                  1
+                ]
+              },
+              "eventId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Unique ID of this event."
+              },
+              "runId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "The agent job ID this event belongs to."
+              },
+              "occurredAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "producerSequence": {
+                "type": "integer",
+                "description": "Monotonic sequence number from the emitting agent; order events by it."
+              },
+              "agent": {
+                "$ref": "#/components/schemas/AgentTraceAgent"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "tool_call.finished"
+                ],
+                "description": "Emitted when a tool call finishes."
+              },
+              "toolCallId": {
+                "type": "string"
+              },
+              "toolName": {
+                "type": "string"
+              },
+              "result": {
+                "description": "The result returned by the tool (arbitrary JSON)."
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "schemaVersion",
+              "eventId",
+              "runId",
+              "occurredAt",
+              "producerSequence",
+              "agent",
+              "type",
+              "artifact"
+            ],
+            "properties": {
+              "schemaVersion": {
+                "type": "integer",
+                "enum": [
+                  1
+                ]
+              },
+              "eventId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Unique ID of this event."
+              },
+              "runId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "The agent job ID this event belongs to."
+              },
+              "occurredAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "producerSequence": {
+                "type": "integer",
+                "description": "Monotonic sequence number from the emitting agent; order events by it."
+              },
+              "agent": {
+                "$ref": "#/components/schemas/AgentTraceAgent"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "artifact.updated"
+                ],
+                "description": "Emitted when an output artifact changes."
+              },
+              "artifact": {
+                "$ref": "#/components/schemas/AgentTraceArtifact"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "schemaVersion",
+              "eventId",
+              "runId",
+              "occurredAt",
+              "producerSequence",
+              "agent",
+              "type",
+              "error"
+            ],
+            "properties": {
+              "schemaVersion": {
+                "type": "integer",
+                "enum": [
+                  1
+                ]
+              },
+              "eventId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "Unique ID of this event."
+              },
+              "runId": {
+                "type": "string",
+                "format": "uuid",
+                "description": "The agent job ID this event belongs to."
+              },
+              "occurredAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "producerSequence": {
+                "type": "integer",
+                "description": "Monotonic sequence number from the emitting agent; order events by it."
+              },
+              "agent": {
+                "$ref": "#/components/schemas/AgentTraceAgent"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "error.occurred"
+                ],
+                "description": "Emitted when a non-fatal error occurs during the run."
+              },
+              "error": {
+                "$ref": "#/components/schemas/AgentTraceError"
+              }
+            }
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type"
         }
       },
       "SuccessResponse": {

--- a/api-reference/webhooks-openapi.json
+++ b/api-reference/webhooks-openapi.json
@@ -857,8 +857,8 @@
                 "properties": {
                   "success": {
                     "type": "boolean",
-                    "description": "Always `false` for this event.",
-                    "const": false
+                    "description": "Always `true` for this event.",
+                    "const": true
                   },
                   "type": {
                     "type": "string",
@@ -892,7 +892,7 @@
                 }
               },
               "example": {
-                "success": false,
+                "success": true,
                 "type": "agent.cancelled",
                 "id": "550e8400-e29b-41d4-a716-446655440000",
                 "webhookId": "d4e5f6a7-0005-0000-0000-000000000000",

--- a/developer-guides/usage-guides/choosing-the-data-extractor.mdx
+++ b/developer-guides/usage-guides/choosing-the-data-extractor.mdx
@@ -41,7 +41,7 @@ The `/agent` endpoint is Firecrawl's most advanced offering—the successor to `
 - **Autonomous Navigation**: The agent searches and navigates deep into sites to find your data
 - **Deep Web Search**: Autonomously discovers information across multiple domains and pages
 - **Parallel Processing**: Processes multiple sources simultaneously for faster results
-- **Models Available**: `spark-1-pro` (default, higher accuracy), `spark-1-mini` (60% cheaper than Pro) and `spark-2` (cheapest and fastest)
+- **Model**: Every run executes on `spark-2` (the default). Spark 1 models are deprecated and route to `spark-2`
 
 ### Example
 
@@ -204,7 +204,7 @@ result = app.agent(
     urls=["https://example.com"],  # Optional - can omit entirely
     prompt="Extract product information from example.com",
     schema=schema,
-    model="spark-2"  # "spark-1-pro" is the default; "spark-1-mini" is also available
+    model="spark-2"  # the default; Spark 1 models are deprecated and route to "spark-2"
 )
 ```
 

--- a/docs.json
+++ b/docs.json
@@ -516,6 +516,8 @@
                     "pages": [
                       "api-reference/endpoint/agent",
                       "api-reference/endpoint/agent-get",
+                      "api-reference/endpoint/agent-trace",
+                      "api-reference/endpoint/agent-snapshot",
                       "api-reference/endpoint/agent-delete"
                     ]
                   },

--- a/features/agent.mdx
+++ b/features/agent.mdx
@@ -28,6 +28,12 @@ import AgentStatusCompleted from "/snippets/v2/agent/status/completed.mdx";
 import AgentWithModelPython from "/snippets/v2/agent/with-model/python.mdx";
 import AgentWithModelJS from "/snippets/v2/agent/with-model/js.mdx";
 import AgentWithModelCURL from "/snippets/v2/agent/with-model/curl.mdx";
+import AgentTracePython from "/snippets/v2/agent/trace/python.mdx";
+import AgentTraceJS from "/snippets/v2/agent/trace/js.mdx";
+import AgentTraceCURL from "/snippets/v2/agent/trace/curl.mdx";
+import AgentSnapshotPython from "/snippets/v2/agent/snapshot/python.mdx";
+import AgentSnapshotJS from "/snippets/v2/agent/snapshot/js.mdx";
+import AgentSnapshotCURL from "/snippets/v2/agent/snapshot/curl.mdx";
 import PlaygroundCTA from "/snippets/shared/playground-cta-agent.mdx";
 import ChooseDataExtractor from "/snippets/shared/choose-data-extractor/from-agent.mdx";
 import AgentFeedbackCTA from "/snippets/agent-feedback-cta.mdx";
@@ -110,11 +116,10 @@ Agent jobs run asynchronously. When you submit a job, you'll receive a Job ID th
 |--------|-------------|
 | `processing` | The agent is still working on your request |
 | `completed` | Extraction finished successfully |
-| `failed` | An error occurred during extraction |
-| `cancelled` | The job was cancelled by the user |
+| `failed` | An error occurred during extraction, or the job was cancelled (cancelled jobs report `failed` with a cancellation error message) |
 
 <Note>
-**Cancellation is cooperative.** When you call the cancel endpoint, the request is registered immediately, but any step already in flight (an LLM reasoning step, a tool call, or a browser action) runs to a clean stopping point before the job transitions to `cancelled`. Credits can continue to accrue during that short window, so the final `creditsUsed` may be higher than the value reported at the moment you clicked cancel.
+**Cancellation is cooperative.** When you call the cancel endpoint, the request is registered immediately, but any step already in flight (an LLM reasoning step, a tool call, or a browser action) runs to a clean stopping point before the job stops. Credits can continue to accrue during that short window, so the final `creditsUsed` may be higher than the value reported at the moment you clicked cancel. A cancelled job reports status `failed` when polled and emits an `agent.cancelled` webhook event.
 </Note>
 
 #### Pending Example
@@ -125,56 +130,55 @@ Agent jobs run asynchronously. When you submit a job, you'll receive a Job ID th
 
 <AgentStatusCompleted />
 
+## Execution Traces and Snapshots
+
+Every run records a canonical execution trace — ordered events covering tool calls, reasoning summaries, progress updates, browser sessions, and output artifact changes. Fetch it to debug a run or power a live progress UI:
+
+<CodeGroup>
+
+<AgentTracePython />
+<AgentTraceJS />
+<AgentTraceCURL />
+
+</CodeGroup>
+
+`artifact.updated` trace events reference the agent's working output by `snapshotId`. Fetch the full content of a snapshot with the snapshots endpoint:
+
+<CodeGroup>
+
+<AgentSnapshotPython />
+<AgentSnapshotJS />
+<AgentSnapshotCURL />
+
+</CodeGroup>
+
+<Note>Traces and snapshots are recorded on Spark 2 runs, which is every new run — jobs started on Spark 1 models before their retirement do not have them. See the [trace](/api-reference/endpoint/agent-trace) and [snapshot](/api-reference/endpoint/agent-snapshot) API references for the full event schema.</Note>
+
 ## Share agent runs
 
 You can share agent runs directly from the Agent playground. Shared links are public — anyone with the link can view the run output and activity — and you can revoke access at any time to disable the link. Shared pages are not indexed by search engines.
 
 ## Model Selection
 
-Firecrawl Agent offers three models. **Spark 1 Pro** is the default. **Spark 2** is cheaper and faster than either Spark 1 model, at comparable accuracy — set `model` to `spark-2` to use it.
+Firecrawl Agent runs on **Spark 2** — cheaper and faster than the earlier Spark 1 models, at comparable accuracy. It is the default: every run executes on `spark-2`, whether or not you set the `model` parameter.
 
-| Model | Cost | Accuracy | Best For |
-|-------|------|----------|----------|
-| `spark-2` | Lowest | Comparable to Pro | Low cost and short run time |
-| `spark-1-mini` | **60% cheaper** than Pro | Standard | Cost-sensitive Spark 1 workloads |
-| `spark-1-pro` | Standard | Higher | Complex research, critical extraction (default) |
-
-<Tip>
-**Spark 1 Pro is the default**, so a request without the `model` parameter uses `spark-1-pro`. Set `model` to `spark-2` to get a lower cost and a shorter run time at comparable accuracy. Set `model` to `spark-1-mini` for a 60% lower cost on simple Spark 1 tasks.
-</Tip>
+<Note>
+**Spark 1 models are deprecated.** The Spark 1 model names remain accepted for backwards compatibility, but requests that use them route to `spark-2`.
+</Note>
 
 ### Spark 2
 
-`spark-2` is our newest agent model. It handles the full range of tasks that previously called for a Mini-versus-Pro decision, so there is no accuracy-versus-cost trade-off to make. Set `model` to `spark-2` to use it.
+`spark-2` handles the full range of tasks that previously called for a Mini-versus-Pro decision, so there is no accuracy-versus-cost trade-off to make.
 
-**Use Spark 2 when:**
-- You want the lowest cost per run
-- Run time matters
-- You would otherwise reach for Spark 1 Pro's accuracy
-
-### Spark 1 Mini
-
-`spark-1-mini` is our efficient model, ideal for straightforward data extraction tasks.
-
-**Use Mini when:**
-- Extracting simple data points (contact info, pricing, etc.)
-- Working with well-structured websites
-- Cost efficiency is a priority
-- Running high-volume extraction jobs
-
-### Spark 1 Pro (Default)
-
-`spark-1-pro` is our flagship model, designed for maximum accuracy on complex extraction tasks. It is the default: a request that does not set `model` uses `spark-1-pro`.
-
-**Use Pro when:**
-- Performing complex competitive analysis
-- Extracting data that requires deep reasoning
-- Accuracy is critical for your use case
-- Dealing with ambiguous or hard-to-find data
+**Highlights:**
+- Lowest cost per run
+- Fastest run time
+- Accuracy comparable to the former Spark 1 flagship
+- The only model with a reasoning budget: pass `effort` (`low`, `medium`, or `high`) to control how hard it thinks
 
 ### Specifying a Model
 
-`spark-1-pro` is the default, so the `model` parameter is optional. Pass it to select a different model:
+The `model` parameter is optional — every request runs `spark-2`:
 
 <CodeGroup>
 
@@ -189,9 +193,12 @@ Firecrawl Agent offers three models. **Spark 1 Pro** is the default. **Spark 2**
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `prompt` | string | **Yes** | Natural language description of the data you want to extract (max 10,000 characters) |
-| `model` | string | No | Model to use: `spark-1-pro` (default), `spark-1-mini`, or `spark-2` |
+| `model` | string | No | Defaults to `spark-2`, the model every run executes on. Spark 1 models are deprecated and route to `spark-2` |
+| `effort` | string | No | Reasoning budget: `low`, `medium`, or `high`. Every run executes on `spark-2`, so `effort` can be sent with or without `model` |
 | `urls` | array | No | Optional list of URLs to focus the extraction |
 | `schema` | object | No | Optional JSON schema for structured output |
+| `strictConstrainToURLs` | boolean | No | If `true`, the agent only visits the URLs provided in the `urls` array |
+| `webhook` | object | No | Webhook to receive agent lifecycle events (`agent.started`, `agent.action`, `agent.completed`, `agent.failed`, `agent.cancelled`). See the [webhook payloads](/api-reference/endpoint/webhook-agent-started) |
 | `maxCredits` | number | No | Maximum number of credits to spend on this agent task. Defaults to **2,500** if not set. The dashboard supports values up to **2,500**; for higher limits, set `maxCredits` via the API (values above 2,500 are always treated as paid requests). If the limit is reached, the job fails and **no data is returned**. Failed runs are not billed: credits used for AI reasoning are never charged on failure, any credits used for tool calls during the run (scraping, search, mapping, etc.) are refunded, and the response reports `creditsUsed: 0`. |
 
 ## Agent vs Extract: What's Improved

--- a/features/models.mdx
+++ b/features/models.mdx
@@ -2,7 +2,7 @@
 title: "Models"
 description: "Choose the right model for your agent extraction tasks."
 og:title: "Agent Models | Firecrawl"
-og:description: "Choose between Spark 2, Spark 1 Mini, and Spark 1 Pro for your agent extraction tasks."
+og:description: "Use Spark 2 for your agent extraction tasks."
 sidebarTitle: "Models"
 hidden: true
 noindex: true
@@ -13,69 +13,37 @@ import AgentWithModelPython from "/snippets/v2/agent/with-model/python.mdx";
 import AgentWithModelJS from "/snippets/v2/agent/with-model/js.mdx";
 import AgentWithModelCURL from "/snippets/v2/agent/with-model/curl.mdx";
 
-Firecrawl Agent offers three models optimized for different use cases. Choose the right model based on your extraction complexity and cost requirements.
+Firecrawl Agent runs on **Spark 2**, the default model for every run. It removes the accuracy-versus-cost decision the Spark 1 models called for: it is cheaper and faster than both of them while matching Spark 1 Pro's accuracy, and it completes a higher share of runs.
 
 ## Available Models
 
-| Model | Cost | Accuracy | Best For |
-|-------|------|----------|----------|
-| `spark-2` | Lowest | Comparable to Pro | Low cost and short run time |
-| `spark-1-mini` | **60% cheaper** than Pro | Standard | Cost-sensitive Spark 1 workloads |
-| `spark-1-pro` | Standard | Higher | Complex research, critical extraction (default) |
+| Model | Status | Notes |
+|-------|--------|-------|
+| `spark-2` | **Default** | Lowest cost, fastest run time, accuracy comparable to Spark 1 Pro |
+| `spark-1-pro` | Deprecated | Former default for complex tasks; routes to `spark-2` |
+| `spark-1-mini` | Deprecated | Former low-cost Spark 1 option; routes to `spark-2` |
 
-<Tip>
-**Spark 1 Pro is the default**, so a request without the `model` parameter uses `spark-1-pro`. Set `model` to `spark-2` to get a lower cost and a shorter run time at comparable accuracy. Set `model` to `spark-1-mini` for a 60% lower cost on simple Spark 1 tasks.
-</Tip>
+<Note>
+**Spark 1 models are deprecated.** The `spark-1-pro` and `spark-1-mini` names remain accepted for backwards compatibility, but every request — with or without the `model` parameter — executes on `spark-2`.
+</Note>
 
 ## Spark 2
 
-`spark-2` is our newest agent model. It removes the accuracy-versus-cost decision: it is cheaper and faster than both Spark 1 models while matching Spark 1 Pro's accuracy, and it completes a higher share of runs. Set `model` to `spark-2` to use it.
+`spark-2` is our newest agent model and powers every agent run.
 
-**Use Spark 2 when:**
-- You want the lowest cost per run
-- Run time matters
-- You would otherwise reach for Spark 1 Pro's accuracy
+**Highlights:**
+- Lowest cost per run and fastest run time
+- Accuracy comparable to the former Spark 1 flagship
+- Handles everything from simple lookups to multi-domain research
+- The only model with a reasoning budget: pass `effort` (`low`, `medium`, or `high`) to control how hard it thinks
 
-**Example use cases:**
-- Anything you run on Spark 1 Mini or Spark 1 Pro today
-- High-volume extraction where cost per run drives the budget
-- Multi-domain research that needs to come back quickly
+## Spark 1 models (deprecated)
 
-## Spark 1 Mini
-
-`spark-1-mini` is our efficient model, ideal for straightforward data extraction tasks.
-
-**Use Mini when:**
-- Extracting simple data points (contact info, pricing, etc.)
-- Working with well-structured websites
-- Cost efficiency is a priority
-- Running high-volume extraction jobs
-
-**Example use cases:**
-- Extracting product prices from e-commerce sites
-- Gathering contact information from company pages
-- Pulling basic metadata from articles
-- Simple data point lookups
-
-## Spark 1 Pro (Default)
-
-`spark-1-pro` is our flagship model, designed for maximum accuracy on complex extraction tasks. It is the default: a request that does not set `model` uses `spark-1-pro`.
-
-**Use Pro when:**
-- Performing complex competitive analysis
-- Extracting data that requires deep reasoning
-- Accuracy is critical for your use case
-- Dealing with ambiguous or hard-to-find data
-
-**Example use cases:**
-- Multi-domain competitive analysis
-- Complex research tasks requiring reasoning
-- Extracting nuanced information from multiple sources
-- Critical business intelligence gathering
+`spark-1-pro` and `spark-1-mini` are deprecated. Their names remain accepted for backwards compatibility, but requests that use them route to `spark-2` — legacy code keeps working, it just runs Spark 2. There is nothing to migrate.
 
 ## Specifying a Model
 
-`spark-1-pro` is the default, so the `model` parameter is optional. Pass it to select a different model:
+The `model` parameter is optional — every request runs `spark-2`:
 
 <CodeGroup>
 
@@ -85,51 +53,16 @@ Firecrawl Agent offers three models optimized for different use cases. Choose th
 
 </CodeGroup>
 
-## Model Comparison
-
-| Feature | Spark 2 | Spark 1 Mini | Spark 1 Pro |
-|---------|---------|--------------|-------------|
-| **Cost** | Lowest | 60% cheaper than Pro | Standard |
-| **Accuracy** | Comparable to Pro | Standard | Higher |
-| **Speed** | Fastest | Fast | Fast |
-| **Best for** | All tasks | Most tasks | Complex tasks |
-| **Reasoning** | Advanced | Standard | Advanced |
-| **Multi-domain** | Excellent | Good | Excellent |
-
 ## Pricing by Model
 
 All models use dynamic, credit-based pricing that scales with task complexity:
 
 - **Spark 2**: Uses substantially fewer credits than either Spark 1 model for equivalent tasks
-- **Spark 1 Mini**: Uses approximately 60% fewer credits than Pro for equivalent tasks
-- **Spark 1 Pro**: Standard credit consumption for maximum accuracy
+- **Spark 1 models (deprecated)**: Requests route to Spark 2 and are billed accordingly
 
 <Info>
 Credit usage varies based on prompt complexity, data processed, and output structure — regardless of model selected.
 </Info>
-
-## Choosing the Right Model
-
-Spark 2 covers both branches below. The tree applies when you are choosing between the two Spark 1 models:
-
-```
-                    ┌─────────────────────────────────┐
-                    │   What type of task?            │
-                    └─────────────────────────────────┘
-                                   │
-                    ┌──────────────┴──────────────┐
-                    ▼                             ▼
-          ┌─────────────────┐           ┌─────────────────┐
-          │  Simple/Direct  │           │ Complex/Research│
-          │  extraction     │           │ multi-domain    │
-          └─────────────────┘           └─────────────────┘
-                    │                             │
-                    ▼                             ▼
-          ┌─────────────────┐           ┌─────────────────┐
-          │  spark-1-mini   │           │  spark-1-pro    │
-          │  (60% cheaper)  │           │  (higher acc.)  │
-          └─────────────────┘           └─────────────────┘
-```
 
 ## API Reference
 

--- a/sdks/cli.mdx
+++ b/sdks/cli.mdx
@@ -356,7 +356,7 @@ Search and gather data from the web using natural language prompts.
 | Option                      | Description                                                                            |
 | --------------------------- | -------------------------------------------------------------------------------------- |
 | `--urls <urls>`             | Optional list of URLs to focus the agent on (comma-separated)                          |
-| `--model <model>`           | Model to use: `spark-1-pro` (default, higher accuracy), `spark-1-mini` (60% cheaper than Pro) or `spark-2` (cheapest and fastest) |
+| `--model <model>`           | Model to use. Defaults to `spark-2`, the model every run executes on. Spark 1 models are deprecated and route to `spark-2` |
 | `--schema <json>`           | JSON schema for structured output (inline JSON string)                                 |
 | `--schema-file <path>`      | Path to JSON schema file for structured output                                         |
 | `--max-credits <number>`    | Maximum credits to spend (job fails if limit reached)                                  |

--- a/snippets/v2/agent/snapshot/curl.mdx
+++ b/snippets/v2/agent/snapshot/curl.mdx
@@ -1,0 +1,4 @@
+```bash cURL
+curl "https://api.firecrawl.dev/v2/agent/JOB_ID/snapshots/SNAPSHOT_ID" \
+  -H "Authorization: Bearer $FIRECRAWL_API_KEY"
+```

--- a/snippets/v2/agent/snapshot/js.mdx
+++ b/snippets/v2/agent/snapshot/js.mdx
@@ -1,0 +1,10 @@
+```js Node
+import { Firecrawl } from 'firecrawl';
+
+const firecrawl = new Firecrawl({ apiKey: "fc-YOUR_API_KEY" });
+
+// artifact.updated trace events reference snapshot content by snapshotId
+const snapshot = await firecrawl.getAgentSnapshot("JOB_ID", "SNAPSHOT_ID");
+
+console.log(snapshot.snapshot);
+```

--- a/snippets/v2/agent/snapshot/python.mdx
+++ b/snippets/v2/agent/snapshot/python.mdx
@@ -1,0 +1,10 @@
+```python Python
+from firecrawl import Firecrawl
+
+app = Firecrawl(api_key="fc-YOUR_API_KEY")
+
+# artifact.updated trace events reference snapshot content by snapshotId
+snapshot = app.get_agent_snapshot("JOB_ID", "SNAPSHOT_ID")
+
+print(snapshot.snapshot)
+```

--- a/snippets/v2/agent/trace/curl.mdx
+++ b/snippets/v2/agent/trace/curl.mdx
@@ -1,0 +1,8 @@
+```bash cURL
+curl "https://api.firecrawl.dev/v2/agent/JOB_ID/trace" \
+  -H "Authorization: Bearer $FIRECRAWL_API_KEY"
+
+# Include currently active browser sessions while the run is in flight
+curl "https://api.firecrawl.dev/v2/agent/JOB_ID/trace?liveView=true" \
+  -H "Authorization: Bearer $FIRECRAWL_API_KEY"
+```

--- a/snippets/v2/agent/trace/js.mdx
+++ b/snippets/v2/agent/trace/js.mdx
@@ -1,0 +1,16 @@
+```js Node
+import { Firecrawl } from 'firecrawl';
+
+const firecrawl = new Firecrawl({ apiKey: "fc-YOUR_API_KEY" });
+
+// Execution trace of a run: ordered events (tool calls, reasoning, artifacts)
+const trace = await firecrawl.getAgentTrace("JOB_ID");
+
+for (const event of trace.events ?? []) {
+  console.log(event.type);
+}
+
+// Include currently active browser sessions while the run is in flight
+const live = await firecrawl.getAgentTrace("JOB_ID", { liveView: true });
+console.log(live.activeBrowserSessions);
+```

--- a/snippets/v2/agent/trace/python.mdx
+++ b/snippets/v2/agent/trace/python.mdx
@@ -1,0 +1,16 @@
+```python Python
+from firecrawl import Firecrawl
+
+app = Firecrawl(api_key="fc-YOUR_API_KEY")
+
+# Execution trace of a run: ordered events (tool calls, reasoning, artifacts)
+trace = app.get_agent_trace("JOB_ID")
+
+for event in trace.events or []:
+    print(event.type)
+
+# Include currently active browser sessions while the run is in flight
+live = app.get_agent_trace("JOB_ID", live_view=True)
+for session in live.active_browser_sessions or []:
+    print(session.live_view_url)
+```

--- a/snippets/v2/agent/with-model/curl.mdx
+++ b/snippets/v2/agent/with-model/curl.mdx
@@ -1,5 +1,5 @@
 ```bash cURL
-# Using Spark 2 (not the default - set it explicitly)
+# Spark 2 is the default — every run executes on it
 curl -X POST "https://api.firecrawl.dev/v2/agent" \
   -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
   -H "Content-Type: application/json" \
@@ -8,23 +8,5 @@ curl -X POST "https://api.firecrawl.dev/v2/agent" \
     "model": "spark-2"
   }'
 
-# Using Spark 1 Mini
-curl -X POST "https://api.firecrawl.dev/v2/agent" \
-  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "prompt": "Find the pricing of Firecrawl",
-    "model": "spark-1-mini"
-  }'
-
-# Using Spark 1 Pro (the default) for complex tasks
-curl -X POST "https://api.firecrawl.dev/v2/agent" \
-  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "prompt": "Compare all enterprise features and pricing across Firecrawl, Apify, and ScrapingBee",
-    "model": "spark-1-pro"
-  }'
+# Deprecated: Spark 1 model names are still accepted, but route to "spark-2".
 ```
-
-

--- a/snippets/v2/agent/with-model/js.mdx
+++ b/snippets/v2/agent/with-model/js.mdx
@@ -3,25 +3,13 @@ import { Firecrawl } from 'firecrawl';
 
 const firecrawl = new Firecrawl({ apiKey: "fc-YOUR_API_KEY" });
 
-// Using Spark 2 (not the default - set it explicitly)
-const resultSpark2 = await firecrawl.agent({
+// Spark 2 is the default — every run executes on it
+const result = await firecrawl.agent({
   prompt: "Find the pricing of Firecrawl",
   model: "spark-2"
 });
 
-// Using Spark 1 Mini
-const result = await firecrawl.agent({
-  prompt: "Find the pricing of Firecrawl",
-  model: "spark-1-mini"
-});
-
-// Using Spark 1 Pro (the default) for complex tasks
-const resultPro = await firecrawl.agent({
-  prompt: "Compare all enterprise features and pricing across Firecrawl, Apify, and ScrapingBee",
-  model: "spark-1-pro"
-});
+// Deprecated: Spark 1 model names are still accepted, but route to "spark-2".
 
 console.log(result.data);
 ```
-
-

--- a/snippets/v2/agent/with-model/python.mdx
+++ b/snippets/v2/agent/with-model/python.mdx
@@ -3,25 +3,13 @@ from firecrawl import Firecrawl
 
 app = Firecrawl(api_key="fc-YOUR_API_KEY")
 
-# Using Spark 2 (not the default - set it explicitly)
+# Spark 2 is the default — every run executes on it
 result = app.agent(
     prompt="Find the pricing of Firecrawl",
     model="spark-2"
 )
 
-# Using Spark 1 Mini
-result = app.agent(
-    prompt="Find the pricing of Firecrawl",
-    model="spark-1-mini"
-)
-
-# Using Spark 1 Pro (the default) for complex tasks
-result = app.agent(
-    prompt="Compare all enterprise features and pricing across Firecrawl, Apify, and ScrapingBee",
-    model="spark-1-pro"
-)
+# Deprecated: Spark 1 model names are still accepted, but route to "spark-2".
 
 print(result.data)
 ```
-
-

--- a/snippets/v2/agent/with-schema/curl.mdx
+++ b/snippets/v2/agent/with-schema/curl.mdx
@@ -4,7 +4,7 @@ curl -X POST "https://api.firecrawl.dev/v2/agent" \
   -H "Content-Type: application/json" \
   -d '{
     "prompt": "Find the founders of Firecrawl",
-    "model": "spark-1-mini",
+    "model": "spark-2",
     "maxCredits": 100,
     "schema": {
       "type": "object",

--- a/snippets/v2/agent/with-schema/js.mdx
+++ b/snippets/v2/agent/with-schema/js.mdx
@@ -13,7 +13,7 @@ const result = await firecrawl.agent({
       background: z.string().describe("Professional background").optional()
     })).describe("List of founders")
   }),
-  model: "spark-1-mini",
+  model: "spark-2",
   maxCredits: 100
 });
 

--- a/snippets/v2/agent/with-schema/python.mdx
+++ b/snippets/v2/agent/with-schema/python.mdx
@@ -16,7 +16,7 @@ class FoundersSchema(BaseModel):
 result = app.agent(
     prompt="Find the founders of Firecrawl",
     schema=FoundersSchema,
-    model="spark-1-mini",
+    model="spark-2",
     max_credits=100
 )
 

--- a/snippets/v2/cli/agent/options.mdx
+++ b/snippets/v2/cli/agent/options.mdx
@@ -1,9 +1,8 @@
 ```bash CLI
-# Use Spark 2 (not the default - set it explicitly)
+# Spark 2 is the default — every run executes on it
 firecrawl agent "Competitive analysis across multiple domains" --model spark-2 --wait
 
-# Use Spark 1 Pro (the default) for higher accuracy
-firecrawl agent "Competitive analysis across multiple domains" --model spark-1-pro --wait
+# Deprecated: Spark 1 model names are still accepted, but route to spark-2.
 
 # Set max credits to limit costs
 firecrawl agent "Gather contact information from company websites" --max-credits 100 --wait


### PR DESCRIPTION
## Summary

Brings the English agent API reference in line with the actual implementation (`firecrawl` API + extract-v3 agent service), and reflects the spark-2 default rollout.

### API reference fixes (`v2-openapi.json`, `webhooks-openapi.json`)
- **`agentCancelled` webhook**: fix `success` from `const: false` to `const: true` (implementation sends `success: true` for cancelled; only `agent.failed` sends `false`)
- **`POST /agent`**: document the `webhook` param (url/headers/metadata/events — makes the five agent webhook payload pages subscribable) and the `effort` param (`low`/`medium`/`high`); add 400/403/500 error responses
- **`GET /agent/{jobId}`**: add `effort` to the response; add 400/404
- **`DELETE /agent/{jobId}`**: add 400/404/409
- **New endpoints**: `GET /agent/{jobId}/trace` (incl. `liveView` query param and `activeBrowserSessions`) and `GET /agent/{jobId}/snapshots/{snapshotId}`, with new endpoint pages and nav entries
- **Full trace event schema**: new `AgentTraceEvent` component — a discriminated union of all 13 publicly emittable canonical events (matches `canonical/events.ts` + `canonical/public.ts` in the agent service: `usage.recorded` excluded, `model` stripped from `agent.started`), plus `AgentTraceAgent`, `AgentTraceError`, `AgentTraceArtifact` components

### Spark 2 default / Spark 1 deprecation
- `spark-2` documented as the default model every run executes on; Spark 1 model names remain accepted but route to `spark-2` (matches the API transform forcing `spark-2`)
- Removed Spark 1 showcase sections from `features/agent.mdx` and `features/models.mdx`; updated `sdks/cli.mdx`, `advanced-scraping-guide.mdx`, `choosing-the-data-extractor.mdx`, and the agent code snippets
- Fixed the status table in `features/agent.mdx`: cancelled jobs report `failed` (there is no `cancelled` status) and emit `agent.cancelled` webhooks

### Trace & snapshot SDK usage
- New `snippets/v2/agent/trace/*` and `snippets/v2/agent/snapshot/*` (Python/JS/cURL) covering `get_agent_trace`/`getAgentTrace` (incl. live view) and `get_agent_snapshot`/`getAgentSnapshot`
- New "Execution Traces and Snapshots" section in `features/agent.mdx`

English source files only — no localized files touched.
