### PR TITLE
docs: add agent quickstart guides for all SDK languages

### DIFF
--- a/agent-quickstart/elixir.mdx
+++ b/agent-quickstart/elixir.mdx
@@ -1,0 +1,236 @@
+---
+title: "Elixir Agent Quickstart"
+description: "Canonical Firecrawl Elixir quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Elixir Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl using the Elixir SDK. It is generated from SDK source and the OpenAPI spec.
+
+## Install
+
+Add to your `mix.exs` dependencies:
+
+```elixir
+{:firecrawl, "~> 1.10"}
+```
+
+Then run:
+
+```bash
+mix deps.get
+```
+
+## Authenticate
+
+Pass the API key as a runtime option on each call:
+
+```elixir
+opts = [api_key: "fc-YOUR_API_KEY"]
+```
+
+To use a self-hosted instance:
+
+```elixir
+opts = [api_key: "fc-YOUR_API_KEY", base_url: "https://your-instance.com"]
+```
+
+## When To Use What
+
+- **`search_and_scrape`**: Use when you start with a query and need to discover relevant pages across the web.
+- **`scrape_and_extract_from_url`**: Use when you already have a URL and want its content (markdown, HTML, structured data, screenshots, etc.).
+- **`interact_with_scrape_browser_session`**: Use when a page needs post-scrape browser actions — clicking, filling forms, executing code in a live browser session.
+
+## Search
+
+### Why use it
+
+Search the web for a query and optionally scrape each result in one call. Returns results grouped by source type (web, news, images).
+
+### Preferred SDK function
+
+```elixir
+Firecrawl.search_and_scrape(params, opts)
+Firecrawl.search_and_scrape!(params, opts)
+```
+
+The bang variant (`!`) raises on error instead of returning `{:error, ...}`.
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.search_and_scrape(
+  [
+    query: "firecrawl web scraping API",
+    limit: 5,
+    scrape_options: [formats: ["markdown"]]
+  ],
+  api_key: "fc-YOUR_API_KEY"
+)
+
+IO.inspect(response.body)
+```
+
+### Parameters
+
+Parameters are a keyword list (first argument).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `query` | `:string` | **Yes** | The search query string. |
+| `sources` | `{:list, :any}` | No | Sources to search: `"web"`, `"news"`, `"images"`. Default: `["web"]`. |
+| `categories` | `{:list, :any}` | No | Filter results: `"github"`, `"research"`, `"pdf"`, `"developer"`. |
+| `include_domains` | `{:list, :string}` | No | Restrict results to these domains. |
+| `exclude_domains` | `{:list, :string}` | No | Exclude results from these domains. |
+| `limit` | `:integer` | No | Max results per source type. Default: `10`. Max: `100`. |
+| `tbs` | `:string` | No | Time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `:string` | No | Geographic location string. |
+| `country` | `:string` | No | ISO country code for geo-targeting. |
+| `ignore_invalid_urls` | `:boolean` | No | Exclude invalid URLs from results. Default: `false`. |
+| `timeout` | `:integer` | No | Timeout in milliseconds. Default: `60000`. |
+| `highlights` | `:boolean` | No | Generate query-relevant highlights. Default: `true`. |
+| `scrape_options` | `:keyword_list` | No | Options applied when scraping each result. |
+| `enterprise` | `{:list, :string}` | No | Enterprise ZDR options. |
+
+### Return type
+
+`{:ok, %Req.Response{}}` or `{:error, exception}`. The response body contains `"data"` with `"web"`, `"news"`, `"images"` arrays.
+
+## Scrape
+
+### Why use it
+
+Scrape a single URL and get back clean markdown, HTML, structured JSON, screenshots, or other formats. Supports browser actions, location targeting, and caching.
+
+### Preferred SDK function
+
+```elixir
+Firecrawl.scrape_and_extract_from_url(params, opts)
+Firecrawl.scrape_and_extract_from_url!(params, opts)
+```
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.scrape_and_extract_from_url(
+  [
+    url: "https://example.com",
+    formats: ["markdown", "links"]
+  ],
+  api_key: "fc-YOUR_API_KEY"
+)
+
+data = response.body["data"]
+IO.puts(data["markdown"])
+```
+
+### Parameters
+
+Parameters are a keyword list (first argument).
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `url` | `:string` | **Yes** | The URL to scrape. |
+| `formats` | `{:list, :any}` | No | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`, or maps with format-specific options. Default: `["markdown"]`. |
+| `only_main_content` | `:boolean` | No | Extract main content only. Default: `true`. |
+| `include_tags` | `{:list, :string}` | No | HTML tags to include. |
+| `exclude_tags` | `{:list, :string}` | No | HTML tags to exclude. |
+| `headers` | `:any` | No | Custom HTTP headers. |
+| `timeout` | `:integer` | No | Timeout in milliseconds. Default: `60000`. |
+| `wait_for` | `:integer` | No | Extra delay in ms before fetching content. Default: `0`. |
+| `mobile` | `:boolean` | No | Emulate a mobile device. Default: `false`. |
+| `actions` | `{:list, :any}` | No | Browser actions: wait, click, write, press, scroll, screenshot, scrape, executeJavascript, pdf. |
+| `location` | `:keyword_list` | No | Location targeting with `country` and `languages`. |
+| `skip_tls_verification` | `:boolean` | No | Skip TLS verification. Default: `true`. |
+| `remove_base64_images` | `:boolean` | No | Remove base64 images from markdown. Default: `true`. |
+| `block_ads` | `:boolean` | No | Block ads and cookie popups. Default: `true`. |
+| `proxy` | `:basic \| :enhanced \| :auto` | No | Proxy type. Default: `"auto"`. |
+| `max_age` | `:integer` | No | Cache max age in milliseconds. Default: `172800000` (2 days). |
+| `min_age` | `:integer` | No | Cache-only: minimum cache age in ms. |
+| `store_in_cache` | `:boolean` | No | Store result in cache. Default: `true`. |
+| `lockdown` | `:boolean` | No | Cache-only mode. Default: `false`. |
+| `parsers` | `{:list, :any}` | No | File parser configs. Default: `["pdf"]`. |
+| `redact_pii` | `:boolean` | No | Redact PII from markdown. Default: `false`. |
+| `profile` | `:keyword_list` | No | Persistent browser profile. |
+| `audit_metadata` | `:keyword_list` | No | User attribution for SIEM logging (requires `username`). |
+| `zero_data_retention` | `:boolean` | No | Enable zero data retention for this scrape. |
+
+### Return type
+
+`{:ok, %Req.Response{}}` or `{:error, exception}`. The response body `"data"` contains the scraped document fields.
+
+## Interact
+
+### Why use it
+
+Run code in the live browser session of an existing scrape job. Use it for clicks, form fills, navigation, or any post-scrape browser automation.
+
+### Preferred SDK function
+
+```elixir
+Firecrawl.interact_with_scrape_browser_session(job_id, params, opts)
+Firecrawl.interact_with_scrape_browser_session!(job_id, params, opts)
+```
+
+### Example
+
+```elixir
+# First, scrape a page to get a job ID
+{:ok, scrape_response} = Firecrawl.scrape_and_extract_from_url(
+  [url: "https://example.com"],
+  api_key: "fc-YOUR_API_KEY"
+)
+
+job_id = scrape_response.body["data"]["metadata"]["scrapeId"]
+
+# Then interact with the browser session
+{:ok, response} = Firecrawl.interact_with_scrape_browser_session(
+  job_id,
+  [
+    code: ~s|document.querySelector("button.submit").click();|,
+    language: :node
+  ],
+  api_key: "fc-YOUR_API_KEY"
+)
+
+IO.inspect(response.body)
+```
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `job_id` | `String.t()` | **Yes** | The scrape job ID (path parameter). |
+| `code` | `:string` | **Yes** | Code to execute in the browser sandbox. |
+| `language` | `:python \| :node \| :bash` | No | Runtime language. Default: `"node"`. |
+| `timeout` | `:integer` | No | Execution timeout in seconds. Default: `30`. Min: `1`, Max: `300`. |
+| `origin` | `:string` | No | Origin label for execution telemetry. |
+
+### Return type
+
+`{:ok, %Req.Response{}}` or `{:error, exception}`. The response body contains `.success`, `.stdout`, `.result`, `.stderr`, `.exitCode`, `.error`.
+
+### Stopping a session
+
+```elixir
+Firecrawl.stop_interactive_scrape_browser_session(job_id, api_key: "fc-YOUR_API_KEY")
+```
+
+## Notes
+
+- **Naming style**: All parameters use snake_case atoms in keyword lists. The SDK serializes to camelCase for the API.
+- **OpenAPI-generated**: The Elixir SDK is generated from the OpenAPI spec. Function names reflect the API operation IDs rather than shortened aliases.
+- **Function naming**:
+  - Search: `search_and_scrape` (not `search`)
+  - Scrape: `scrape_and_extract_from_url` (not `scrape`)
+  - Interact: `interact_with_scrape_browser_session` (not `interact`)
+  - Stop interaction: `stop_interactive_scrape_browser_session`
+- **Bang variants**: Every function has a `!` variant that raises `Firecrawl.Error` on non-2xx responses instead of returning `{:error, ...}`.
+- **Req-based**: The SDK uses the `Req` HTTP library. Runtime options (second or third argument) accept `:api_key`, `:base_url`, and any `Req` option.
+- **No deprecated aliases**: The Elixir SDK has no deprecated function names.
+
+## Source Of Truth
+
+- `firecrawl/apps/elixir-sdk/lib/firecrawl.ex`
+- `firecrawl/apps/elixir-sdk/mix.exs`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/java.mdx
+++ b/agent-quickstart/java.mdx
@@ -1,0 +1,257 @@
+---
+title: "Java Agent Quickstart"
+description: "Canonical Firecrawl Java quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Java Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl using the Java SDK. It is generated from SDK source and the OpenAPI spec.
+
+## Install
+
+### Maven
+
+```xml
+<dependency>
+    <groupId>com.firecrawl</groupId>
+    <artifactId>firecrawl-java</artifactId>
+    <version>1.16.0</version>
+</dependency>
+```
+
+### Gradle
+
+```groovy
+implementation 'com.firecrawl:firecrawl-java:1.16.0'
+```
+
+Requires Java 11+.
+
+## Authenticate
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey("fc-YOUR_API_KEY")
+    .build();
+```
+
+Builder defaults: `apiUrl` = `"https://api.firecrawl.dev"`, `timeoutMs` = `300000`, `maxRetries` = `3`, `backoffFactor` = `0.5`.
+
+## When To Use What
+
+- **`search`**: Use when you start with a query and need to discover relevant pages across the web.
+- **`scrape`**: Use when you already have a URL and want its content (markdown, HTML, structured data, screenshots, etc.).
+- **`interact`**: Use when a page needs post-scrape browser actions — clicking, filling forms, executing code in a live browser session.
+
+## Search
+
+### Why use it
+
+Search the web for a query and optionally scrape each result in one call. Returns results grouped by source type (web, news, images).
+
+### Preferred SDK method
+
+```java
+client.search(query)
+client.search(query, options)
+```
+
+### Example
+
+```java
+import com.firecrawl.models.SearchOptions;
+import com.firecrawl.models.SearchData;
+
+SearchData results = client.search("firecrawl web scraping API",
+    SearchOptions.builder()
+        .limit(5)
+        .build()
+);
+
+if (results.getWeb() != null) {
+    for (var item : results.getWeb()) {
+        System.out.println(item.get("title") + " " + item.get("url"));
+    }
+}
+```
+
+### Parameters
+
+Parameters are fields on `SearchOptions` (builder pattern).
+
+| Field | Type | Description |
+|---|---|---|
+| `sources` | `List<Object>` | Sources to search: `"web"`, `"news"`, `"images"`. Default: `["web"]`. |
+| `categories` | `List<Object>` | Filter results: `"github"`, `"research"`, `"pdf"`, `"developer"`. |
+| `includeDomains` | `List<String>` | Restrict results to these domains. Cannot be used with `excludeDomains`. |
+| `excludeDomains` | `List<String>` | Exclude results from these domains. Cannot be used with `includeDomains`. |
+| `limit` | `Integer` | Max results per source type. Default: `10`. Max: `100`. |
+| `tbs` | `String` | Time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `String` | Geographic location string. |
+| `ignoreInvalidURLs` | `Boolean` | Exclude URLs invalid for other Firecrawl endpoints. Default: `false`. |
+| `timeout` | `Integer` | Timeout in milliseconds. Default: `60000`. |
+| `highlights` | `Boolean` | Generate query-relevant highlights. Default: `true`. |
+| `scrapeOptions` | `ScrapeOptions` | Options applied when scraping each result. |
+| `integration` | `String` | Integration identifier for tracking. |
+
+### Return type
+
+`SearchData` with `.getWeb()`, `.getNews()`, `.getImages()` returning `List<Map<String, Object>>`.
+
+## Scrape
+
+### Why use it
+
+Scrape a single URL and get back clean markdown, HTML, structured JSON, screenshots, or other formats. Supports browser actions, location targeting, and caching.
+
+### Preferred SDK method
+
+```java
+client.scrape(url)
+client.scrape(url, options)
+```
+
+### Example
+
+```java
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.Document;
+import java.util.List;
+
+Document doc = client.scrape("https://example.com",
+    ScrapeOptions.builder()
+        .formats(List.of("markdown", "links"))
+        .build()
+);
+
+System.out.println(doc.getMarkdown());
+System.out.println(doc.getLinks());
+```
+
+#### Extracting structured JSON
+
+```java
+import com.firecrawl.models.JsonFormat;
+import java.util.Map;
+
+Document doc = client.scrape("https://example.com/pricing",
+    ScrapeOptions.builder()
+        .formats(List.of(new JsonFormat("Extract pricing tiers",
+            Map.of("type", "object", "properties", Map.of("tiers", Map.of("type", "array"))))))
+        .build()
+);
+
+System.out.println(doc.getJson());
+```
+
+### Parameters
+
+Parameters are fields on `ScrapeOptions` (builder pattern).
+
+| Field | Type | Description |
+|---|---|---|
+| `formats` | `List<Object>` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`, or format objects like `JsonFormat`, `QuestionFormat`, `HighlightsFormat`. Default: `["markdown"]`. |
+| `onlyMainContent` | `Boolean` | Extract main content only. Default: `true`. |
+| `includeTags` | `List<String>` | HTML tags to include. |
+| `excludeTags` | `List<String>` | HTML tags to exclude. |
+| `headers` | `Map<String, String>` | Custom HTTP headers. |
+| `timeout` | `Integer` | Timeout in milliseconds. Default: `60000`. Min: `1000`, Max: `300000`. |
+| `waitFor` | `Integer` | Extra delay in ms before fetching content. Default: `0`. |
+| `mobile` | `Boolean` | Emulate a mobile device. Default: `false`. |
+| `actions` | `List<Map<String, Object>>` | Browser actions: wait, click, write, press, scroll, screenshot, scrape, executeJavascript, pdf. |
+| `location` | `LocationConfig` | Location targeting with `country` and `languages`. |
+| `skipTlsVerification` | `Boolean` | Skip TLS verification. Default: `true`. |
+| `removeBase64Images` | `Boolean` | Remove base64 images from markdown. Default: `true`. |
+| `blockAds` | `Boolean` | Block ads and cookie popups. Default: `true`. |
+| `proxy` | `String` | Proxy type: `"basic"`, `"enhanced"`, `"auto"`. Default: `"auto"`. |
+| `maxAge` | `Long` | Cache max age in milliseconds. Default: `172800000` (2 days). |
+| `storeInCache` | `Boolean` | Store result in cache. Default: `true`. |
+| `lockdown` | `Boolean` | Cache-only mode. Default: `false`. |
+| `parsers` | `List<Object>` | File parser configs. Default: `["pdf"]`. |
+| `redactPII` | `Boolean` | Redact PII from markdown. Default: `false`. |
+| `auditMetadata` | `AuditMetadata` | User attribution for SIEM logging. |
+| `integration` | `String` | Integration identifier. |
+
+### Return type
+
+`Document` with getters for `.getMarkdown()`, `.getHtml()`, `.getJson()`, `.getScreenshot()`, `.getLinks()`, `.getMetadata()`, etc.
+
+## Interact
+
+### Why use it
+
+Run code in the live browser session of an existing scrape job. Use it for clicks, form fills, navigation, or any post-scrape browser automation.
+
+### Preferred SDK method
+
+```java
+client.interact(jobId, code)
+client.interact(jobId, code, language, timeout)
+client.interact(jobId, code, language, timeout, origin)
+```
+
+### Example
+
+```java
+import com.firecrawl.models.BrowserExecuteResponse;
+
+// First, scrape a page to get a job ID
+Document doc = client.scrape("https://example.com");
+String jobId = (String) doc.getMetadata().get("scrapeId");
+
+// Then interact with the browser session
+BrowserExecuteResponse response = client.interact(
+    jobId,
+    "document.querySelector('button.submit').click();"
+);
+
+System.out.println(response.getStdout());
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `jobId` | `String` | **Required.** The scrape job ID (from `metadata.scrapeId`). |
+| `code` | `String` | **Required.** Code to execute in the browser sandbox. |
+| `language` | `String` | Runtime language: `"python"`, `"node"`, `"bash"`. Default: `"node"`. |
+| `timeout` | `Integer` | Execution timeout in seconds. Default: `30`. Min: `1`, Max: `300`. |
+| `origin` | `String` | Origin label for execution telemetry. |
+
+### Return type
+
+`BrowserExecuteResponse` with `.isSuccess()`, `.getStdout()`, `.getResult()`, `.getStderr()`, `.getExitCode()`, `.isKilled()`, `.getError()`.
+
+### Stopping a session
+
+```java
+client.stopInteractiveBrowser(jobId);
+```
+
+### Async variants
+
+All methods have async counterparts returning `CompletableFuture`:
+
+```java
+CompletableFuture<Document> future = client.scrapeAsync(url, options);
+CompletableFuture<SearchData> future = client.searchAsync(query, options);
+CompletableFuture<BrowserExecuteResponse> future = client.interactAsync(jobId, code);
+```
+
+## Notes
+
+- **Naming style**: All parameters use camelCase.
+- **Builder pattern**: `ScrapeOptions`, `SearchOptions`, `BatchScrapeOptions`, and `ParseOptions` use the builder pattern.
+- **Format types**: Use `JsonFormat`, `QuestionFormat`, `HighlightsFormat` objects for rich format options. `QueryFormat` is deprecated.
+- **Interact**: The Java SDK takes `code` as a required positional parameter. For prompt-based interaction, use the REST API directly.
+- **Deprecated aliases** (migration only):
+  - `scrapeExecute()` → use `interact()`
+  - `deleteScrapeBrowser()` → use `stopInteractiveBrowser()`
+
+## Source Of Truth
+
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/node.mdx
+++ b/agent-quickstart/node.mdx
@@ -1,0 +1,233 @@
+---
+title: "Node.js Agent Quickstart"
+description: "Canonical Firecrawl Node.js/TypeScript quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Node.js Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl using the Node.js/TypeScript SDK. It is generated from SDK source and the OpenAPI spec.
+
+## Install
+
+```bash
+npm install @mendable/firecrawl-js
+```
+
+## Authenticate
+
+```typescript
+import Firecrawl from "@mendable/firecrawl-js";
+
+const client = new Firecrawl({ apiKey: "fc-YOUR_API_KEY" });
+```
+
+The API key can also be set via the `FIRECRAWL_API_KEY` environment variable. The default API URL is `https://api.firecrawl.dev` (override with `apiUrl` or `FIRECRAWL_API_URL`).
+
+## When To Use What
+
+- **`search`**: Use when you start with a query and need to discover relevant pages across the web.
+- **`scrape`**: Use when you already have a URL and want its content (markdown, HTML, structured data, screenshots, etc.).
+- **`interact`**: Use when a page needs post-scrape browser actions — clicking, filling forms, executing code in a live browser session.
+
+## Search
+
+### Why use it
+
+Search the web for a query and optionally scrape each result in one call. Returns results grouped by source type (web, news, images).
+
+### Preferred SDK method
+
+```typescript
+client.search(query, options?)
+```
+
+### Example
+
+```typescript
+const results = await client.search("firecrawl web scraping API", {
+  limit: 5,
+  scrapeOptions: { formats: ["markdown"] },
+});
+
+for (const item of results.web ?? []) {
+  console.log(item.title, item.url);
+}
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `string` | **Required.** The search query string. |
+| `sources` | `Array<"web" \| "news" \| "images">` | Sources to search. Default: `["web"]`. |
+| `categories` | `Array<"github" \| "research" \| "pdf" \| "developer">` | Filter results by category. |
+| `includeDomains` | `string[]` | Restrict results to these domains. Cannot be used with `excludeDomains`. |
+| `excludeDomains` | `string[]` | Exclude results from these domains. Cannot be used with `includeDomains`. |
+| `limit` | `number` | Max results per source type. Default: `10`. Max: `100`. |
+| `tbs` | `string` | Time-based search filter (e.g. `"qdr:d"` for past day, `"qdr:w"` for past week). |
+| `location` | `string` | Geographic location string (e.g. `"San Francisco,California,United States"`). |
+| `ignoreInvalidURLs` | `boolean` | Exclude URLs invalid for other Firecrawl endpoints. Default: `false`. |
+| `timeout` | `number` | Timeout in milliseconds. Default: `60000`. |
+| `highlights` | `boolean` | Generate query-relevant highlights. Default: `true`. |
+| `scrapeOptions` | `ScrapeOptions` | Options applied when scraping each result. Pass to get full page content. |
+| `enterprise` | `Array<"anon" \| "zdr">` | Enterprise zero-data-retention options. Must be enabled for your team. |
+| `threatProtection` | `ThreatProtectionOptions` | Per-request threat protection override. |
+| `integration` | `string` | Integration identifier for tracking. |
+
+### Return type
+
+`SearchData` with optional `.web`, `.news`, `.images` arrays depending on the sources requested.
+
+## Scrape
+
+### Why use it
+
+Scrape a single URL and get back clean markdown, HTML, structured JSON, screenshots, or other formats. Supports browser actions, location targeting, and caching.
+
+### Preferred SDK method
+
+```typescript
+client.scrape(url, options?)
+```
+
+### Example
+
+```typescript
+const doc = await client.scrape("https://example.com", {
+  formats: ["markdown", "links"],
+});
+
+console.log(doc.markdown);
+console.log(doc.links);
+```
+
+#### Extracting structured JSON
+
+```typescript
+const doc = await client.scrape("https://example.com/pricing", {
+  formats: [
+    {
+      type: "json",
+      prompt: "Extract pricing tiers",
+      schema: { type: "object", properties: { tiers: { type: "array" } } },
+    },
+  ],
+});
+
+console.log(doc.json);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `string` | **Required.** The URL to scrape. |
+| `formats` | `FormatOption[]` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`, or objects with format-specific options. Default: `["markdown"]`. |
+| `onlyMainContent` | `boolean` | Extract main content only, excluding headers/navs/footers. Default: `true`. |
+| `includeTags` | `string[]` | HTML tags to include in output. |
+| `excludeTags` | `string[]` | HTML tags to exclude from output. |
+| `headers` | `Record<string, string>` | Custom HTTP headers to send (cookies, user-agent, etc.). |
+| `timeout` | `number` | Timeout in milliseconds. Default: `60000`. Min: `1000`, Max: `300000`. |
+| `waitFor` | `number` | Extra delay in milliseconds before fetching content. Default: `0`. |
+| `mobile` | `boolean` | Emulate a mobile device. Default: `false`. |
+| `actions` | `ActionOption[]` | Browser actions to perform before grabbing content (wait, click, write, press, scroll, screenshot, scrape, executeJavascript, pdf). |
+| `location` | `LocationConfig` | Location targeting with `country` (ISO 3166-1 alpha-2) and `languages`. Default country: `"US"`. |
+| `skipTlsVerification` | `boolean` | Skip TLS certificate verification. Default: `true`. |
+| `removeBase64Images` | `boolean` | Remove base64 images from markdown output. Default: `true`. |
+| `fastMode` | `boolean` | Enable fast mode (quicker, less accurate). |
+| `blockAds` | `boolean` | Block ads and cookie popups. Default: `true`. |
+| `proxy` | `"basic" \| "stealth" \| "enhanced" \| "auto"` | Proxy type. Default: `"auto"`. |
+| `maxAge` | `number` | Cache max age in milliseconds. 0 to bypass cache. Default: `172800000` (2 days). |
+| `minAge` | `number` | Cache-only mode: minimum cache age in ms. Returns 404 on cache miss. |
+| `storeInCache` | `boolean` | Store result in Firecrawl cache. Default: `true`. |
+| `lockdown` | `boolean` | Serve only from cache, never make outbound requests. Default: `false`. |
+| `parsers` | `Array<string \| PDFParser>` | File parser configs. Default: `["pdf"]`. |
+| `redactPII` | `boolean \| RedactPIIOptions` | Redact PII from markdown. Pass `true` for defaults or an object to tune. |
+| `profile` | `{ name: string; saveChanges?: boolean }` | Persistent browser profile for shared session state. |
+| `threatProtection` | `ThreatProtectionOptions` | Per-request threat protection override. |
+| `auditMetadata` | `{ username: string }` | User attribution for SIEM logging. |
+| `integration` | `string` | Integration identifier. |
+| `autoResume` | `boolean` | SDK-only. Automatically retry on transient processing errors. Enabled by default. |
+
+### Return type
+
+`Document` with fields matching the requested formats (e.g. `.markdown`, `.html`, `.json`, `.screenshot`, `.links`, `.metadata`).
+
+## Interact
+
+### Why use it
+
+Run code or a natural-language prompt in the live browser session of an existing scrape job. Use it for clicks, form fills, navigation, or any post-scrape browser automation.
+
+### Preferred SDK method
+
+```typescript
+client.interact(jobId, args)
+```
+
+### Example
+
+```typescript
+// First, scrape a page to get a job ID
+const doc = await client.scrape("https://example.com", {
+  formats: ["markdown"],
+});
+const jobId = doc.metadata?.scrapeId;
+
+// Then interact with the browser session
+const response = await client.interact(jobId, {
+  code: `document.querySelector("button.submit").click();`,
+  language: "node",
+  timeout: 30,
+});
+
+console.log(response.stdout);
+```
+
+#### Using a prompt instead of code
+
+```typescript
+const response = await client.interact(jobId, {
+  prompt: "Click the login button and fill in the email field with test@example.com",
+});
+
+console.log(response.output);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `jobId` | `string` | **Required.** The scrape job ID (from `metadata.scrapeId`). |
+| `code` | `string` | Code to execute in the browser sandbox. Provide either `code` or `prompt`. |
+| `prompt` | `string` | Natural-language instruction for the browser agent. Provide either `code` or `prompt`. |
+| `language` | `"python" \| "node" \| "bash"` | Runtime language for code execution. Default: `"node"`. |
+| `timeout` | `number` | Execution timeout in seconds. Default: `30`. Min: `1`, Max: `300`. |
+| `origin` | `string` | Origin label for execution telemetry. |
+
+### Return type
+
+`ScrapeExecuteResponse` with `.success`, `.stdout`, `.result`, `.stderr`, `.exitCode`, `.output` (for prompt-based), `.liveViewUrl`, `.interactiveLiveViewUrl`, `.cdpUrl`.
+
+### Stopping a session
+
+```typescript
+await client.stopInteraction(jobId);
+```
+
+## Notes
+
+- **Naming style**: All parameters use camelCase.
+- **Async by default**: All methods return Promises.
+- **Auto-resume**: `scrape` automatically retries on transient `processing_continues` responses (up to 5 retries, 20 minutes max). Disable with `autoResume: false`.
+- **Deprecated aliases** (migration only):
+  - `scrapeUrl()` → use `scrape()`
+  - `scrapeExecute()` → use `interact()`
+  - `stopInteractiveBrowser()` / `deleteScrapeBrowser()` → use `stopInteraction()`
+
+## Source Of Truth
+
+- `firecrawl/apps/js-sdk/firecrawl/src/index.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/python.mdx
+++ b/agent-quickstart/python.mdx
@@ -1,0 +1,248 @@
+---
+title: "Python Agent Quickstart"
+description: "Canonical Firecrawl Python quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Python Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl using the Python SDK. It is generated from SDK source and the OpenAPI spec.
+
+## Install
+
+```bash
+pip install firecrawl-py
+```
+
+Requires Python 3.8+.
+
+## Authenticate
+
+```python
+from firecrawl import Firecrawl
+
+client = Firecrawl(api_key="fc-YOUR_API_KEY")
+```
+
+The API key can also be passed implicitly if set elsewhere. The default API URL is `https://api.firecrawl.dev` (override with `api_url`).
+
+For async usage:
+
+```python
+from firecrawl import AsyncFirecrawl
+
+client = AsyncFirecrawl(api_key="fc-YOUR_API_KEY")
+```
+
+## When To Use What
+
+- **`search`**: Use when you start with a query and need to discover relevant pages across the web.
+- **`scrape`**: Use when you already have a URL and want its content (markdown, HTML, structured data, screenshots, etc.).
+- **`interact`**: Use when a page needs post-scrape browser actions — clicking, filling forms, executing code in a live browser session.
+
+## Search
+
+### Why use it
+
+Search the web for a query and optionally scrape each result in one call. Returns results grouped by source type (web, news, images).
+
+### Preferred SDK method
+
+```python
+client.search(query, **kwargs)
+```
+
+### Example
+
+```python
+results = client.search(
+    "firecrawl web scraping API",
+    limit=5,
+    scrape_options={"formats": ["markdown"]},
+)
+
+for item in results.web or []:
+    print(item.title, item.url)
+```
+
+### Parameters
+
+All parameters after `query` are keyword-only.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `str` | **Required.** The search query string. |
+| `sources` | `list[str]` | Sources to search: `"web"`, `"news"`, `"images"`. Default: `["web"]`. |
+| `categories` | `list[str]` | Filter results: `"github"`, `"research"`, `"pdf"`, `"developer"`. |
+| `include_domains` | `list[str]` | Restrict results to these domains. Cannot be used with `exclude_domains`. |
+| `exclude_domains` | `list[str]` | Exclude results from these domains. Cannot be used with `include_domains`. |
+| `limit` | `int` | Max results per source type. Default: `5` (SDK), `10` (API). Max: `100`. |
+| `tbs` | `str` | Time-based search filter (e.g. `"qdr:d"` for past day, `"qdr:w"` for past week). |
+| `location` | `str` | Geographic location string (e.g. `"San Francisco,California,United States"`). |
+| `ignore_invalid_urls` | `bool` | Exclude URLs invalid for other Firecrawl endpoints. Default: `False`. |
+| `timeout` | `int` | Timeout in milliseconds. Default: `300000` (SDK). |
+| `highlights` | `bool` | Generate query-relevant highlights. Default: `True`. |
+| `scrape_options` | `ScrapeOptions \| dict` | Options applied when scraping each result. Pass to get full page content. |
+| `enterprise` | `list[str]` | Enterprise zero-data-retention options (`"anon"`, `"zdr"`). Must be enabled for your team. |
+| `threat_protection` | `ThreatProtectionOptions` | Per-request threat protection override. |
+| `integration` | `str` | Integration identifier for tracking. |
+
+### Return type
+
+`SearchData` with optional `.web`, `.news`, `.images` lists depending on the sources requested.
+
+## Scrape
+
+### Why use it
+
+Scrape a single URL and get back clean markdown, HTML, structured JSON, screenshots, or other formats. Supports browser actions, location targeting, and caching.
+
+### Preferred SDK method
+
+```python
+client.scrape(url, **kwargs)
+```
+
+### Example
+
+```python
+doc = client.scrape(
+    "https://example.com",
+    formats=["markdown", "links"],
+)
+
+print(doc.markdown)
+print(doc.links)
+```
+
+#### Extracting structured JSON
+
+```python
+doc = client.scrape(
+    "https://example.com/pricing",
+    formats=[
+        {
+            "type": "json",
+            "prompt": "Extract pricing tiers",
+            "schema": {"type": "object", "properties": {"tiers": {"type": "array"}}},
+        }
+    ],
+)
+
+print(doc.json)
+```
+
+### Parameters
+
+All parameters after `url` are keyword-only.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `str` | **Required.** The URL to scrape. |
+| `formats` | `list` | Output formats: `"markdown"`, `"html"`, `"rawHtml"` (or `"raw_html"`), `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"changeTracking"` (or `"change_tracking"`), `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`, or dicts with format-specific options. Default: `["markdown"]`. |
+| `only_main_content` | `bool` | Extract main content only, excluding headers/navs/footers. Default: `True`. |
+| `include_tags` | `list[str]` | HTML tags to include in output. |
+| `exclude_tags` | `list[str]` | HTML tags to exclude from output. |
+| `headers` | `dict[str, str]` | Custom HTTP headers (cookies, user-agent, etc.). |
+| `timeout` | `int` | Timeout in milliseconds. Default: `60000`. Min: `1000`, Max: `300000`. |
+| `wait_for` | `int` | Extra delay in milliseconds before fetching content. Default: `0`. |
+| `mobile` | `bool` | Emulate a mobile device. Default: `False`. |
+| `actions` | `list` | Browser actions before grabbing content (wait, click, write, press, scroll, screenshot, scrape, executeJavascript, pdf). |
+| `location` | `Location` | Location targeting with `country` (ISO 3166-1 alpha-2) and `languages`. Default country: `"US"`. |
+| `skip_tls_verification` | `bool` | Skip TLS certificate verification. Default: `True`. |
+| `remove_base64_images` | `bool` | Remove base64 images from markdown output. Default: `True`. |
+| `fast_mode` | `bool` | Enable fast mode (quicker, less accurate). |
+| `block_ads` | `bool` | Block ads and cookie popups. Default: `True`. |
+| `proxy` | `str` | Proxy type: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. Default: `"auto"`. |
+| `max_age` | `int` | Cache max age in milliseconds. 0 to bypass cache. Default: `172800000` (2 days). |
+| `store_in_cache` | `bool` | Store result in Firecrawl cache. Default: `True`. |
+| `lockdown` | `bool` | Serve only from cache, never make outbound requests. Default: `False`. |
+| `parsers` | `list` | File parser configs. Default: `["pdf"]`. |
+| `threat_protection` | `ThreatProtectionOptions` | Per-request threat protection override. |
+| `profile` | `dict` | Persistent browser profile (`{"name": "...", "save_changes": True}`). |
+| `audit_metadata` | `AuditMetadata` | User attribution for SIEM logging (`{"username": "..."}`). |
+| `integration` | `str` | Integration identifier. |
+| `auto_resume` | `bool` | SDK-only. Automatically retry on transient processing errors. Enabled by default. |
+
+### Return type
+
+`Document` with attributes matching the requested formats (e.g. `.markdown`, `.html`, `.json`, `.screenshot`, `.links`, `.metadata`).
+
+## Interact
+
+### Why use it
+
+Run code or a natural-language prompt in the live browser session of an existing scrape job. Use it for clicks, form fills, navigation, or any post-scrape browser automation.
+
+### Preferred SDK method
+
+```python
+client.interact(job_id, code=None, **kwargs)
+```
+
+### Example
+
+```python
+# First, scrape a page to get a job ID
+doc = client.scrape("https://example.com", formats=["markdown"])
+job_id = doc.metadata.scrape_id
+
+# Then interact with the browser session
+response = client.interact(
+    job_id,
+    code='document.querySelector("button.submit").click();',
+    language="node",
+    timeout=30,
+)
+
+print(response.stdout)
+```
+
+#### Using a prompt instead of code
+
+```python
+response = client.interact(
+    job_id,
+    prompt="Click the login button and fill in the email field with test@example.com",
+)
+
+print(response.output)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `str` | **Required.** The scrape job ID (from `metadata.scrape_id`). |
+| `code` | `str \| None` | Code to execute in the browser sandbox. Provide either `code` or `prompt`. |
+| `prompt` | `str \| None` | Natural-language instruction for the browser agent. Provide either `code` or `prompt`. |
+| `language` | `"python" \| "node" \| "bash"` | Runtime language for code execution. Default: `"node"`. |
+| `timeout` | `int \| None` | Execution timeout in seconds. Default: `30`. Min: `1`, Max: `300`. |
+| `origin` | `str \| None` | Origin label for execution telemetry. |
+
+### Return type
+
+`BrowserExecuteResponse` with `.success`, `.stdout`, `.result`, `.stderr`, `.exit_code`, `.output` (for prompt-based), `.live_view_url`, `.interactive_live_view_url`, `.cdp_url`.
+
+### Stopping a session
+
+```python
+client.stop_interaction(job_id)
+```
+
+## Notes
+
+- **Naming style**: All parameters use snake_case. The SDK serializes them to camelCase for the API.
+- **Format aliases**: `"raw_html"` and `"change_tracking"` are accepted as snake_case aliases for `"rawHtml"` and `"changeTracking"`.
+- **Async variant**: Use `AsyncFirecrawl` (aliased as `AsyncFirecrawlApp`) for async/await usage. Same methods and parameters.
+- **`redact_pii` and `min_age`**: Available on `ScrapeOptions` but not directly exposed as keyword arguments on `scrape()`. Pass them via a `ScrapeOptions` object in `search(scrape_options=...)`.
+- **Deprecated aliases** (migration only):
+  - `scrape_url()` → use `scrape()`
+  - `scrape_execute()` → use `interact()`
+  - `delete_scrape_browser()` / `stop_interactive_browser()` → use `stop_interaction()`
+
+## Source Of Truth
+
+- `firecrawl/apps/python-sdk/firecrawl/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/rust.mdx
+++ b/agent-quickstart/rust.mdx
@@ -1,0 +1,256 @@
+---
+title: "Rust Agent Quickstart"
+description: "Canonical Firecrawl Rust quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Rust Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl using the Rust SDK. It is generated from SDK source and the OpenAPI spec.
+
+## Install
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+firecrawl = "2"
+```
+
+## Authenticate
+
+```rust
+use firecrawl::Client;
+
+let client = Client::new("fc-YOUR_API_KEY")?;
+```
+
+For self-hosted instances:
+
+```rust
+let client = Client::new_selfhosted("https://your-instance.com", Some("fc-YOUR_API_KEY"))?;
+```
+
+## When To Use What
+
+- **`search`**: Use when you start with a query and need to discover relevant pages across the web.
+- **`scrape`**: Use when you already have a URL and want its content (markdown, HTML, structured data, screenshots, etc.).
+- **`interact`**: Use when a page needs post-scrape browser actions — clicking, filling forms, executing code in a live browser session.
+
+## Search
+
+### Why use it
+
+Search the web for a query and optionally scrape each result in one call. Returns results grouped by source type (web, news, images).
+
+### Preferred SDK method
+
+```rust
+client.search(query, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, SearchOptions, ScrapeOptions};
+
+let client = Client::new("fc-YOUR_API_KEY")?;
+
+let response = client.search("firecrawl web scraping API", SearchOptions {
+    limit: Some(5),
+    scrape_options: Some(ScrapeOptions::default()),
+    ..Default::default()
+}).await?;
+
+if let Some(web_results) = response.data.web {
+    for item in web_results {
+        println!("{:?}", item);
+    }
+}
+```
+
+There is also a convenience method that searches and returns only scraped documents:
+
+```rust
+let docs = client.search_and_scrape("firecrawl", 5).await?;
+```
+
+### Parameters
+
+Parameters are fields on the `SearchOptions` struct. All fields are `Option`.
+
+| Field | Type | Description |
+|---|---|---|
+| `limit` | `Option<u32>` | Max results per source type. Default: `5`. Max: `20`. |
+| `sources` | `Option<Vec<SearchSource>>` | Sources to search: `Web`, `News`, `Images`. Default: `[Web]`. |
+| `categories` | `Option<Vec<SearchCategory>>` | Filter results: `Github`, `Research`, `Pdf`. |
+| `include_domains` | `Option<Vec<String>>` | Restrict results to these domains. Cannot be used with `exclude_domains`. |
+| `exclude_domains` | `Option<Vec<String>>` | Exclude results from these domains. Cannot be used with `include_domains`. |
+| `tbs` | `Option<String>` | Time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `Option<String>` | Geographic location string. |
+| `ignore_invalid_urls` | `Option<bool>` | Exclude URLs invalid for other Firecrawl endpoints. Default: `false`. |
+| `timeout` | `Option<u32>` | Timeout in milliseconds. Default: `60000`. |
+| `highlights` | `Option<bool>` | Generate query-relevant highlights. Default: `true`. |
+| `scrape_options` | `Option<ScrapeOptions>` | Options applied when scraping each result. |
+| `integration` | `Option<String>` | Integration identifier for tracking. |
+| `origin` | `Option<String>` | Origin label. Auto-set to `"rust-sdk@{version}"` if not provided. |
+
+### Return type
+
+`SearchResponse` with `.data` (`SearchData`) containing optional `.web` (`Vec<SearchResultOrDocument>`), `.news`, `.images`.
+
+## Scrape
+
+### Why use it
+
+Scrape a single URL and get back clean markdown, HTML, structured JSON, screenshots, or other formats. Supports browser actions, location targeting, and caching.
+
+### Preferred SDK method
+
+```rust
+client.scrape(url, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, Format};
+
+let client = Client::new("fc-YOUR_API_KEY")?;
+
+let doc = client.scrape("https://example.com", ScrapeOptions {
+    formats: Some(vec![Format::Markdown, Format::Links]),
+    ..Default::default()
+}).await?;
+
+println!("{}", doc.markdown.unwrap_or_default());
+```
+
+#### Extracting structured JSON
+
+```rust
+use serde_json::json;
+
+let result = client.scrape_with_schema(
+    "https://example.com/pricing",
+    json!({"type": "object", "properties": {"tiers": {"type": "array"}}}),
+    Some("Extract pricing tiers"),
+).await?;
+
+println!("{}", result);
+```
+
+### Parameters
+
+Parameters are fields on the `ScrapeOptions` struct. All fields are `Option`.
+
+| Field | Type | Description |
+|---|---|---|
+| `formats` | `Option<Vec<Format>>` | Output formats: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `Json`, `ChangeTracking`, `Attributes`, `Branding`, `Product`, `Menu`, `Audio`, `Video`, `Question(QuestionFormat)`, `Highlights(HighlightsFormat)`. Default: `[Markdown]`. |
+| `only_main_content` | `Option<bool>` | Extract main content only. Default: `true`. |
+| `include_tags` | `Option<Vec<String>>` | HTML tags to include. |
+| `exclude_tags` | `Option<Vec<String>>` | HTML tags to exclude. |
+| `headers` | `Option<HashMap<String, String>>` | Custom HTTP headers. |
+| `timeout` | `Option<u32>` | Timeout in milliseconds. Default: `60000`. |
+| `wait_for` | `Option<u32>` | Extra delay in ms before fetching content. Default: `0`. |
+| `mobile` | `Option<bool>` | Emulate a mobile device. Default: `false`. |
+| `actions` | `Option<Vec<Action>>` | Browser actions: `Wait`, `Click`, `Write`, `Press`, `Scroll`, `Screenshot`, `Scrape`, `ExecuteJavascript`, `Pdf`. |
+| `location` | `Option<LocationConfig>` | Location targeting with `country` and `languages`. |
+| `skip_tls_verification` | `Option<bool>` | Skip TLS verification. Default: `true`. |
+| `remove_base64_images` | `Option<bool>` | Remove base64 images from markdown. Default: `true`. |
+| `fast_mode` | `Option<bool>` | Fast mode (quicker, less accurate). |
+| `block_ads` | `Option<bool>` | Block ads and cookie popups. Default: `true`. |
+| `proxy` | `Option<ProxyType>` | Proxy type: `Basic`, `Stealth`, `Enhanced`, `Auto`. Default: `Auto`. |
+| `max_age` | `Option<u32>` | Cache max age in seconds. |
+| `min_age` | `Option<u32>` | Cache-only: minimum cache age in seconds. |
+| `store_in_cache` | `Option<bool>` | Store result in cache. Default: `true`. |
+| `lockdown` | `Option<bool>` | Cache-only mode, no outbound requests. Default: `false`. |
+| `parsers` | `Option<Vec<ParserConfig>>` | File parser configs. Default: `["pdf"]`. |
+| `redact_pii` | `Option<bool>` | Redact PII from markdown. Default: `false`. |
+| `profile` | `Option<ProfileConfig>` | Persistent browser profile (`name`, `save_changes`). |
+| `audit_metadata` | `Option<AuditMetadata>` | User attribution for SIEM logging. |
+| `integration` | `Option<String>` | Integration identifier. |
+| `json_options` | `Option<JsonOptions>` | JSON extraction options (`schema`, `prompt`, `system_prompt`, `check_prompt_injection`). |
+| `screenshot_options` | `Option<ScreenshotOptions>` | Screenshot options (`full_page`, `quality`, `viewport`). |
+| `change_tracking_options` | `Option<ChangeTrackingOptions>` | Change tracking options (`modes`, `schema`, `prompt`, `tag`). |
+| `attribute_selectors` | `Option<Vec<AttributeSelector>>` | Attribute extraction selectors (`selector`, `attribute`). |
+| `origin` | `Option<String>` | Origin label. Auto-set to `"rust-sdk@{version}"` if not provided. |
+
+### Return type
+
+`Document` with optional fields matching requested formats (`.markdown`, `.html`, `.json`, `.screenshot`, `.links`, `.metadata`, etc.).
+
+## Interact
+
+### Why use it
+
+Run code or a natural-language prompt in the live browser session of an existing scrape job. Use it for clicks, form fills, navigation, or any post-scrape browser automation.
+
+### Preferred SDK method
+
+```rust
+client.interact(job_id, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, ScrapeExecuteOptions, Format};
+
+let client = Client::new("fc-YOUR_API_KEY")?;
+
+// First, scrape a page to get a job ID
+let doc = client.scrape("https://example.com", ScrapeOptions {
+    formats: Some(vec![Format::Markdown]),
+    ..Default::default()
+}).await?;
+
+let job_id = doc.metadata.as_ref().and_then(|m| m.scrape_id.as_ref()).unwrap();
+
+// Then interact with the browser session
+let response = client.interact(job_id, ScrapeExecuteOptions {
+    code: Some(r#"document.querySelector("button.submit").click();"#.into()),
+    ..Default::default()
+}).await?;
+
+println!("{:?}", response.stdout);
+```
+
+### Parameters
+
+Parameters are fields on the `ScrapeExecuteOptions` struct.
+
+| Field | Type | Description |
+|---|---|---|
+| `code` | `Option<String>` | Code to execute in the browser sandbox. Provide either `code` or `prompt`. |
+| `prompt` | `Option<String>` | Natural-language instruction for the browser agent. Provide either `code` or `prompt`. |
+| `language` | `Option<ScrapeExecuteLanguage>` | Runtime language: `Python`, `Node`, `Bash`. Default: `Node`. |
+| `timeout` | `Option<u32>` | Execution timeout in seconds. Default: `30`. Min: `1`, Max: `300`. |
+| `origin` | `Option<String>` | Origin label. Auto-set to `"rust-sdk@{version}"` if not provided. |
+
+### Return type
+
+`ScrapeExecuteResponse` with `.success`, `.stdout`, `.result`, `.stderr`, `.exit_code`, `.output`, `.live_view_url`, `.interactive_live_view_url`.
+
+### Stopping a session
+
+```rust
+client.stop_interaction(job_id).await?;
+```
+
+## Notes
+
+- **Naming style**: Struct fields use snake_case. Serialization to the API is camelCase via serde.
+- **Async**: All methods are async and require `.await`.
+- **Origin auto-set**: `origin` is automatically set to `"rust-sdk@{version}"` on `search`, `scrape`, and `interact` if not explicitly provided.
+- **Validation**: `interact` returns `FirecrawlError::Misuse` if neither `code` nor `prompt` is provided.
+- **Deprecated aliases** (migration only):
+  - `scrape_execute()` → use `interact()`
+  - `stop_interactive_browser()` / `delete_scrape_browser()` → use `stop_interaction()`
+
+## Source Of Truth
+
+- `firecrawl/apps/rust-sdk/src/v2/client.rs`
+- `firecrawl/apps/rust-sdk/src/v2/search.rs`
+- `firecrawl/apps/rust-sdk/src/v2/scrape.rs`
+- `firecrawl/apps/rust-sdk/src/v2/types.rs`
+- `firecrawl-docs/api-reference/v2-openapi.json`


### PR DESCRIPTION
## Summary

- Adds canonical per-language agent quickstart documents for **Node.js/TypeScript**, **Python**, **Rust**, **Java**, and **Elixir** in `agent-quickstart/`
- Each file covers `search`, `scrape`, and `interact` endpoints with realistic examples, every confirmed parameter with descriptions, and language-specific notes
- All content is generated from SDK source code and the OpenAPI spec (`v2-openapi.json`) — no invented parameters or behavior

## Details

Each quickstart follows a consistent structure:
- Install and authenticate
- When to use what (search vs scrape vs interact)
- Per-endpoint sections with: why use it, preferred SDK method, example, full parameter table, return type
- Language-specific notes (naming conventions, async patterns, deprecated aliases)
- Source of truth references

**Sources used:**
- `apps/js-sdk/firecrawl/src/v2/client.ts` + `types.ts`
- `apps/python-sdk/firecrawl/v2/client.py` + `types.py`
- `apps/rust-sdk/src/v2/scrape.rs` + `search.rs` + `types.rs`
- `apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java` + models
- `apps/elixir-sdk/lib/firecrawl.ex`
- `api-reference/v2-openapi.json`

## Test plan

- [ ] Verify each `.mdx` file renders cleanly in Mintlify
- [ ] Spot-check parameter tables against SDK source for accuracy
- [ ] Confirm examples use correct method signatures per language

---
_Generated by [Claude Code](https://claude.ai/code/session_019yrF8x9fjexHW7Tac64BBv)_