### PR TITLE
docs(agent): clean up dead nav group and cross-link agent docs

### DIFF
--- a/advanced-scraping-guide.mdx
+++ b/advanced-scraping-guide.mdx
@@ -459,6 +459,8 @@ curl -X POST https://api.firecrawl.dev/v2/scrape \
 
 Use the `/v2/agent` endpoint for autonomous, multi-page data extraction. The agent runs asynchronously: you start a job, then poll for results.
 
+[Agent](/features/agent) is the canonical reference for this endpoint, including execution traces, webhooks, and the full parameter list.
+
 ### Agent options
 
 | Parameter | Type | Default | Description |
@@ -469,6 +471,7 @@ Use the `/v2/agent` endpoint for autonomous, multi-page data extraction. The age
 | `maxCredits` | `number` | `2500` | Maximum credits the agent can spend. The dashboard supports up to 2,500; for higher limits, set this via the API (values above 2,500 are always billed as paid requests). |
 | `strictConstrainToURLs` | `boolean` | `false` | When `true`, the agent only visits the provided URLs. |
 | `model` | `string` | `"spark-2"` | AI model to use. Spark 1 models are deprecated and currently route to `"spark-2"`. |
+| `effort` | `string` | _(unset)_ | Reasoning budget: `"low"`, `"medium"`, or `"high"`. Every run executes on `"spark-2"`, so you can send `effort` with or without `model`. |
 
 <CodeGroup>
 

--- a/docs.json
+++ b/docs.json
@@ -201,13 +201,7 @@
                       "features/parse",
                       "features/map",
                       "features/crawl",
-                      "features/agent",
-                      {
-                        "group": "Agent (Research Preview)",
-                        "hidden": true,
-                        "icon": "robot",
-                        "pages": []
-                      }
+                      "features/agent"
                     ]
                   },
                   {

--- a/features/agent.mdx
+++ b/features/agent.mdx
@@ -99,6 +99,7 @@ Agent jobs run asynchronously. When you submit a job, you'll receive a Job ID th
 
 - **Default method**: `agent()` waits and returns final results
 - **Start then poll**: Use `start_agent` (Python) or `startAgent` (Node) to get a Job ID immediately, then poll with `get_agent_status` / `getAgentStatus`
+- **Push instead of poll**: Pass a `webhook` when you start the job to receive [agent events](/webhooks/events#agent-events) as the run progresses and finishes
 
 <Note>Job results are available via the API for 24 hours after completion. After this period, you can still view your agent history and results in the [activity logs](https://www.firecrawl.dev/app/logs).</Note>
 

--- a/sdks/node.mdx
+++ b/sdks/node.mdx
@@ -18,6 +18,8 @@ import MapNodeShort from '/snippets/v2/map/short/js.mdx'
 import ExtractNodeShort from '/snippets/v2/extract/short/js.mdx'
 import CrawlWebSocketNodeBase from '/snippets/v2/crawl-websocket/base/js.mdx'
 import PersistentJS from '/snippets/v2/browser/persistent/js.mdx'
+import AgentWithSchemaNode from '/snippets/v2/agent/with-schema/js.mdx'
+import AgentStatusNode from '/snippets/v2/agent/status/js.mdx'
 
 Scrape single pages, crawl entire sites, and map URLs from your Node.js application. The SDK handles pagination, retries, and async job polling so you can focus on working with the returned data.
 
@@ -108,6 +110,18 @@ Discover all URLs on a website with the `map` method. Pass a starting URL and ge
 To extract structured data from websites with error handling, use the `extractUrl` method. It takes the starting URL as a parameter and returns the extracted data as a dictionary.
 
 <ExtractNodeShort /> */}
+
+### Running an Agent
+
+Hand a research or extraction task to an agent with the `agent` method. Pass a `prompt`, an optional `schema` to shape the output, and `maxCredits` to cap what the run can spend.
+
+<AgentWithSchemaNode />
+
+Agent runs are asynchronous. Use `startAgent` to get a job ID back immediately, then poll it with `getAgentStatus`.
+
+<AgentStatusNode />
+
+Every run also records an execution trace and output snapshots, which you can read with `getAgentTrace` and `getAgentSnapshot`. See [Agent](/features/agent) for the event schema and the full parameter list.
 
 ### Crawling a Website with WebSockets
 

--- a/sdks/python.mdx
+++ b/sdks/python.mdx
@@ -19,6 +19,8 @@ import ScrapeAndCrawlExamplePython from '/snippets/v2/scrape-and-crawl/python.md
 import CrawlWebSocketPythonBase from '/snippets/v2/crawl-websocket/base/python.mdx'
 import PersistentPython from '/snippets/v2/browser/persistent/python.mdx'
 import AIOPython from '/snippets/v2/async/base/python.mdx'
+import AgentWithSchemaPython from '/snippets/v2/agent/with-schema/python.mdx'
+import AgentStatusPython from '/snippets/v2/agent/status/python.mdx'
 
 ## Installation
 
@@ -108,6 +110,18 @@ Use `map` to generate a list of URLs from a website. The options let you customi
 To extract structured data from websites, use the `extract` method. It takes the URLs to extract data from, a prompt, and a schema as arguments. The schema is a Pydantic model that defines the structure of the extracted data.
 
 <ExtractPythonShort /> */}
+
+### Run an Agent
+
+Hand a research or extraction task to an agent with the `agent` method. It takes a `prompt`, an optional `schema` to shape the output, and `max_credits` to cap what the run can spend.
+
+<AgentWithSchemaPython />
+
+Agent runs are asynchronous. Use `start_agent` to get a job ID back immediately, then poll it with `get_agent_status`.
+
+<AgentStatusPython />
+
+Every run also records an execution trace and output snapshots, which you can read with `get_agent_trace` and `get_agent_snapshot`. See [Agent](/features/agent) for the event schema and the full parameter list.
 
 ### Crawling a Website with WebSockets
 

--- a/webhooks/events.mdx
+++ b/webhooks/events.mdx
@@ -252,6 +252,8 @@ Sent when extraction fails. The `error` field contains the failure reason.
 
 ## Agent Events
 
+Sent for jobs started with a `webhook` on [`/v2/agent`](/features/agent).
+
 ### `agent.started`
 
 Sent when the agent job begins processing.


### PR DESCRIPTION
## Summary

Agent-docs housekeeping: a dead nav entry, missing cross-links between the async surfaces, one stale options table, and two SDK pages that never documented the endpoint.

- **docs.json**: deletes the empty hidden `Agent (Research Preview)` nav group (`"pages": []`) from the English navigation tree.
- **features/agent.mdx**: adds a "Push instead of poll" bullet in **Job Status and Completion** linking to [agent webhook events](/webhooks/events#agent-events).
- **webhooks/events.mdx**: adds a return link from `## Agent Events` back to [`/features/agent`](/features/agent).
- **advanced-scraping-guide.mdx**: points the **Agent endpoint** section at `/features/agent` as the canonical reference, and adds the missing `effort` row to the options table (verified against `agentRequestSchema` in `apps/api/src/controllers/v2/types.ts`).
- **sdks/node.mdx**: adds a **Running an Agent** section covering `agent`, `startAgent`, `getAgentStatus`, and a pointer to `getAgentTrace` / `getAgentSnapshot`, reusing the existing `snippets/v2/agent/` snippets.
- **sdks/python.mdx**: adds the same section for `agent`, `start_agent`, `get_agent_status`, `get_agent_trace`, and `get_agent_snapshot`.

The same dead nav group also exists in the `es`, `fr`, and `ja` navigation trees inside `docs.json`. Those trees are generated by the localization pipeline (`gt.config.json` lists `./docs.json` under its composite `$.navigation.languages` schema), so they're left for the bot to sync. No localized files touched.

## Verified, but deliberately left out

- **quickstart.mdx routing line.** The page is still the unmodified Mintlify starter template ("Start building awesome documentation in under 5 minutes", cards pointing at `/settings/global` and `/api-playground/configuration`) and is not referenced anywhere in `docs.json`. A Firecrawl capability pointer would be the only real content on a page that otherwise describes Mintlify. The page needs deleting or rewriting first, which is a bigger call than this PR.
- **The `webhook` option row** in the `advanced-scraping-guide.mdx` table. It's in the request schema, but the guide's table is deliberately a short subset and `/features/agent` documents it in full.

🤖 Generated with [Claude Code](https://claude.com/claude-code)