### PR TITLE
docs(agent): document list agent runs endpoint

### DIFF
--- a/api-reference/endpoint/agent-list.mdx
+++ b/api-reference/endpoint/agent-list.mdx
@@ -1,0 +1,8 @@
+---
+title: 'List Agent Runs'
+openapi: '/api-reference/v2-openapi.json GET /agent'
+noindex: true
+
+---
+
+> Are you an AI agent that needs a Firecrawl API key? See [firecrawl.dev/agent-onboarding/SKILL.md](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for automated onboarding instructions.

--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -2464,6 +2464,154 @@
       }
     },
     "/agent": {
+      "get": {
+        "summary": "List agent runs",
+        "operationId": "listAgents",
+        "tags": [
+          "Agent"
+        ],
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "before",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "description": "Only return agent runs created before this unix millisecond timestamp. Pages are fixed at 20 runs; use the `before` value from the previous page's `next` URL to fetch the next page."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of agent runs, most recent first",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "agents": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string",
+                            "format": "uuid"
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "targetHint": {
+                            "type": "string",
+                            "description": "Short hint describing the run's target (first URL or prompt)"
+                          },
+                          "origin": {
+                            "type": "string",
+                            "description": "Origin of the run (e.g. \"api\")"
+                          },
+                          "integration": {
+                            "type": "string",
+                            "description": "Integration identifier, if the run was started with one"
+                          },
+                          "settings": {
+                            "type": "object",
+                            "properties": {
+                              "hidden": {
+                                "type": "boolean"
+                              },
+                              "starred": {
+                                "type": "boolean"
+                              },
+                              "label": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "processing",
+                              "completed",
+                              "failed"
+                            ]
+                          },
+                          "options": {
+                            "type": "object",
+                            "description": "Options the run was started with",
+                            "properties": {
+                              "urls": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "format": "uri"
+                                }
+                              },
+                              "prompt": {
+                                "type": "string"
+                              },
+                              "schema": {
+                                "type": "object"
+                              },
+                              "model": {
+                                "type": "string",
+                                "enum": [
+                                  "spark-2",
+                                  "spark-1-pro",
+                                  "spark-1-mini"
+                                ],
+                                "description": "Model preset used for the agent run. Every new run executes on spark-2; Spark 1 names only appear on legacy runs."
+                              },
+                              "effort": {
+                                "type": "string",
+                                "enum": [
+                                  "low",
+                                  "medium",
+                                  "high"
+                                ],
+                                "description": "Reasoning budget used for the agent run (only present for runs that set effort)"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "next": {
+                      "type": "string",
+                      "description": "Absolute URL of the next page. Only present when more pages exist."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request — the before timestamp is invalid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid before timestamp."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
       "post": {
         "summary": "Start an agent task for agentic data extraction",
         "operationId": "startAgent",

--- a/docs.json
+++ b/docs.json
@@ -509,6 +509,7 @@
                     "group": "Agent Endpoints",
                     "pages": [
                       "api-reference/endpoint/agent",
+                      "api-reference/endpoint/agent-list",
                       "api-reference/endpoint/agent-get",
                       "api-reference/endpoint/agent-trace",
                       "api-reference/endpoint/agent-snapshot",

--- a/features/agent.mdx
+++ b/features/agent.mdx
@@ -23,6 +23,9 @@ import AgentWithURLsCURL from "/snippets/v2/agent/with-urls/curl.mdx";
 import AgentStatusPython from "/snippets/v2/agent/status/python.mdx";
 import AgentStatusJS from "/snippets/v2/agent/status/js.mdx";
 import AgentStatusCURL from "/snippets/v2/agent/status/curl.mdx";
+import AgentListPython from "/snippets/v2/agent/list/python.mdx";
+import AgentListJS from "/snippets/v2/agent/list/js.mdx";
+import AgentListCURL from "/snippets/v2/agent/list/curl.mdx";
 import AgentStatusPending from "/snippets/v2/agent/status/pending.mdx";
 import AgentStatusCompleted from "/snippets/v2/agent/status/completed.mdx";
 import AgentWithModelPython from "/snippets/v2/agent/with-model/python.mdx";
@@ -136,6 +139,20 @@ Agent jobs run asynchronously. When you submit a job, you'll receive a Job ID th
 #### Completed Example
 
 <AgentStatusCompleted />
+
+## Listing agent runs
+
+`GET /agent` lists every agent run your team has made, most recent first — including runs started from the playground or the API. Each entry carries the run's ID, creation time, status, a short target hint, and the options it was started with.
+
+Results are paginated in fixed pages of 20 runs. When more pages exist, the response includes a `next` URL; pass its `before` timestamp to fetch the next page. The SDK methods do not auto-paginate, so you stay in control of how far back to go.
+
+<CodeGroup>
+
+<AgentListPython />
+<AgentListJS />
+<AgentListCURL />
+
+</CodeGroup>
 
 ## Following a run in progress
 

--- a/snippets/v2/agent/list/curl.mdx
+++ b/snippets/v2/agent/list/curl.mdx
@@ -1,0 +1,9 @@
+```bash cURL
+curl -X GET "https://api.firecrawl.dev/v2/agent" \
+  -H "Authorization: Bearer $FIRECRAWL_API_KEY"
+
+# Fetch the next page (unix ms timestamp from the previous page's `next` URL)
+curl -X GET "https://api.firecrawl.dev/v2/agent?before=1756600000000" \
+  -H "Authorization: Bearer $FIRECRAWL_API_KEY"
+```
+

--- a/snippets/v2/agent/list/js.mdx
+++ b/snippets/v2/agent/list/js.mdx
@@ -1,0 +1,19 @@
+```js Node
+import { Firecrawl } from 'firecrawl';
+
+const firecrawl = new Firecrawl({ apiKey: "fc-YOUR_API_KEY" });
+
+// List your most recent agent runs
+const page = await firecrawl.listAgents();
+
+for (const run of page.agents ?? []) {
+  console.log(run.id, run.status, run.targetHint);
+}
+
+// Fetch the next page using the cursor from `next`
+if (page.next) {
+  const before = Number(new URL(page.next).searchParams.get("before"));
+  const older = await firecrawl.listAgents({ before });
+}
+```
+

--- a/snippets/v2/agent/list/python.mdx
+++ b/snippets/v2/agent/list/python.mdx
@@ -1,0 +1,17 @@
+```python Python
+from firecrawl import Firecrawl
+
+app = Firecrawl(api_key="fc-YOUR_API_KEY")
+
+# List your most recent agent runs
+page = app.list_agents()
+
+for run in page.agents:
+    print(run.id, run.status, run.target_hint)
+
+# Fetch the next page using the cursor from `next`
+if page.next:
+    before = int(page.next.split("before=")[-1])
+    older = app.list_agents(before=before)
+```
+


### PR DESCRIPTION
Documents the new `GET /v2/agent` endpoint (firecrawl/firecrawl#4467) that lists a team's agent runs, most recent first, with cursor pagination via `before`.

Changes:
- **`api-reference/v2-openapi.json`**: adds the `GET /agent` operation (`listAgents`) with the `before` query param and the full response schema (`agents` items with `settings`/`options`, plus the `next` page URL)
- **`api-reference/endpoint/agent-list.mdx`**: new API reference page, registered in `docs.json` under Agent Endpoints
- **`features/agent.mdx`**: new "Listing agent runs" section with Python/JS/cURL snippets (new `snippets/v2/agent/list/*`)

English source files only — no localized files touched.

Note: the SDK methods (`listAgents` / `list_agents`) deliberately do **not** auto-paginate, since this endpoint can page through every agent run a team has ever made.