### PR TITLE
Add agent quickstart docs for all SDK languages

### DIFF
--- a/agent-quickstart/elixir.mdx
+++ b/agent-quickstart/elixir.mdx
@@ -1,0 +1,226 @@
+---
+title: "Elixir Agent Quickstart"
+description: "Canonical Firecrawl Elixir quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Elixir Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl using the Elixir SDK. It is generated from SDK source and OpenAPI spec.
+
+## Install
+
+Add to your `mix.exs` dependencies:
+
+```elixir
+{:firecrawl, "~> 1.10"}
+```
+
+Then run:
+
+```bash
+mix deps.get
+```
+
+## Authenticate
+
+Set the API key in application config:
+
+```elixir
+config :firecrawl, api_key: "fc-YOUR_API_KEY"
+```
+
+Or pass it per-request:
+
+```elixir
+Firecrawl.scrape_and_extract_from_url([url: "https://example.com"], api_key: "fc-YOUR_API_KEY")
+```
+
+Omitting the key uses the keyless free tier (rate-limited per IP).
+
+**Per-request options (second keyword list):**
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `api_key` | `string` | Application config or `nil` | API key override for this request |
+| `base_url` | `string` | `"https://api.firecrawl.dev/v2"` | Base URL override |
+
+## When To Use What
+
+- **`search_and_scrape`**: Use when you start with a query and need to discover relevant pages. Returns ranked results with optional scraping.
+- **`scrape_and_extract_from_url`**: Use when you already have a URL and want its content in markdown, HTML, JSON, or other formats.
+- **`interact_with_scrape_browser_session`**: Use when a page needs post-scrape browser actions — clicking, filling forms, running code in the browser sandbox.
+
+## Search
+
+### Why use it
+
+Search the web for a query and get back ranked results. Optionally scrape each result page inline by passing `scrape_options`.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.search_and_scrape(params, opts \\ [])
+```
+
+Bang variant `search_and_scrape!/2` raises on error.
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.search_and_scrape(
+  query: "firecrawl web scraping API",
+  limit: 5,
+  scrape_options: [formats: ["markdown"]]
+)
+
+for item <- response.body["data"]["web"] || [] do
+  IO.puts("#{item["title"]} #{item["url"]}")
+end
+```
+
+### Parameters
+
+All parameters are passed as a keyword list. All are optional except `query`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `:string` | **Required.** The search query. |
+| `limit` | `:integer` | Max results to return. |
+| `sources` | `{:list, :any}` | Sources: `"web"`, `"news"`, `"images"`. |
+| `categories` | `{:list, :any}` | Filter: `"github"`, `"research"`, `"pdf"`. |
+| `include_domains` | `{:list, :string}` | Restrict results to these domains. |
+| `exclude_domains` | `{:list, :string}` | Exclude results from these domains. |
+| `tbs` | `:string` | Time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `:string` | Location string for geo-targeted results. |
+| `country` | `:string` | ISO country code for geo-targeting (e.g. `"US"`). |
+| `ignore_invalid_urls` | `:boolean` | Ignore invalid URLs in results. |
+| `timeout` | `:integer` | Timeout in milliseconds. |
+| `highlights` | `:boolean` | Generate query-relevant highlights. Default: `true`. |
+| `scrape_options` | `:keyword_list` | Scrape options applied to each result page. |
+| `enterprise` | `{:list, :string}` | Enterprise options: `["zdr"]` or `["anon"]`. |
+
+**Returns:** `{:ok, Req.Response.t()}` or `{:error, Exception.t()}`. The response body contains `"data"` with `"web"`, `"news"`, and `"images"` lists.
+
+## Scrape
+
+### Why use it
+
+Scrape a single URL and get its content as markdown, HTML, structured JSON, screenshots, or other formats.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.scrape_and_extract_from_url(params, opts \\ [])
+```
+
+Bang variant `scrape_and_extract_from_url!/2` raises on error.
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown", "links"],
+  only_main_content: true
+)
+
+IO.puts(response.body["data"]["markdown"])
+```
+
+### Parameters
+
+All parameters are passed as a keyword list. All are optional except `url`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `:string` | **Required.** The URL to scrape. |
+| `formats` | `{:list, :any}` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"changeTracking"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`. |
+| `only_main_content` | `:boolean` | Extract only the main content, excluding headers/navs/footers. |
+| `include_tags` | `{:list, :string}` | HTML tags to include in output. |
+| `exclude_tags` | `{:list, :string}` | HTML tags to exclude from output. |
+| `timeout` | `:integer` | Timeout in milliseconds (default 60000, max 300000). |
+| `wait_for` | `:integer` | Delay in ms before fetching content. |
+| `mobile` | `:boolean` | Emulate a mobile device. |
+| `headers` | `:any` | Custom HTTP headers. |
+| `actions` | `{:list, :any}` | Browser actions before scraping. |
+| `parsers` | `{:list, :any}` | Parser configs (e.g. `"pdf"`). |
+| `location` | `:keyword_list` | Geo-location with `country` and `languages` fields. |
+| `skip_tls_verification` | `:boolean` | Skip TLS certificate verification. |
+| `remove_base64_images` | `:boolean` | Remove base64 images from output. |
+| `block_ads` | `:boolean` | Block ads and cookie popups. |
+| `proxy` | `:basic \| :enhanced \| :auto` | Proxy tier. |
+| `max_age` | `:integer` | Use cached result if younger than this (ms). |
+| `min_age` | `:integer` | Min age for cache-only check (ms). |
+| `store_in_cache` | `:boolean` | Store result in Firecrawl cache. |
+| `lockdown` | `:boolean` | Serve from cache only. |
+| `redact_pii` | `:boolean` | Redact PII from returned content. |
+| `audit_metadata` | `:keyword_list` | User attribution for SIEM logging (requires `username`). |
+| `profile` | `:keyword_list` | Persistent browser profile. |
+
+**Returns:** `{:ok, Req.Response.t()}` or `{:error, Exception.t()}`. The response body contains `"data"` with `"markdown"`, `"html"`, `"links"`, `"metadata"`, etc.
+
+## Interact
+
+### Why use it
+
+Execute code in the browser session of a previous scrape job. Use this for clicking buttons, filling forms, navigating multi-step flows, or running arbitrary JavaScript/Python/Bash in the browser sandbox.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.interact_with_scrape_browser_session(job_id, params, opts \\ [])
+```
+
+Bang variant `interact_with_scrape_browser_session!/3` raises on error.
+
+### Example
+
+```elixir
+{:ok, scrape_response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown"]
+)
+
+job_id = scrape_response.body["data"]["metadata"]["jobId"]
+
+{:ok, result} = Firecrawl.interact_with_scrape_browser_session(job_id,
+  code: "document.querySelector('button.load-more').click();",
+  language: :node,
+  timeout: 30
+)
+
+IO.puts(result.body["stdout"])
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `String.t()` | **Required.** The scrape job ID (first positional argument). |
+| `code` | `:string` | **Required.** Code to execute in the browser sandbox. |
+| `language` | `:python \| :node \| :bash` | Execution language. Default: `:node`. |
+| `timeout` | `:integer` | Execution timeout in seconds (1–300). |
+
+**Returns:** `{:ok, Req.Response.t()}` with body containing `"success"`, `"stdout"`, `"stderr"`, `"result"`, `"exitCode"`, `"killed"`, `"error"`.
+
+**Stop the session:**
+
+```elixir
+Firecrawl.stop_interactive_scrape_browser_session(job_id)
+```
+
+## Notes
+
+- All parameter names use **snake_case** (e.g. `only_main_content`, `skip_tls_verification`). The SDK converts them to camelCase JSON keys internally.
+- Parameters are passed as **keyword lists**, not maps.
+- The SDK is **auto-generated from the OpenAPI spec**. Function names match the OpenAPI operation IDs closely.
+- The `interact_with_scrape_browser_session` function only supports `code`, not `prompt` (natural-language browser instruction). Use `code` to execute scripts directly.
+- Proxy values are atoms (`:basic`, `:enhanced`, `:auto`), not strings.
+- Every function has a bang variant (`!`) that raises instead of returning `{:error, ...}`.
+- There are **no deprecated aliases** in the Elixir SDK.
+
+## Source Of Truth
+
+- `firecrawl/apps/elixir-sdk/lib/firecrawl.ex`
+- `firecrawl/apps/elixir-sdk/mix.exs`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/java.mdx
+++ b/agent-quickstart/java.mdx
@@ -1,0 +1,247 @@
+---
+title: "Java Agent Quickstart"
+description: "Canonical Firecrawl Java quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Java Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl using the Java SDK. It is generated from SDK source and OpenAPI spec.
+
+## Install
+
+**Gradle:**
+
+```kotlin
+implementation("com.firecrawl:firecrawl-java:1.16.0")
+```
+
+**Maven:**
+
+```xml
+<dependency>
+    <groupId>com.firecrawl</groupId>
+    <artifactId>firecrawl-java</artifactId>
+    <version>1.16.0</version>
+</dependency>
+```
+
+## Authenticate
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+
+FirecrawlClient app = FirecrawlClient.builder()
+    .apiKey("fc-YOUR_API_KEY")
+    .build();
+```
+
+Or read the API key from the `FIRECRAWL_API_KEY` environment variable:
+
+```java
+FirecrawlClient app = FirecrawlClient.fromEnv();
+```
+
+A null or blank key uses the keyless free tier (rate-limited per IP).
+
+**Builder options:**
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `apiKey` | `String` | `FIRECRAWL_API_KEY` env var or `firecrawl.apiKey` system property | API key for authentication |
+| `apiUrl` | `String` | `"https://api.firecrawl.dev"` | Base URL for the API |
+| `timeoutMs` | `long` | `300000` (5 min) | Per-request timeout in milliseconds |
+| `maxRetries` | `int` | `3` | Max automatic retries for transient failures |
+| `backoffFactor` | `double` | `0.5` | Exponential backoff factor in seconds |
+| `asyncExecutor` | `Executor` | `ForkJoinPool.commonPool()` | Executor for async methods |
+| `httpClient` | `OkHttpClient` | SDK-created | Custom HTTP client (overrides `timeoutMs`) |
+
+## When To Use What
+
+- **`search`**: Use when you start with a query and need to discover relevant pages. Returns ranked results with optional scraping of each result.
+- **`scrape`**: Use when you already have a URL and want its content in markdown, HTML, JSON, or other formats.
+- **`interact`**: Use when a page needs post-scrape browser actions — clicking, filling forms, running code in the browser sandbox.
+
+## Search
+
+### Why use it
+
+Search the web for a query and get back ranked results. Optionally scrape each result page inline by passing `scrapeOptions`.
+
+### Preferred SDK method
+
+```java
+app.search(query)
+app.search(query, options)
+```
+
+### Example
+
+```java
+import com.firecrawl.models.SearchOptions;
+import com.firecrawl.models.SearchData;
+
+SearchData results = app.search("firecrawl web scraping API",
+    SearchOptions.builder()
+        .limit(5)
+        .highlights(true)
+        .build());
+
+for (var item : results.getWeb()) {
+    System.out.println(item.get("title") + " " + item.get("url"));
+}
+```
+
+### Parameters
+
+All fields on `SearchOptions` are nullable and set via the builder.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `String` | **Required.** The search query (first positional argument). |
+| `limit` | `Integer` | Max results to return. |
+| `sources` | `List<Object>` | Sources: `"web"`, `"news"`, `"images"` as strings or `{type: "web"}` maps. |
+| `categories` | `List<Object>` | Filter: `"github"`, `"research"`, `"pdf"`. |
+| `includeDomains` | `List<String>` | Restrict results to these domains. |
+| `excludeDomains` | `List<String>` | Exclude results from these domains. |
+| `tbs` | `String` | Time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `String` | Location string for geo-targeted results. |
+| `ignoreInvalidURLs` | `Boolean` | Ignore invalid URLs in results. |
+| `timeout` | `Integer` | Timeout in milliseconds. |
+| `highlights` | `Boolean` | Generate query-relevant highlights. Default: `true`. |
+| `scrapeOptions` | `ScrapeOptions` | Scrape options applied to each result page. |
+| `integration` | `String` | Integration identifier for tracking. |
+
+**Returns:** `SearchData` with `getWeb()`, `getNews()`, and `getImages()` lists.
+
+Async variant: `searchAsync(query, options)` returns `CompletableFuture<SearchData>`.
+
+## Scrape
+
+### Why use it
+
+Scrape a single URL and get its content as markdown, HTML, structured JSON, screenshots, or other formats.
+
+### Preferred SDK method
+
+```java
+app.scrape(url)
+app.scrape(url, options)
+```
+
+### Example
+
+```java
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.Document;
+
+Document doc = app.scrape("https://example.com",
+    ScrapeOptions.builder()
+        .formats(List.of("markdown", "links"))
+        .onlyMainContent(true)
+        .build());
+
+System.out.println(doc.getMarkdown());
+```
+
+### Parameters
+
+All fields on `ScrapeOptions` are nullable and set via the builder.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `String` | **Required.** The URL to scrape (first positional argument). |
+| `formats` | `List<Object>` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"audio"`, `"video"`, or typed objects like `JsonFormat`, `QuestionFormat`, `HighlightsFormat`. |
+| `onlyMainContent` | `Boolean` | Extract only the main content, excluding headers/navs/footers. |
+| `includeTags` | `List<String>` | HTML tags to include in output. |
+| `excludeTags` | `List<String>` | HTML tags to exclude from output. |
+| `timeout` | `Integer` | Timeout in milliseconds (1000–300000). |
+| `waitFor` | `Integer` | Delay in ms before fetching content. |
+| `mobile` | `Boolean` | Emulate a mobile device. |
+| `headers` | `Map<String, String>` | Custom HTTP headers. |
+| `actions` | `List<Map<String, Object>>` | Browser actions before scraping. |
+| `parsers` | `List<Object>` | Parser configs (e.g. `"pdf"` string or `PdfParser` object). |
+| `location` | `LocationConfig` | Geo-location with `country` and `languages` fields. |
+| `skipTlsVerification` | `Boolean` | Skip TLS certificate verification. |
+| `removeBase64Images` | `Boolean` | Remove base64 images from output. |
+| `blockAds` | `Boolean` | Block ads and cookie popups. |
+| `proxy` | `String` | Proxy tier: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. |
+| `maxAge` | `Long` | Use cached result if younger than this (ms). |
+| `storeInCache` | `Boolean` | Store result in Firecrawl cache. |
+| `lockdown` | `Boolean` | Serve from cache only. |
+| `redactPII` | `Boolean` | Redact PII from returned content. |
+| `auditMetadata` | `AuditMetadata` | User attribution for SIEM logging (`username` field). |
+| `integration` | `String` | Integration identifier. |
+
+**Returns:** `Document` with getters like `getMarkdown()`, `getHtml()`, `getRawHtml()`, `getLinks()`, `getImages()`, `getScreenshot()`, `getMetadata()`, etc.
+
+Async variant: `scrapeAsync(url, options)` returns `CompletableFuture<Document>`.
+
+## Interact
+
+### Why use it
+
+Execute code in the browser session of a previous scrape job. Use this for clicking buttons, filling forms, navigating multi-step flows, or running arbitrary JavaScript/Python/Bash in the browser sandbox.
+
+### Preferred SDK method
+
+```java
+app.interact(jobId, code)
+app.interact(jobId, code, language, timeout)
+app.interact(jobId, code, language, timeout, origin)
+```
+
+### Example
+
+```java
+import com.firecrawl.models.BrowserExecuteResponse;
+
+Document doc = app.scrape("https://example.com");
+String jobId = (String) doc.getMetadata().get("jobId");
+
+BrowserExecuteResponse result = app.interact(
+    jobId,
+    "document.querySelector('button.load-more').click();",
+    "node",
+    30
+);
+
+System.out.println(result.getStdout());
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `jobId` | `String` | **Required.** The scrape job ID. |
+| `code` | `String` | **Required.** Code to execute in the browser sandbox. |
+| `language` | `String` | Execution language: `"python"`, `"node"`, `"bash"`. Default: `"node"`. |
+| `timeout` | `Integer` | Execution timeout in seconds (1–300). Default: `30`. |
+| `origin` | `String` | Origin label for request attribution. |
+
+**Returns:** `BrowserExecuteResponse` with `isSuccess()`, `getStdout()`, `getStderr()`, `getResult()`, `getExitCode()`, `getKilled()`, `getError()`.
+
+Async variants: `interactAsync(jobId, code)`, `interactAsync(jobId, code, language, timeout)`, etc.
+
+**Stop the session:**
+
+```java
+app.stopInteractiveBrowser(jobId);
+```
+
+## Notes
+
+- All parameter names use **camelCase** (e.g. `onlyMainContent`, `skipTlsVerification`, `scrapeOptions`).
+- Options classes use the **builder pattern**: `ScrapeOptions.builder().formats(...).build()`.
+- All `Boolean` options use boxed `Boolean` (not primitive `boolean`), so unset fields are `null` and omitted from JSON.
+- The `interact` method takes `code` as a required positional `String` parameter. The `prompt` parameter (natural-language browser instruction) is not available in the Java SDK; use `code` instead.
+- Every sync method has an `*Async` variant returning `CompletableFuture`.
+- **Deprecated aliases** (use the preferred names instead):
+  - `scrapeExecute()` → `interact()`
+  - `deleteScrapeBrowser()` → `stopInteractiveBrowser()`
+
+## Source Of Truth
+
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/ScrapeOptions.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/SearchOptions.java`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/node.mdx
+++ b/agent-quickstart/node.mdx
@@ -1,0 +1,208 @@
+---
+title: "Node.js Agent Quickstart"
+description: "Canonical Firecrawl Node.js/TypeScript quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Node.js Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl using the Node.js/TypeScript SDK. It is generated from SDK source and OpenAPI spec.
+
+## Install
+
+```bash
+npm install @mendable/firecrawl-js
+```
+
+## Authenticate
+
+```typescript
+import Firecrawl from "@mendable/firecrawl-js";
+
+const app = new Firecrawl("fc-YOUR_API_KEY");
+```
+
+The API key can also be set via the `FIRECRAWL_API_KEY` environment variable. Omitting the key uses the keyless free tier (rate-limited per IP).
+
+**Client options:**
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `apiKey` | `string \| null` | `FIRECRAWL_API_KEY` env var | API key for authentication |
+| `apiUrl` | `string \| null` | `"https://api.firecrawl.dev"` | Base URL for the API |
+| `timeoutMs` | `number` | — | Per-request timeout in milliseconds |
+| `maxRetries` | `number` | — | Max automatic retries for transient failures |
+| `backoffFactor` | `number` | — | Exponential backoff factor for retries |
+
+## When To Use What
+
+- **`search`**: Use when you start with a query and need to discover relevant pages. Returns ranked results with optional scraping of each result.
+- **`scrape`**: Use when you already have a URL and want its content in markdown, HTML, JSON, or other formats.
+- **`interact`**: Use when a page needs post-scrape browser actions — clicking, filling forms, running code, or prompting an AI agent in the browser.
+
+## Search
+
+### Why use it
+
+Search the web for a query and get back ranked results. Optionally scrape each result page inline by passing `scrapeOptions`.
+
+### Preferred SDK method
+
+```typescript
+app.search(query, options?)
+```
+
+### Example
+
+```typescript
+const results = await app.search("firecrawl web scraping API", {
+  limit: 5,
+  scrapeOptions: { formats: ["markdown"] },
+});
+
+for (const item of results.web ?? []) {
+  console.log(item.title, item.url);
+}
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `string` | **Required.** The search query (max 500 chars). |
+| `limit` | `number` | Max results to return. Must be positive. |
+| `sources` | `Array<"web" \| "news" \| "images" \| { type: string }>` | Which result sources to include. Default: web only. |
+| `categories` | `Array<"github" \| "research" \| "pdf" \| object>` | Filter results by category. |
+| `includeDomains` | `string[]` | Restrict results to these domains. Cannot combine with `excludeDomains`. |
+| `excludeDomains` | `string[]` | Exclude results from these domains. Cannot combine with `includeDomains`. |
+| `tbs` | `string` | Time-based search filter (e.g. `"qdr:d"` for past day, `"qdr:w"` for past week). |
+| `location` | `string` | Location string for geo-targeted results. |
+| `ignoreInvalidURLs` | `boolean` | Ignore invalid URLs in results. |
+| `timeout` | `number` | Timeout in milliseconds. Must be positive. |
+| `highlights` | `boolean` | Generate query-relevant highlights. Default: `true`. |
+| `scrapeOptions` | `ScrapeOptions` | Scrape options applied to each result page. |
+| `enterprise` | `Array<"default" \| "anon" \| "zdr">` | Enterprise zero data retention options. |
+| `threatProtection` | `ThreatProtectionOptions` | Enterprise per-request threat protection override. |
+| `integration` | `string` | Integration identifier for tracking. |
+
+**Returns:** `SearchData` with optional `.web`, `.news`, and `.images` arrays depending on `sources`.
+
+## Scrape
+
+### Why use it
+
+Scrape a single URL and get its content as markdown, HTML, structured JSON, screenshots, or other formats.
+
+### Preferred SDK method
+
+```typescript
+app.scrape(url, options?)
+```
+
+### Example
+
+```typescript
+const doc = await app.scrape("https://example.com", {
+  formats: ["markdown", "links"],
+  onlyMainContent: true,
+});
+
+console.log(doc.markdown);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `string` | **Required.** The URL to scrape. |
+| `formats` | `FormatOption[]` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"changeTracking"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`, or objects like `{ type: "question", question: "..." }` and `{ type: "highlights", query: "..." }`. |
+| `onlyMainContent` | `boolean` | Extract only the main content, excluding headers/navs/footers. |
+| `includeTags` | `string[]` | HTML tags to include in output. |
+| `excludeTags` | `string[]` | HTML tags to exclude from output. |
+| `timeout` | `number` | Timeout in milliseconds (1000–300000). |
+| `waitFor` | `number` | Delay in ms before fetching content. |
+| `mobile` | `boolean` | Emulate a mobile device. |
+| `headers` | `Record<string, string>` | Custom HTTP headers to send with the request. |
+| `actions` | `ActionOption[]` | Browser actions to perform before scraping: `wait`, `click`, `write`, `press`, `scroll`, `screenshot`, `scrape`, `executeJavascript`, `pdf`. |
+| `parsers` | `Array<string \| PDFParser>` | Parser configs. Include `"pdf"` to extract PDF content to markdown. |
+| `location` | `{ country?: string; languages?: string[] }` | Geo-location for proxy routing. |
+| `skipTlsVerification` | `boolean` | Skip TLS certificate verification. |
+| `removeBase64Images` | `boolean` | Remove base64 images from output. |
+| `fastMode` | `boolean` | Enable fast mode (less accuracy). |
+| `blockAds` | `boolean` | Block ads and cookie popups. |
+| `proxy` | `"basic" \| "stealth" \| "enhanced" \| "auto"` | Proxy tier. `auto` tries basic first, retries with enhanced on failure. |
+| `maxAge` | `number` | Use cached result if younger than this (ms). `0` bypasses cache. |
+| `storeInCache` | `boolean` | Store result in Firecrawl cache. |
+| `lockdown` | `boolean` | Serve from cache only; never makes outbound request. |
+| `redactPII` | `boolean \| RedactPIIOptions` | Redact PII from returned content. |
+| `auditMetadata` | `{ username: string }` | User attribution for SIEM logging. |
+| `profile` | `{ name: string; saveChanges?: boolean }` | Persistent browser profile for session continuity. |
+| `integration` | `string` | Integration identifier. |
+| `autoResume` | `boolean` | SDK-only. Auto-retry when a large doc outlives the request window. Default: `true`. |
+| `threatProtection` | `ThreatProtectionOptions` | Enterprise per-request threat protection override. |
+
+**Returns:** `Document` with fields like `markdown`, `html`, `rawHtml`, `links`, `images`, `screenshot`, `metadata`, etc.
+
+## Interact
+
+### Why use it
+
+Execute code or send a natural-language prompt in the browser session of a previous scrape job. Use this for clicking buttons, filling forms, navigating multi-step flows, or running arbitrary JavaScript/Python/Bash in the browser sandbox.
+
+### Preferred SDK method
+
+```typescript
+app.interact(jobId, args)
+```
+
+### Example
+
+```typescript
+const doc = await app.scrape("https://example.com", {
+  formats: ["markdown"],
+});
+
+const jobId = doc.metadata.jobId;
+
+const result = await app.interact(jobId, {
+  code: "document.querySelector('button.load-more').click();",
+  language: "node",
+  timeout: 30,
+});
+
+console.log(result.stdout);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `jobId` | `string` | **Required.** The scrape job ID (from `doc.metadata.jobId`). |
+| `code` | `string` | Code to execute. One of `code` or `prompt` is required. |
+| `prompt` | `string` | Natural-language instruction for the AI browser agent. One of `code` or `prompt` is required. |
+| `language` | `"python" \| "node" \| "bash"` | Execution language. Default: `"node"`. |
+| `timeout` | `number` | Execution timeout in seconds (1–300). |
+
+**Returns:** `ScrapeExecuteResponse` with `success`, `stdout`, `stderr`, `result`, `exitCode`, `killed`, `error`, and optional `liveViewUrl` / `interactiveLiveViewUrl`.
+
+**Stop the session:**
+
+```typescript
+await app.stopInteraction(jobId);
+```
+
+## Notes
+
+- All parameter names use **camelCase** (e.g. `onlyMainContent`, `skipTlsVerification`, `scrapeOptions`).
+- `includeDomains` and `excludeDomains` on search are mutually exclusive.
+- The `SearchData` return type has `.web`, `.news`, and `.images` arrays. Accessing `.data` throws a helpful migration error.
+- **Deprecated aliases** (use the preferred names instead):
+  - `scrapeUrl()` → `scrape()`
+  - `scrapeExecute()` → `interact()`
+  - `stopInteractiveBrowser()` / `deleteScrapeBrowser()` → `stopInteraction()`
+
+## Source Of Truth
+
+- `firecrawl/apps/js-sdk/firecrawl/src/index.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/python.mdx
+++ b/agent-quickstart/python.mdx
@@ -1,0 +1,208 @@
+---
+title: "Python Agent Quickstart"
+description: "Canonical Firecrawl Python quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Python Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl using the Python SDK. It is generated from SDK source and OpenAPI spec.
+
+## Install
+
+```bash
+pip install firecrawl-py
+```
+
+## Authenticate
+
+```python
+from firecrawl import Firecrawl
+
+app = Firecrawl(api_key="fc-YOUR_API_KEY")
+```
+
+The API key can also be set via the `FIRECRAWL_API_KEY` environment variable. Omitting the key uses the keyless free tier (rate-limited per IP).
+
+**Client options:**
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `api_key` | `str` | `FIRECRAWL_API_KEY` env var | API key for authentication |
+| `api_url` | `str` | `"https://api.firecrawl.dev"` | Base URL for the API |
+| `timeout` | `float` | `None` | Default request timeout in seconds |
+| `max_retries` | `int` | `3` | Max automatic retries for transient failures |
+| `backoff_factor` | `float` | `0.5` | Exponential backoff factor for retries |
+
+## When To Use What
+
+- **`search`**: Use when you start with a query and need to discover relevant pages. Returns ranked results with optional scraping of each result.
+- **`scrape`**: Use when you already have a URL and want its content in markdown, HTML, JSON, or other formats.
+- **`interact`**: Use when a page needs post-scrape browser actions — clicking, filling forms, running code, or prompting an AI agent in the browser.
+
+## Search
+
+### Why use it
+
+Search the web for a query and get back ranked results. Optionally scrape each result page inline by passing `scrape_options`.
+
+### Preferred SDK method
+
+```python
+app.search(query, **kwargs)
+```
+
+### Example
+
+```python
+results = app.search(
+    "firecrawl web scraping API",
+    limit=5,
+    scrape_options={"formats": ["markdown"]},
+)
+
+for item in results.web or []:
+    print(item.title, item.url)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `str` | **Required.** The search query (max 500 chars). |
+| `limit` | `int` | Max results to return. Default: `5`. |
+| `sources` | `list` | Which result sources to include: `"web"`, `"news"`, `"images"`. |
+| `categories` | `list` | Filter results by category: `"github"`, `"research"`, `"pdf"`, `"developer"`. |
+| `include_domains` | `list[str]` | Restrict results to these domains. Cannot combine with `exclude_domains`. |
+| `exclude_domains` | `list[str]` | Exclude results from these domains. Cannot combine with `include_domains`. |
+| `tbs` | `str` | Time-based search filter (e.g. `"qdr:d"` for past day, `"qdr:w"` for past week). |
+| `location` | `str` | Location string for geo-targeted results. |
+| `ignore_invalid_urls` | `bool` | Ignore invalid URLs in results. |
+| `timeout` | `int` | Timeout in milliseconds. Default: `300000`. |
+| `highlights` | `bool` | Generate query-relevant highlights. Default: `True`. |
+| `scrape_options` | `ScrapeOptions \| dict` | Scrape options applied to each result page. |
+| `enterprise` | `list[str]` | Enterprise options: `["zdr"]` or `["anon"]`. |
+| `threat_protection` | `ThreatProtectionOptions` | Enterprise per-request threat protection override. |
+| `integration` | `str` | Integration identifier for tracking. |
+
+**Returns:** `SearchData` with optional `.web`, `.news`, and `.images` attributes.
+
+## Scrape
+
+### Why use it
+
+Scrape a single URL and get its content as markdown, HTML, structured JSON, screenshots, or other formats.
+
+### Preferred SDK method
+
+```python
+app.scrape(url, **kwargs)
+```
+
+### Example
+
+```python
+doc = app.scrape(
+    "https://example.com",
+    formats=["markdown", "links"],
+    only_main_content=True,
+)
+
+print(doc.markdown)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `str` | **Required.** The URL to scrape. |
+| `formats` | `list` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"changeTracking"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`, or dicts like `{"type": "question", "question": "..."}` and `{"type": "highlights", "query": "..."}`. |
+| `only_main_content` | `bool` | Extract only the main content, excluding headers/navs/footers. |
+| `include_tags` | `list[str]` | HTML tags to include in output. |
+| `exclude_tags` | `list[str]` | HTML tags to exclude from output. |
+| `timeout` | `int` | Timeout in milliseconds (1000–300000). |
+| `wait_for` | `int` | Delay in ms before fetching content. |
+| `mobile` | `bool` | Emulate a mobile device. |
+| `headers` | `dict[str, str]` | Custom HTTP headers to send with the request. |
+| `actions` | `list` | Browser actions before scraping: `wait`, `click`, `write`, `press`, `scroll`, `screenshot`, `scrape`, `executeJavascript`, `pdf`. |
+| `parsers` | `list` | Parser configs. Include `"pdf"` to extract PDF content to markdown. |
+| `location` | `Location` | Geo-location with `country` and `languages` fields. |
+| `skip_tls_verification` | `bool` | Skip TLS certificate verification. |
+| `remove_base64_images` | `bool` | Remove base64 images from output. |
+| `fast_mode` | `bool` | Enable fast mode (less accuracy). |
+| `block_ads` | `bool` | Block ads and cookie popups. |
+| `proxy` | `str` | Proxy tier: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. |
+| `max_age` | `int` | Use cached result if younger than this (ms). |
+| `store_in_cache` | `bool` | Store result in Firecrawl cache. |
+| `lockdown` | `bool` | Serve from cache only; never makes outbound request. |
+| `redact_pii` | `bool` | Redact PII from returned content. |
+| `audit_metadata` | `AuditMetadata` | User attribution for SIEM logging (`username` field). |
+| `profile` | `dict` | Persistent browser profile for session continuity. |
+| `integration` | `str` | Integration identifier. |
+| `threat_protection` | `ThreatProtectionOptions` | Enterprise per-request threat protection override. |
+
+**Returns:** `Document` with attributes like `markdown`, `html`, `raw_html`, `links`, `images`, `screenshot`, `metadata`, etc.
+
+## Interact
+
+### Why use it
+
+Execute code or send a natural-language prompt in the browser session of a previous scrape job. Use this for clicking buttons, filling forms, navigating multi-step flows, or running arbitrary JavaScript/Python/Bash in the browser sandbox.
+
+### Preferred SDK method
+
+```python
+app.interact(job_id, code=None, prompt=None, **kwargs)
+```
+
+### Example
+
+```python
+doc = app.scrape("https://example.com", formats=["markdown"])
+job_id = doc.metadata.get("jobId")
+
+result = app.interact(
+    job_id,
+    code="document.querySelector('button.load-more').click();",
+    language="node",
+    timeout=30,
+)
+
+print(result.stdout)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `str` | **Required.** The scrape job ID. |
+| `code` | `str` | Code to execute. One of `code` or `prompt` is required. |
+| `prompt` | `str` | Natural-language instruction for the AI browser agent. One of `code` or `prompt` is required. |
+| `language` | `"python" \| "node" \| "bash"` | Execution language. Default: `"node"`. |
+| `timeout` | `int` | Execution timeout in seconds (1–300). |
+
+**Returns:** `BrowserExecuteResponse` with `success`, `stdout`, `stderr`, `result`, `exit_code`, `killed`, `error`.
+
+**Stop the session:**
+
+```python
+app.stop_interaction(job_id)
+```
+
+## Notes
+
+- All parameter names use **snake_case** (e.g. `only_main_content`, `skip_tls_verification`, `scrape_options`).
+- `include_domains` and `exclude_domains` on search are mutually exclusive.
+- The `SearchData` return type has `.web`, `.news`, and `.images` attributes. Accessing `.data` raises an `AttributeError` with migration guidance.
+- An async client is available: `from firecrawl import AsyncFirecrawl`.
+- **Deprecated aliases** (use the preferred names instead):
+  - `scrape_url()` → `scrape()`
+  - `scrape_execute()` → `interact()`
+  - `stop_interactive_browser()` / `delete_scrape_browser()` → `stop_interaction()`
+  - `FirecrawlApp` → `Firecrawl`
+
+## Source Of Truth
+
+- `firecrawl/apps/python-sdk/firecrawl/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/rust.mdx
+++ b/agent-quickstart/rust.mdx
@@ -1,0 +1,230 @@
+---
+title: "Rust Agent Quickstart"
+description: "Canonical Firecrawl Rust quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Rust Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl using the Rust SDK. It is generated from SDK source and OpenAPI spec.
+
+## Install
+
+```bash
+cargo add firecrawl
+```
+
+## Authenticate
+
+```rust
+use firecrawl::Client;
+
+let app = Client::new("fc-YOUR_API_KEY")?;
+```
+
+For self-hosted instances:
+
+```rust
+let app = Client::new_selfhosted("https://your-instance.com", Some("fc-YOUR_API_KEY"))?;
+```
+
+Passing `None` for the API key uses the keyless free tier (rate-limited per IP).
+
+## When To Use What
+
+- **`search`**: Use when you start with a query and need to discover relevant pages. Returns ranked results with optional scraping of each result.
+- **`scrape`**: Use when you already have a URL and want its content in markdown, HTML, JSON, or other formats.
+- **`interact`**: Use when a page needs post-scrape browser actions — clicking, filling forms, running code, or prompting an AI agent in the browser.
+
+## Search
+
+### Why use it
+
+Search the web for a query and get back ranked results. Optionally scrape each result page inline by setting `scrape_options`.
+
+### Preferred SDK method
+
+```rust
+app.search(query, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, SearchOptions, ScrapeOptions};
+
+let app = Client::new("fc-YOUR_API_KEY")?;
+
+let response = app.search("firecrawl web scraping API", SearchOptions {
+    limit: Some(5),
+    scrape_options: Some(ScrapeOptions::default()),
+    ..Default::default()
+}).await?;
+
+if let Some(web) = response.data.web {
+    for item in web {
+        println!("{:?}", item);
+    }
+}
+```
+
+### Parameters
+
+All fields on `SearchOptions` are `Option` and default to `None`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `impl AsRef<str>` | **Required.** The search query (first positional argument). |
+| `limit` | `Option<u32>` | Max results. Default: 5, max: 20. |
+| `sources` | `Option<Vec<SearchSource>>` | Sources: `SearchSource::Web`, `News`, `Images`. |
+| `categories` | `Option<Vec<SearchCategory>>` | Filter: `SearchCategory::Github`, `Research`, `Pdf`. |
+| `include_domains` | `Option<Vec<String>>` | Restrict results to these domains. |
+| `exclude_domains` | `Option<Vec<String>>` | Exclude results from these domains. |
+| `tbs` | `Option<String>` | Time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `Option<String>` | Location string for geo-targeted results. |
+| `ignore_invalid_urls` | `Option<bool>` | Ignore invalid URLs in results. |
+| `timeout` | `Option<u32>` | Timeout in milliseconds. |
+| `highlights` | `Option<bool>` | Generate query-relevant highlights. Default: true. |
+| `scrape_options` | `Option<ScrapeOptions>` | Scrape options applied to each result page. |
+| `integration` | `Option<String>` | Integration identifier for tracking. |
+
+**Returns:** `SearchResponse` containing `SearchData` with optional `.web`, `.news`, and `.images` vectors.
+
+A convenience method `search_and_scrape(query, limit)` returns `Vec<Document>` directly.
+
+## Scrape
+
+### Why use it
+
+Scrape a single URL and get its content as markdown, HTML, structured JSON, screenshots, or other formats.
+
+### Preferred SDK method
+
+```rust
+app.scrape(url, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, Format};
+
+let app = Client::new("fc-YOUR_API_KEY")?;
+
+let doc = app.scrape("https://example.com", ScrapeOptions {
+    formats: Some(vec![Format::Markdown, Format::Links]),
+    only_main_content: Some(true),
+    ..Default::default()
+}).await?;
+
+println!("{}", doc.markdown.unwrap_or_default());
+```
+
+### Parameters
+
+All fields on `ScrapeOptions` are `Option` and default to `None`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `impl AsRef<str>` | **Required.** The URL to scrape (first positional argument). |
+| `formats` | `Option<Vec<Format>>` | Output formats: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `Json`, `ChangeTracking`, `Branding`, `Product`, `Menu`, `Audio`, `Video`, `Question(QuestionFormat)`, `Highlights(HighlightsFormat)`. |
+| `only_main_content` | `Option<bool>` | Extract only the main content, excluding headers/navs/footers. |
+| `include_tags` | `Option<Vec<String>>` | HTML tags to include in output. |
+| `exclude_tags` | `Option<Vec<String>>` | HTML tags to exclude from output. |
+| `timeout` | `Option<u32>` | Timeout in milliseconds. |
+| `wait_for` | `Option<u32>` | Delay in ms before fetching content. |
+| `mobile` | `Option<bool>` | Emulate a mobile device. |
+| `headers` | `Option<HashMap<String, String>>` | Custom HTTP headers. |
+| `actions` | `Option<Vec<Action>>` | Browser actions before scraping. |
+| `parsers` | `Option<Vec<ParserConfig>>` | Parser configs for file processing (e.g. PDF). |
+| `location` | `Option<LocationConfig>` | Geo-location with `country` and `languages` fields. |
+| `skip_tls_verification` | `Option<bool>` | Skip TLS certificate verification. |
+| `remove_base64_images` | `Option<bool>` | Remove base64 images from output. |
+| `fast_mode` | `Option<bool>` | Enable fast mode (less accuracy). |
+| `block_ads` | `Option<bool>` | Block ads and cookie popups. |
+| `proxy` | `Option<ProxyType>` | Proxy tier: `Basic`, `Stealth`, `Enhanced`, `Auto`. |
+| `max_age` | `Option<u32>` | Use cached result if younger than this (seconds). |
+| `min_age` | `Option<u32>` | Min age for cache-only check (seconds). |
+| `store_in_cache` | `Option<bool>` | Store result in Firecrawl cache. |
+| `lockdown` | `Option<bool>` | Serve from cache only. |
+| `redact_pii` | `Option<bool>` | Redact PII from returned content. |
+| `audit_metadata` | `Option<AuditMetadata>` | User attribution for SIEM logging. |
+| `profile` | `Option<ProfileConfig>` | Persistent browser profile (`name`, `save_changes`). |
+| `integration` | `Option<String>` | Integration identifier. |
+| `json_options` | `Option<JsonOptions>` | JSON extraction options (`schema`, `prompt`, `system_prompt`, `check_prompt_injection`). |
+| `screenshot_options` | `Option<ScreenshotOptions>` | Screenshot options (`full_page`, `quality`, `viewport`). |
+| `change_tracking_options` | `Option<ChangeTrackingOptions>` | Change tracking options (`modes`, `schema`, `prompt`, `tag`). |
+| `attribute_selectors` | `Option<Vec<AttributeSelector>>` | Attribute extraction selectors. |
+
+**Returns:** `Document` with optional fields like `markdown`, `html`, `raw_html`, `links`, `images`, `screenshot`, `metadata`, etc.
+
+A convenience method `scrape_with_schema(url, schema, prompt)` extracts structured JSON using a JSON Schema.
+
+## Interact
+
+### Why use it
+
+Execute code or send a natural-language prompt in the browser session of a previous scrape job. Use this for clicking buttons, filling forms, navigating multi-step flows, or running arbitrary JavaScript/Python/Bash in the browser sandbox.
+
+### Preferred SDK method
+
+```rust
+app.interact(job_id, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, ScrapeExecuteOptions};
+
+let app = Client::new("fc-YOUR_API_KEY")?;
+
+let doc = app.scrape("https://example.com", ScrapeOptions::default()).await?;
+let job_id = doc.metadata.as_ref()
+    .and_then(|m| m.additional.get("jobId"))
+    .and_then(|v| v.as_str())
+    .unwrap();
+
+let result = app.interact(job_id, ScrapeExecuteOptions {
+    code: Some("document.querySelector('button.load-more').click();".into()),
+    language: None, // defaults to Node
+    timeout: Some(30),
+    ..Default::default()
+}).await?;
+
+println!("{:?}", result.stdout);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `impl AsRef<str>` | **Required.** The scrape job ID. |
+| `code` | `Option<String>` | Code to execute. One of `code` or `prompt` is required. |
+| `prompt` | `Option<String>` | Natural-language instruction for the AI browser agent. One of `code` or `prompt` is required. |
+| `language` | `Option<ScrapeExecuteLanguage>` | Execution language: `Python`, `Node`, `Bash`. Default: `Node`. |
+| `timeout` | `Option<u32>` | Execution timeout in seconds (1–300). |
+
+**Returns:** `ScrapeExecuteResponse` with `success`, `stdout`, `stderr`, `result`, `exit_code`, `killed`, `error`, and optional `live_view_url` / `interactive_live_view_url`.
+
+**Stop the session:**
+
+```rust
+app.stop_interaction(job_id).await?;
+```
+
+## Notes
+
+- Struct fields use **snake_case** (e.g. `only_main_content`, `skip_tls_verification`). They serialize to **camelCase** JSON automatically.
+- All option structs derive `Default`, so use `..Default::default()` to fill unset fields.
+- Methods accept `impl Into<Option<ScrapeOptions>>` and `impl Into<Option<SearchOptions>>`, so you can pass `None`, a bare struct, or `Some(struct)`.
+- The `interact` method requires `ScrapeExecuteOptions` directly (not wrapped in `Option`) since at least `code` or `prompt` must be set.
+- **Deprecated aliases** (use the preferred names instead):
+  - `scrape_execute()` → `interact()`
+  - `stop_interactive_browser()` / `delete_scrape_browser()` → `stop_interaction()`
+
+## Source Of Truth
+
+- `firecrawl/apps/rust-sdk/src/v2/client.rs`
+- `firecrawl/apps/rust-sdk/src/v2/search.rs`
+- `firecrawl/apps/rust-sdk/src/v2/scrape.rs`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs.json
+++ b/docs.json
@@ -650,6 +650,16 @@
                     ]
                   },
                   {
+                    "group": "Agent Quickstarts",
+                    "pages": [
+                      "agent-quickstart/node",
+                      "agent-quickstart/python",
+                      "agent-quickstart/rust",
+                      "agent-quickstart/java",
+                      "agent-quickstart/elixir"
+                    ]
+                  },
+                  {
                     "group": "LLM SDKs and Frameworks",
                     "pages": [
                       "developer-guides/llm-sdks-and-frameworks/openai",


### PR DESCRIPTION
## Summary

- Add canonical agent quickstart documents for **Node.js/TypeScript**, **Python**, **Rust**, **Java**, and **Elixir** under `agent-quickstart/`
- Each file covers `search`, `scrape`, and `interact` endpoints with install instructions, auth patterns, exact SDK method names, realistic examples, and every confirmed parameter with descriptions
- Generated from SDK source code and OpenAPI spec as source of truth — no invented parameters or behavior
- Add "Agent Quickstarts" navigation group in the Build with AI tab of `docs.json`

## What's in each quickstart

| File | Package | Key methods |
|---|---|---|
| `node.mdx` | `@mendable/firecrawl-js` | `scrape()`, `search()`, `interact()` |
| `python.mdx` | `firecrawl-py` | `scrape()`, `search()`, `interact()` |
| `rust.mdx` | `firecrawl` crate | `scrape()`, `search()`, `interact()` |
| `java.mdx` | `com.firecrawl:firecrawl-java` | `scrape()`, `search()`, `interact()` |
| `elixir.mdx` | `:firecrawl` hex | `scrape_and_extract_from_url()`, `search_and_scrape()`, `interact_with_scrape_browser_session()` |

## Language-specific notes documented

- Python and JS SDKs support `prompt` as an alternative to `code` in `interact`; Java and Elixir only support `code`
- Elixir SDK is OpenAPI-generated with longer function names and keyword-list parameters
- Deprecated aliases documented as migration notes in each file's Notes section
- Parameter naming conventions documented per language (camelCase for JS/Java, snake_case for Python/Rust/Elixir)

## Test plan

- [ ] Verify each `.mdx` file renders cleanly in the Mintlify dev server
- [ ] Confirm navigation shows "Agent Quickstarts" group in the Build with AI tab
- [ ] Spot-check parameter lists against SDK source for accuracy

---
_Generated by [Claude Code](https://claude.ai/code/session_0132sk6mQRjtfqJPeepnQZTn)_