### PR TITLE
docs: stop advertising the github search category

### DIFF
--- a/agent-source-of-truth/curl.mdx
+++ b/agent-source-of-truth/curl.mdx
@@ -101,7 +101,7 @@ Successful responses include `success`, `data`, optional `warning`, `id`, and `c
   - Type: array of typed category objects
   - Use when: you want to filter results by category.
   - Confirmed object shapes:
-    - `{ "type": "github" }`
+    - `{ "type": "developer" }`
     - `{ "type": "research" }`
     - `{ "type": "pdf" }`
 

--- a/agent-source-of-truth/elixir.mdx
+++ b/agent-source-of-truth/elixir.mdx
@@ -92,10 +92,10 @@ Use search to discover relevant pages from a query, then pick URLs to scrape or 
   - Type: list of atoms, strings, or maps
   - Use when: you want to filter results by category.
   - Confirmed values:
-    - `"github"` or `:github`
+    - `"developer"` or `:developer`
     - `"research"` or `:research`
     - `"pdf"` or `:pdf`
-    - `%{type: "github" | "research" | "pdf"}`
+    - `%{type: "developer" | "research" | "pdf"}`
 
 - `limit`
   - Type: integer

--- a/agent-source-of-truth/java.mdx
+++ b/agent-source-of-truth/java.mdx
@@ -119,10 +119,10 @@ SearchData results = client.search("site:docs.firecrawl.dev crawl webhooks", opt
   - Type: List of category strings or maps
   - Use when: you want to filter results by category.
   - Confirmed values:
-    - `"github"`: GitHub-focused results
+    - `"developer"`: Developer Index results
     - `"research"`: research and academic results
     - `"pdf"`: PDF-focused results
-    - `{type: "github" | "research" | "pdf"}`: typed category map form
+    - `{type: "developer" | "research" | "pdf"}`: typed category map form
 
 - `options.limit`
   - Type: Integer

--- a/agent-source-of-truth/node.mdx
+++ b/agent-source-of-truth/node.mdx
@@ -104,10 +104,10 @@ const results = await client.search("site:docs.firecrawl.dev crawl webhooks", {
   - Type: array of category names or typed category objects
   - Use when: you want to filter results by category.
   - Confirmed values:
-    - `"github"`: GitHub-focused results
+    - `"developer"`: Developer Index results
     - `"research"`: research and academic results
     - `"pdf"`: PDF-focused results
-    - `{ type: "github" | "research" | "pdf" }`: typed category object form
+    - `{ type: "developer" | "research" | "pdf" }`: typed category object form
 
 - `options.limit`
   - Type: number

--- a/agent-source-of-truth/python.mdx
+++ b/agent-source-of-truth/python.mdx
@@ -112,10 +112,10 @@ results = client.search(
   - Type: list of category names or `Category` objects
   - Use when: you want to filter results by category.
   - Confirmed values:
-    - `"github"`: GitHub-focused results
+    - `"developer"`: Developer Index results
     - `"research"`: research and academic results
     - `"pdf"`: PDF-focused results
-    - `Category(type="github" | "research" | "pdf")`: typed category object form
+    - `Category(type="developer" | "research" | "pdf")`: typed category object form
 
 - `limit`
   - Type: int

--- a/agent-source-of-truth/rust.mdx
+++ b/agent-source-of-truth/rust.mdx
@@ -111,7 +111,7 @@ let results = client
 - `options.categories`
   - Type: `Vec<SearchCategory>`
   - Use when: you want to filter results by category.
-  - Confirmed values: `Github`, `Research`, `Pdf`
+  - Confirmed values: `Research`, `Pdf`
 
 - `options.limit`
   - Type: u32

--- a/api-reference/endpoint/search.mdx
+++ b/api-reference/endpoint/search.mdx
@@ -47,7 +47,6 @@ Examples: `"US"`, `"DE"`, `"FR"`, `"JP"`, `"UK"`, `"CA"`.
 
 Filter search results by specific categories using the `categories` parameter:
 
-- **`github`**: Search within GitHub repositories, code, issues, and documentation
 - **`research`**: Restrict web search to academic and research **websites** (arxiv.org, nature.com, ieee.org, pubmed.ncbi.nlm.nih.gov, biorxiv.org, medrxiv.org, and similar). Returns ordinary web page results with snippets — not paper records
 - **`pdf`**: Search for PDFs
 - **`developer`**: Search the [Developer Index](/features/developer) — issues, merged pull requests, and READMEs from public code repositories, alongside curated documentation sites
@@ -63,7 +62,7 @@ To search scientific literature directly — paper abstracts across PubMed, bioR
 ```json
 {
   "query": "machine learning",
-  "categories": ["github", "research"],
+  "categories": ["research", "pdf"],
   "limit": 10
 }
 ```
@@ -104,16 +103,16 @@ Each result includes a `category` field indicating its source:
   "data": {
     "web": [
       {
-        "url": "https://github.com/example/ml-project",
-        "title": "Machine Learning Project",
-        "description": "Implementation of ML algorithms",
-        "category": "github"
-      },
-      {
         "url": "https://arxiv.org/abs/2024.12345",
         "title": "ML Research Paper",
         "description": "Latest advances in machine learning",
         "category": "research"
+      },
+      {
+        "url": "https://example.com/ml-survey.pdf",
+        "title": "ML Survey",
+        "description": "A survey of machine learning methods",
+        "category": "pdf"
       }
     ]
   }

--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -3924,12 +3924,12 @@
                       "oneOf": [
                         {
                           "type": "object",
-                          "title": "GitHub",
+                          "title": "Developer",
                           "properties": {
                             "type": {
                               "type": "string",
                               "enum": [
-                                "github"
+                                "developer"
                               ]
                             }
                           },

--- a/developer-guides/cookbooks/ai-research-assistant-cookbook.mdx
+++ b/developer-guides/cookbooks/ai-research-assistant-cookbook.mdx
@@ -535,7 +535,7 @@ export default ChatBotDemo;
         location: z.string().optional().describe('Location for localized results'),
         tbs: z.string().optional().describe('Time filter (qdr:h, qdr:d, qdr:w, qdr:m, qdr:y)'),
         sources: z.array(z.enum(['web', 'news', 'images'])).optional().describe('Result types'),
-        categories: z.array(z.enum(['github', 'research', 'pdf'])).optional().describe('Filter categories'),
+        categories: z.array(z.enum(['developer', 'research', 'pdf'])).optional().describe('Filter categories'),
       }),
       execute: async ({ query, limit, location, tbs, sources, categories }) => {
         console.log('Searching:', query);

--- a/features/search.mdx
+++ b/features/search.mdx
@@ -104,7 +104,6 @@ You can request multiple sources in a single call (e.g., `sources: ["web", "news
 
 Filter search results by specific categories using the `categories` parameter:
 
-- `github`: Search within GitHub repositories, code, issues, and documentation
 - `research`: Restrict web search to academic and research **websites** (arxiv.org, nature.com, ieee.org, pubmed.ncbi.nlm.nih.gov, biorxiv.org, medrxiv.org, and similar). Returns ordinary web page results with snippets — not paper records. To search papers themselves, use the [Research Index](/features/research)
 - `pdf`: Search for PDFs
 - `developer`: Search the [Developer Index](/features/developer) — issues, merged pull requests, and READMEs from public code repositories, alongside curated documentation sites
@@ -114,21 +113,6 @@ Filter search results by specific categories using the `categories` parameter:
 
 If you want to search scientific literature — full abstracts, in-paper passage reads, and citation-graph expansion over a paper index of PubMed, bioRxiv, medRxiv, and arXiv — use the [Research Index](/features/research) instead.
 </Note>
-
-### GitHub Category Search
-
-Search specifically within GitHub repositories:
-
-```bash cURL
-curl -X POST https://api.firecrawl.dev/v2/search \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer fc-YOUR_API_KEY" \
-  -d '{
-    "query": "web scraping python",
-    "categories": ["github"],
-    "limit": 10
-  }'
-```
 
 ### Research Category Search
 
@@ -178,7 +162,7 @@ curl -X POST https://api.firecrawl.dev/v2/search \
   -H "Authorization: Bearer fc-YOUR_API_KEY" \
   -d '{
     "query": "neural networks",
-    "categories": ["github", "research"],
+    "categories": ["research", "pdf"],
     "limit": 15
   }'
 ```
@@ -227,16 +211,16 @@ Each search result includes a `category` field indicating its source:
   "data": {
     "web": [
       {
-        "url": "https://github.com/example/neural-network",
-        "title": "Neural Network Implementation",
-        "description": "A PyTorch implementation of neural networks",
-        "category": "github"
-      },
-      {
         "url": "https://arxiv.org/abs/2024.12345",
         "title": "Advances in Neural Network Architecture",
         "description": "Research paper on neural network improvements",
         "category": "research"
+      },
+      {
+        "url": "https://example.com/neural-networks.pdf",
+        "title": "Neural Networks Survey",
+        "description": "A survey of neural network architectures",
+        "category": "pdf"
       }
     ]
   }

--- a/sdks/cli.mdx
+++ b/sdks/cli.mdx
@@ -171,7 +171,7 @@ Search the web and optionally scrape the results.
 | ---------------------------- | ------------------------------------------------------------------------------------------- |
 | `--limit <number>`           | Maximum results (default: 5, max: 100)                                                      |
 | `--sources <sources>`        | Sources to search: `web`, `images`, `news` (comma-separated)                                |
-| `--categories <categories>`  | Filter by category: `github`, `research`, `pdf`, `developer` (comma-separated)                           |
+| `--categories <categories>`  | Filter by category: `research`, `pdf`, `developer` (comma-separated)                           |
 | `--tbs <value>`              | Time filter: `qdr:h` (hour), `qdr:d` (day), `qdr:w` (week), `qdr:m` (month), `qdr:y` (year) |
 | `--location <location>`      | Geo-targeting (e.g., "Berlin,Germany")                                                      |
 | `--country <code>`           | ISO country code (default: US)                                                              |

--- a/snippets/v2/cli/search/options.mdx
+++ b/snippets/v2/cli/search/options.mdx
@@ -3,7 +3,7 @@
 firecrawl search "AI" --sources web,news,images
 
 # Search with category filters
-firecrawl search "react hooks" --categories github
+firecrawl search "react hooks" --categories developer
 firecrawl search "machine learning" --categories research,pdf
 
 # Time-based filtering


### PR DESCRIPTION
## Why

The `github` search category still returns GitHub-hosted web results, while `developer` hits the Developer Index. Live Search docs, the API playground schema, CLI examples, and agent source-of-truth files still lead with `categories: ["github"]`, so coding traffic never reaches the index. This change stops advertising that flag on English docs so new traffic uses `developer` instead. The API continues to accept `github`; this is a documentation change only. Research category docs are unchanged.

## Summary

- Remove the GitHub category bullet, dedicated example section, and mixed-category `github` examples from `/features/search` and `/api-reference/endpoint/search`.
- Replace the OpenAPI `/search` category playground option `github` with `developer` so Try-it-out and generated examples no longer default to GitHub.
- Point CLI examples and the research-assistant cookbook enum at `developer`.
- Update agent source-of-truth category lists to `developer` (Rust lists only `Research` and `Pdf`, because the published SDK enum has no `Developer` variant).
- English sources only. Locale copies are left for the translation pipeline.

## Test plan

- [x] Open `/features/search`. Confirm there is no GitHub Category Search heading and no `categories: ["github"]` example. Confirm Developer Category Search and mixed `["research", "pdf"]` remain.
- [ ] Open `/api-reference/endpoint/search`. Confirm the categories list and examples have no `github`. Confirm the playground schema first option is Developer.
- [ ] Open `/sdks/cli`. Confirm `--categories developer` in the options snippet and that the options table lists `research`, `pdf`, `developer` only.
- [ ] Open `/agent-source-of-truth/python` (and node/curl/java/elixir). Confirm confirmed values list `developer`, not `github`.
- [ ] Open `/agent-source-of-truth/rust`. Confirm confirmed values are `Research`, `Pdf` only.
- [ ] Confirm locale files (`es/`, `fr/`, `ja/`, `zh/`, `pt-BR/`) were not modified.
- [ ] Confirm `/features/research` and `/features/developer` were not modified.