### PR TITLE
docs: fix dead bounty CTA buttons (static survey hrefs)

### DIFF
--- a/snippets/agent-feedback-cta.mdx
+++ b/snippets/agent-feedback-cta.mdx
@@ -10,7 +10,7 @@
     To qualify, complete a high-signal interview (thoughtful, concrete use cases, etc) with our Firecrawl Feedback Assistant. Only takes a few minutes, can be stopped at any time, and is both human/agent-friendly (just paste the link into your agentic harness!). Never used /agent? Your take still counts.
   </p>
   <a
-    href={"https://www.firecrawl.dev/survey/7pjb4?src=" + (props.src || "docs-agent")}
+    href="https://www.firecrawl.dev/survey/7pjb4?src=docs-agent"
     className="firecrawl-cta-btn-primary firecrawl-cta-btn-inline"
   >
     Start the interview

--- a/snippets/general-feedback-cta.mdx
+++ b/snippets/general-feedback-cta.mdx
@@ -10,7 +10,7 @@
     To qualify, complete a high-signal interview (thoughtful, concrete use cases, etc) with our Firecrawl Feedback Assistant. Only takes a few minutes, can be stopped at any time, and is both human/agent-friendly (just paste the link into your agentic harness!). New to Firecrawl? Your take still counts.
   </p>
   <a
-    href={"https://www.firecrawl.dev/survey/dsag9?src=" + (props.src || "docs-introduction")}
+    href="https://www.firecrawl.dev/survey/dsag9?src=docs-introduction"
     className="firecrawl-cta-btn-primary firecrawl-cta-btn-inline"
   >
     Start the interview

--- a/snippets/interact-feedback-cta.mdx
+++ b/snippets/interact-feedback-cta.mdx
@@ -10,7 +10,7 @@
     To qualify, complete a high-signal interview (thoughtful, concrete use cases, etc) with our Firecrawl Feedback Assistant. Only takes a few minutes, can be stopped at any time, and is both human/agent-friendly (just paste the link into your agentic harness!). Never used /interact? Your take still counts.
   </p>
   <a
-    href={"https://www.firecrawl.dev/survey/ogu30?src=" + (props.src || "docs-interact")}
+    href="https://www.firecrawl.dev/survey/ogu30?src=docs-interact"
     className="firecrawl-cta-btn-primary firecrawl-cta-btn-inline"
   >
     Start the interview


### PR DESCRIPTION
**Problem:** on the live docs, the "Start the interview" buttons in the /agent, /interact, and general feedback bounty CTAs render as `<a href="">`, so clicking reloads the page at the top. The source hrefs are fine; Mintlify's renderer blanks the JSX expression `href={"https://www.firecrawl.dev/survey/<slug>?src=" + (props.src || "docs-<topic>")}` at render time (the compiled expression is still visible in the page payload, the rendered anchor is empty).

**Fix:** static string hrefs in the three English snippets:
- `snippets/agent-feedback-cta.mdx` -> https://www.firecrawl.dev/survey/7pjb4?src=docs-agent
- `snippets/interact-feedback-cta.mdx` -> https://www.firecrawl.dev/survey/ogu30?src=docs-interact
- `snippets/general-feedback-cta.mdx` -> https://www.firecrawl.dev/survey/dsag9?src=docs-introduction

Each snippet renders on exactly one English page, so dropping the `src` prop loses no attribution. Localized snippets (`ja/`, `zh/`, `es/`, `fr/`, ...) are not touched per the docs convention; locadex syncs them.

Verify on the Mintlify preview for this PR: the button on /features/agent should open the survey.

🤖 Generated with [Claude Code](https://claude.com/claude-code)