### PR TITLE
Add agent quickstart docs for all SDK languages

### DIFF
--- a/agent-quickstart/elixir.mdx
+++ b/agent-quickstart/elixir.mdx
@@ -1,0 +1,254 @@
+---
+title: "Elixir Agent Quickstart"
+description: "Canonical Firecrawl Elixir quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Elixir Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating Firecrawl via the Elixir SDK. It is generated from SDK source (`:firecrawl` hex package v1.11.0) and the Firecrawl OpenAPI spec. The Elixir SDK is auto-generated from the OpenAPI spec, so function names are OpenAPI-shaped rather than shorthand.
+
+## Install
+
+Add to your `mix.exs` dependencies:
+
+```elixir
+defp deps do
+  [
+    {:firecrawl, "~> 1.11"}
+  ]
+end
+```
+
+## Authenticate
+
+### Application config (recommended)
+
+```elixir
+# config/config.exs
+config :firecrawl, api_key: "fc-YOUR_API_KEY"
+```
+
+### Per-call option
+
+```elixir
+Firecrawl.scrape_and_extract_from_url([url: "https://example.com"],
+  api_key: "fc-YOUR_API_KEY"
+)
+```
+
+Omit the key entirely for the free tier (rate-limited per IP). For self-hosted instances, override `base_url`:
+
+```elixir
+config :firecrawl,
+  api_key: "fc-YOUR_API_KEY",
+  base_url: "https://your-instance.com/v2"
+```
+
+## When To Use What
+
+- **`scrape_and_extract_from_url`**: Already have a URL and want to extract page content (markdown, HTML, structured JSON, screenshots, etc.).
+- **`search_and_scrape`**: Start with a text query and need to discover relevant URLs and content across the web.
+- **`interact_with_scrape_browser_session`**: The page needs post-scrape browser actions — clicking buttons, filling forms, executing code in the live browser session.
+
+## Search
+
+### Why use it
+
+Search lets you find relevant web pages, news, or images from a query string. Optionally scrape each result in the same call.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.search_and_scrape(params, opts \\ [])
+```
+
+Bang variant: `Firecrawl.search_and_scrape!(params, opts)`
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.search_and_scrape(
+  query: "latest firecrawl features",
+  limit: 5,
+  scrape_options: [formats: ["markdown"]]
+)
+
+for result <- response.body["data"]["web"] || [] do
+  IO.puts("#{result["title"]} - #{result["url"]}")
+end
+```
+
+### Parameters
+
+All parameters are passed as a keyword list. Only `query` is required.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `:string` | The search query (required). Max 500 characters. |
+| `sources` | `{:list, :any}` | Sources: `"web"`, `"news"`, `"images"`. Default: `["web"]`. |
+| `categories` | `{:list, :any}` | Category filters: `"github"`, `"research"`, `"pdf"`, `"developer"`. |
+| `include_domains` | `{:list, :string}` | Restrict results to these domains. |
+| `exclude_domains` | `{:list, :string}` | Exclude results from these domains. |
+| `limit` | `:integer` | Max results to return. Server default: 10. |
+| `tbs` | `:string` | Time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `:string` | Geographic location for results. |
+| `country` | `:string` | ISO country code for geo-targeting (e.g. `"US"`). |
+| `ignore_invalid_urls` | `:boolean` | Exclude invalid URLs. |
+| `timeout` | `:integer` | Timeout in ms. Server default: 60000. |
+| `highlights` | `:boolean` | Generate highlights. Default: `true`. |
+| `scrape_options` | `:keyword_list` | Options applied when scraping each result. See Scrape parameters. |
+| `enterprise` | `{:list, :string}` | Enterprise ZDR: `["zdr"]` or `["anon"]`. |
+
+### Response shape
+
+Returns `{:ok, %Req.Response{}}` where `response.body` contains:
+
+```json
+{
+  "success": true,
+  "data": {
+    "web": [{ "title": "...", "url": "...", "markdown": "..." }],
+    "news": [...],
+    "images": [...]
+  }
+}
+```
+
+## Scrape
+
+### Why use it
+
+Scrape fetches a single URL and returns its content in one or more formats: markdown, HTML, structured JSON, screenshots, audio/video extraction, and more.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.scrape_and_extract_from_url(params, opts \\ [])
+```
+
+Bang variant: `Firecrawl.scrape_and_extract_from_url!(params, opts)`
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown", "links"],
+  only_main_content: true,
+  timeout: 30000
+)
+
+doc = response.body["data"]
+IO.puts(doc["markdown"])
+IO.inspect(doc["links"])
+```
+
+### Parameters
+
+All parameters are passed as a keyword list. Only `url` is required.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `:string` | The URL to scrape (required). |
+| `formats` | `{:list, :any}` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`. Or config maps for json/question/highlights. Default: `["markdown"]`. |
+| `headers` | `:any` | Custom HTTP headers. |
+| `include_tags` | `{:list, :string}` | HTML tags to include. |
+| `exclude_tags` | `{:list, :string}` | HTML tags to exclude. |
+| `only_main_content` | `:boolean` | Main content only. Server default: `true`. |
+| `timeout` | `:integer` | Timeout in ms. Min: 1000, Max: 300000. Server default: 60000. |
+| `wait_for` | `:integer` | Extra delay in ms before fetching. |
+| `mobile` | `:boolean` | Emulate mobile device. |
+| `parsers` | `{:list, :any}` | Parser configs (e.g. pdf mode). |
+| `actions` | `{:list, :any}` | Browser actions before grabbing content. |
+| `location` | `:keyword_list` | Geolocation settings. |
+| `skip_tls_verification` | `:boolean` | Skip TLS verification. |
+| `remove_base64_images` | `:boolean` | Strip base64 images from markdown. Server default: `true`. |
+| `block_ads` | `:boolean` | Block ads and cookie popups. Server default: `true`. |
+| `proxy` | `:basic \| :enhanced \| :auto` | Proxy type. Server default: `"auto"`. |
+| `max_age` | `:integer` | Max cache age in ms. Server default: 172800000 (2 days). |
+| `min_age` | `:integer` | Cache-only mode. Set to `1` to accept any cached data. |
+| `store_in_cache` | `:boolean` | Cache the result. Server default: `true`. |
+| `lockdown` | `:boolean` | Serve only cached results. |
+| `redact_pii` | `:boolean` | Redact PII. |
+| `profile` | `:keyword_list` | Persistent browser storage. |
+| `audit_metadata` | `:keyword_list` | User attribution: `[username: "agent-1"]`. |
+| `zero_data_retention` | `:boolean` | Zero data retention mode. |
+
+## Interact
+
+### Why use it
+
+Interact lets you execute code in a live browser session tied to a previous scrape job. Use it for clicking elements, filling forms, navigating multi-step flows, or extracting dynamic content.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.interact_with_scrape_browser_session(job_id, params, opts \\ [])
+```
+
+Bang variant: `Firecrawl.interact_with_scrape_browser_session!(job_id, params, opts)`
+
+To end the session:
+
+```elixir
+Firecrawl.stop_interactive_scrape_browser_session(job_id, opts \\ [])
+```
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.interact_with_scrape_browser_session(
+  "job-id-here",
+  code: "document.querySelector('#submit').click();",
+  language: :node,
+  timeout: 30
+)
+
+IO.puts(response.body["stdout"])
+
+# End the session
+{:ok, _} = Firecrawl.stop_interactive_scrape_browser_session("job-id-here")
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `String.t()` | The scrape job ID (required, first positional argument). |
+| `code` | `:string` | Code to execute in the browser sandbox (required). Max 100000 characters. |
+| `language` | `:python \| :node \| :bash` | Language of the code. Default: `"node"`. |
+| `timeout` | `:integer` | Execution timeout in seconds (1-300). Server default: 30. |
+| `origin` | `:string` | Origin tag for telemetry. |
+
+### Response
+
+Returns `{:ok, %Req.Response{}}` where `response.body` contains:
+
+| Field | Type | Description |
+|---|---|---|
+| `"success"` | `boolean` | Whether execution succeeded. |
+| `"cdpUrl"` | `string?` | Chrome DevTools Protocol WebSocket URL. |
+| `"liveViewUrl"` | `string?` | Read-only live view URL. |
+| `"interactiveLiveViewUrl"` | `string?` | Interactive live view URL. |
+| `"output"` | `string?` | AI agent response (when using prompt). |
+| `"stdout"` | `string?` | Standard output from code execution. |
+| `"result"` | `string?` | Alias for stdout. |
+| `"stderr"` | `string?` | Standard error. |
+| `"exitCode"` | `integer?` | Exit code. |
+| `"killed"` | `boolean` | Whether killed due to timeout. |
+| `"error"` | `string?` | Error message. |
+
+## Notes
+
+- **Auto-generated SDK**: The Elixir SDK is auto-generated from the OpenAPI spec via `generate.exs`. Function names mirror the OpenAPI operation IDs rather than being shortened.
+- **Naming style**: Parameters use snake_case in Elixir keyword lists (e.g. `only_main_content`, `include_tags`). These are converted to camelCase JSON keys automatically.
+- **Return type**: All functions return `{:ok, %Req.Response{}}` or `{:error, exception}`. Bang variants (`!`) raise on error.
+- **Response data**: Access response data via `response.body` — it is a decoded JSON map, not a struct.
+- **Error handling**: HTTP 4xx/5xx responses raise `Firecrawl.Error` (with `:status` and `:body` fields) in bang variants, or return `{:error, %Firecrawl.Error{}}` in non-bang variants.
+- **Interact code-only**: The Elixir SDK `interact_with_scrape_browser_session` only accepts `code`, not `prompt`, at the time of this writing.
+
+## Source Of Truth
+
+- `firecrawl/apps/elixir-sdk/lib/firecrawl.ex`
+- `firecrawl/apps/elixir-sdk/mix.exs`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/java.mdx
+++ b/agent-quickstart/java.mdx
@@ -1,0 +1,266 @@
+---
+title: "Java Agent Quickstart"
+description: "Canonical Firecrawl Java quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Java Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating Firecrawl via the Java SDK. It is generated from SDK source (`com.firecrawl:firecrawl-java` v1.17.0) and the Firecrawl OpenAPI spec.
+
+## Install
+
+### Gradle
+
+```groovy
+implementation "com.firecrawl:firecrawl-java:1.17.0"
+```
+
+### Maven
+
+```xml
+<dependency>
+    <groupId>com.firecrawl</groupId>
+    <artifactId>firecrawl-java</artifactId>
+    <version>1.17.0</version>
+</dependency>
+```
+
+Requires Java 11+.
+
+## Authenticate
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey("fc-YOUR_API_KEY")
+    .build();
+
+// Or read from FIRECRAWL_API_KEY env var / firecrawl.apiKey system property:
+FirecrawlClient client = FirecrawlClient.fromEnv();
+
+// Omit apiKey entirely for the free tier (rate-limited per IP)
+FirecrawlClient client = FirecrawlClient.builder().build();
+```
+
+Builder options:
+
+| Parameter | Type | Default |
+|---|---|---|
+| `apiKey` | `String` | `null` → falls back to `FIRECRAWL_API_KEY` env var, then `firecrawl.apiKey` system property |
+| `apiUrl` | `String` | `"https://api.firecrawl.dev"` (or `FIRECRAWL_API_URL` env var) |
+| `timeoutMs` | `long` | `300000` (5 min) |
+| `maxRetries` | `int` | `3` |
+| `backoffFactor` | `double` | `0.5` |
+| `asyncExecutor` | `Executor` | `ForkJoinPool.commonPool()` |
+| `httpClient` | `OkHttpClient` | Auto-created with `timeoutMs` |
+
+## When To Use What
+
+- **`search`**: Start with a text query and need to discover relevant URLs and content across the web.
+- **`scrape`**: Already have a URL and want to extract page content (markdown, HTML, structured JSON, screenshots, etc.).
+- **`interact`**: The page needs post-scrape browser actions — clicking buttons, filling forms, executing code in the live browser session.
+
+## Search
+
+### Why use it
+
+Search lets you find relevant web pages, news, or images from a query string. Optionally scrape each result in the same call.
+
+### Preferred SDK method
+
+```java
+client.search(query)
+client.search(query, options)
+```
+
+### Example
+
+```java
+import com.firecrawl.models.SearchOptions;
+import com.firecrawl.models.SearchData;
+
+SearchData results = client.search("latest firecrawl features",
+    SearchOptions.builder()
+        .limit(5)
+        .build()
+);
+
+if (results.getWeb() != null) {
+    for (var page : results.getWeb()) {
+        System.out.println(page.get("title") + " " + page.get("url"));
+    }
+}
+```
+
+### Parameters
+
+All fields on `SearchOptions.builder()` are optional (null = not sent to API).
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `String` | The search query (required, first positional argument). Max 500 characters. |
+| `sources` | `List<Object>` | Sources: `"web"`, `"news"`, `"images"`. Default: `["web"]`. |
+| `categories` | `List<Object>` | Categories: `"github"`, `"research"`, `"pdf"`. |
+| `includeDomains` | `List<String>` | Restrict results to these domains. |
+| `excludeDomains` | `List<String>` | Exclude results from these domains. |
+| `limit` | `Integer` | Max results to return. Server default: 10. |
+| `tbs` | `String` | Time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `String` | Geographic location for results. |
+| `ignoreInvalidURLs` | `Boolean` | Exclude invalid URLs from results. |
+| `timeout` | `Integer` | Timeout in ms. Server default: 60000. |
+| `highlights` | `Boolean` | Generate highlights. Default (server): `true`. |
+| `scrapeOptions` | `ScrapeOptions` | Options applied when scraping each result. See Scrape parameters. |
+| `integration` | `String` | Integration identifier. |
+
+### Response shape
+
+Returns `SearchData` with:
+
+- `getWeb()` — `List<Map<String, Object>>` — web results
+- `getNews()` — `List<Map<String, Object>>` — news results
+- `getImages()` — `List<Map<String, Object>>` — image results
+
+## Scrape
+
+### Why use it
+
+Scrape fetches a single URL and returns its content in one or more formats: markdown, HTML, structured JSON, screenshots, audio/video extraction, and more.
+
+### Preferred SDK method
+
+```java
+client.scrape(url)
+client.scrape(url, options)
+```
+
+### Example
+
+```java
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.Document;
+import java.util.List;
+
+Document doc = client.scrape("https://example.com",
+    ScrapeOptions.builder()
+        .formats(List.of("markdown", "links"))
+        .onlyMainContent(true)
+        .timeout(30000)
+        .build()
+);
+
+System.out.println(doc.getMarkdown());
+System.out.println(doc.getLinks());
+```
+
+### Parameters
+
+All fields on `ScrapeOptions.builder()` are optional (null = not sent to API).
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `String` | The URL to scrape (required, first positional argument). |
+| `formats` | `List<Object>` | Output formats. Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"json"`, `"audio"`, `"video"`, etc. Or config objects (`JsonFormat`, `QuestionFormat`, `HighlightsFormat`). Default: `["markdown"]`. |
+| `headers` | `Map<String, String>` | Custom HTTP headers. |
+| `includeTags` | `List<String>` | HTML tags to include. |
+| `excludeTags` | `List<String>` | HTML tags to exclude. |
+| `onlyMainContent` | `Boolean` | Main content only. Server default: `true`. |
+| `timeout` | `Integer` | Timeout in ms. Server default: 60000. |
+| `waitFor` | `Integer` | Extra delay in ms before fetching. |
+| `mobile` | `Boolean` | Emulate mobile device. |
+| `parsers` | `List<Object>` | Parser configs (e.g. `"pdf"` or `PdfParser` with `maxPages`, `pages`, `blocks`, `pageMarkers`). |
+| `actions` | `List<Map<String, Object>>` | Browser actions before grabbing content. |
+| `location` | `LocationConfig` | Geolocation: `new LocationConfig("US", List.of("en"))`. |
+| `skipTlsVerification` | `Boolean` | Skip TLS verification. |
+| `removeBase64Images` | `Boolean` | Strip base64 images from markdown. Server default: `true`. |
+| `blockAds` | `Boolean` | Block ads. Server default: `true`. |
+| `proxy` | `String` | Proxy type: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. Server default: `"auto"`. |
+| `maxAge` | `Long` | Max cache age in ms. Server default: 172800000 (2 days). |
+| `storeInCache` | `Boolean` | Cache the result. Server default: `true`. |
+| `lockdown` | `Boolean` | Serve only cached results. |
+| `redactPII` | `Boolean` | Redact PII. |
+| `auditMetadata` | `AuditMetadata` | User attribution: `new AuditMetadata("agent-1")`. |
+| `integration` | `String` | Integration identifier. |
+
+## Interact
+
+### Why use it
+
+Interact lets you execute code in a live browser session tied to a previous scrape job. Use it for clicking elements, filling forms, navigating multi-step flows, or extracting dynamic content.
+
+### Preferred SDK method
+
+```java
+client.interact(jobId, code)
+client.interact(jobId, code, language, timeout)
+client.interact(jobId, code, language, timeout, origin)
+```
+
+To end the session:
+
+```java
+client.stopInteractiveBrowser(jobId)
+```
+
+### Example
+
+```java
+import com.firecrawl.models.BrowserExecuteResponse;
+import com.firecrawl.models.BrowserDeleteResponse;
+
+BrowserExecuteResponse result = client.interact(
+    "job-id-here",
+    "document.querySelector('#submit').click();",
+    "node",
+    30
+);
+
+System.out.println(result.getStdout());
+
+// End the session
+BrowserDeleteResponse stopped = client.stopInteractiveBrowser("job-id-here");
+System.out.println("Session lasted " + stopped.getSessionDurationMs() + "ms");
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `jobId` | `String` | The scrape job ID (required). |
+| `code` | `String` | Code to execute in the browser sandbox (required). Max 100000 characters. |
+| `language` | `String` | `"python"`, `"node"`, or `"bash"`. Default: `"node"`. |
+| `timeout` | `Integer` | Execution timeout in seconds (1-300). Server default: 30. |
+| `origin` | `String` | Origin tag for telemetry. Falls back to `"java-sdk@1.17.0"`. |
+
+### Response
+
+Returns `BrowserExecuteResponse`:
+
+| Field | Type | Description |
+|---|---|---|
+| `success` | `boolean` | Whether execution succeeded. |
+| `stdout` | `String` | Standard output. |
+| `result` | `String` | Alias for stdout. |
+| `stderr` | `String` | Standard error. |
+| `exitCode` | `Integer` | Exit code. |
+| `killed` | `Boolean` | Whether killed due to timeout. |
+| `error` | `String` | Error message. |
+
+All methods also have `*Async` variants returning `CompletableFuture<...>`.
+
+## Notes
+
+- **Naming style**: All parameters use camelCase (e.g. `onlyMainContent`, `includeTags`), matching Java conventions and the API wire format.
+- **Deprecated aliases**: `scrapeExecute()` → use `interact()`. `deleteScrapeBrowser()` → use `stopInteractiveBrowser()`. Deprecated async variants also exist.
+- **Builder pattern**: `ScrapeOptions` and `SearchOptions` use builders: `ScrapeOptions.builder().formats(...).build()`.
+- **Interact code-only**: The Java SDK `interact` method currently requires `code` as a positional argument. There is no `prompt` parameter in the Java SDK at the time of this writing.
+- **Async**: Every sync method has a corresponding `*Async` variant that returns `CompletableFuture`. The executor can be customized via `asyncExecutor` in the client builder.
+
+## Source Of Truth
+
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/ScrapeOptions.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/SearchOptions.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/Document.java`
+- `firecrawl/apps/java-sdk/build.gradle.kts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/node.mdx
+++ b/agent-quickstart/node.mdx
@@ -1,0 +1,254 @@
+---
+title: "Node.js Agent Quickstart"
+description: "Canonical Firecrawl Node.js quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Node.js Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating Firecrawl via the Node.js/TypeScript SDK. It is generated from SDK source (`@mendable/firecrawl-js` v4.38.0) and the Firecrawl OpenAPI spec.
+
+## Install
+
+```bash
+npm install @mendable/firecrawl-js
+```
+
+Requires Node.js >= 22.
+
+## Authenticate
+
+```typescript
+import Firecrawl from "@mendable/firecrawl-js";
+
+const client = new Firecrawl("fc-YOUR_API_KEY");
+// Or: new Firecrawl({ apiKey: "fc-YOUR_API_KEY" })
+// Or omit the key to use the free tier (rate-limited per IP)
+```
+
+The key can also be set via `FIRECRAWL_API_KEY` environment variable. The base URL defaults to `https://api.firecrawl.dev` and can be overridden with `apiUrl` or `FIRECRAWL_API_URL`.
+
+## When To Use What
+
+- **`search`**: Start with a text query and need to discover relevant URLs and content across the web.
+- **`scrape`**: Already have a URL and want to extract page content (markdown, HTML, structured JSON, screenshots, etc.).
+- **`interact`**: The page needs post-scrape browser actions — clicking buttons, filling forms, executing JavaScript in the live browser session.
+
+## Search
+
+### Why use it
+
+Search lets you find relevant web pages, news, or images from a query string. Optionally scrape each result in the same call.
+
+### Preferred SDK method
+
+```typescript
+client.search(query, options?)
+```
+
+### Example
+
+```typescript
+const results = await client.search("latest firecrawl features", {
+  limit: 5,
+  scrapeOptions: { formats: ["markdown"] },
+});
+
+for (const page of results.web ?? []) {
+  console.log(page.title, page.url);
+  console.log(page.markdown?.slice(0, 200));
+}
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `string` | The search query (required, first positional argument). Max 500 characters. |
+| `sources` | `Array<"web" \| "news" \| "images" \| { type: ... }>` | Sources to search. Determines which arrays appear in the response. Default: `["web"]`. |
+| `categories` | `Array<"github" \| "research" \| "pdf" \| "developer" \| { type: ... }>` | Category filters. `"research"` filters by domain, not a paper index. `"developer"` returns developer-index results. |
+| `includeDomains` | `string[]` | Restrict results to these domains. Cannot combine with `excludeDomains`. |
+| `excludeDomains` | `string[]` | Exclude results from these domains. Cannot combine with `includeDomains`. |
+| `limit` | `number` | Max results to return (per source type). Must be positive. Server default: 10. |
+| `tbs` | `string` | Time-based search filter. Examples: `"qdr:d"` (past day), `"qdr:w"` (past week), `"sbd:1"` (sort by date). |
+| `location` | `string` | Geographic location for results (e.g. `"San Francisco,California,United States"`). |
+| `ignoreInvalidURLs` | `boolean` | Exclude invalid URLs from results. |
+| `timeout` | `number` | Timeout in ms. Must be positive. Server default: 60000. |
+| `highlights` | `boolean` | Generate query-relevant highlights. Default: `true`. |
+| `scrapeOptions` | `ScrapeOptions` | Options applied when scraping each search result page. See Scrape parameters. |
+| `enterprise` | `Array<"default" \| "anon" \| "zdr">` | Enterprise zero data retention options. |
+| `threatProtection` | `ThreatProtectionOptions` | Per-request threat protection override (enterprise). |
+| `integration` | `string` | Integration identifier. |
+| `origin` | `string` | Origin tag for telemetry. |
+
+### Response shape
+
+Returns `SearchData` with optional arrays depending on requested sources:
+
+- `web` — `Array<{ url, title?, description?, position?, category?, markdown?, ... }>`
+- `news` — `Array<{ title?, url?, snippet?, date?, imageUrl?, position? }>`
+- `images` — `Array<{ title?, imageUrl?, imageWidth?, imageHeight?, url?, position? }>`
+
+## Scrape
+
+### Why use it
+
+Scrape fetches a single URL and returns its content in one or more formats: markdown, HTML, structured JSON, screenshots, audio/video extraction, and more.
+
+### Preferred SDK method
+
+```typescript
+client.scrape(url, options?)
+```
+
+### Example
+
+```typescript
+const doc = await client.scrape("https://example.com", {
+  formats: ["markdown", "links"],
+  onlyMainContent: true,
+  timeout: 30000,
+});
+
+console.log(doc.markdown);
+console.log(doc.links);
+```
+
+#### JSON extraction example
+
+```typescript
+const doc = await client.scrape("https://example.com/product", {
+  formats: [
+    {
+      type: "json",
+      schema: {
+        type: "object",
+        properties: {
+          title: { type: "string" },
+          price: { type: "number" },
+        },
+      },
+    },
+  ],
+});
+
+console.log(doc.json);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `string` | The URL to scrape (required, first positional argument). |
+| `formats` | `FormatOption[]` | Output formats. Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`. Or config objects like `{ type: "json", schema, prompt }`, `{ type: "screenshot", fullPage, quality, viewport }`, `{ type: "question", question }`, `{ type: "highlights", query }`. Default: `["markdown"]`. |
+| `headers` | `Record<string, string>` | Custom HTTP headers to send with the request. |
+| `includeTags` | `string[]` | HTML tags to include in the output. |
+| `excludeTags` | `string[]` | HTML tags to exclude from the output. |
+| `onlyMainContent` | `boolean` | Only return main content, excluding headers/navs/footers. Server default: `true`. |
+| `timeout` | `number` | Timeout in ms. Min: 1000, Max: 300000. Server default: 60000. |
+| `waitFor` | `number` | Extra delay in ms before fetching content. Server default: 0. |
+| `mobile` | `boolean` | Emulate a mobile device. Server default: `false`. |
+| `parsers` | `Array<string \| PDFParser>` | Parser configs. `PDFParser`: `{ type: "pdf", mode?: "fast" \| "auto" \| "ocr", maxPages?, pages?, blocks?, pageMarkers? }`. |
+| `actions` | `ActionOption[]` | Browser actions to perform before grabbing content. Types: `wait`, `screenshot`, `click`, `write`, `press`, `scroll`, `scrape`, `executeJavascript`, `pdf`. |
+| `location` | `{ country?: string, languages?: string[] }` | Geolocation settings. Country is ISO 3166-1 alpha-2. |
+| `skipTlsVerification` | `boolean` | Skip TLS certificate verification. |
+| `removeBase64Images` | `boolean` | Remove base64 images from markdown. Server default: `true`. |
+| `fastMode` | `boolean` | Quick scrape mode. |
+| `blockAds` | `boolean` | Block ads and cookie popups. Server default: `true`. |
+| `proxy` | `"basic" \| "stealth" \| "enhanced" \| "auto" \| string` | Proxy type. `"auto"` retries with enhanced if basic fails. Server default: `"auto"`. |
+| `maxAge` | `number` | Use cached result if younger than this many ms. Server default: 172800000 (2 days). `0` to bypass cache. |
+| `minAge` | `number` | Cache-only mode. Value in ms specifies minimum cache age. Set to `1` to accept any cached data. |
+| `storeInCache` | `boolean` | Whether to cache the result. Server default: `true`. |
+| `lockdown` | `boolean` | Serve only cached results, never make outbound requests. |
+| `redactPII` | `boolean \| RedactPIIOptions` | Redact PII from markdown. `RedactPIIOptions`: `{ mode?: "accurate" \| "aggressive" \| "fast", entities?: RedactPIIEntity[], replaceStyle?: "tag" \| "mask" \| "remove" }`. |
+| `profile` | `{ name: string, saveChanges?: boolean }` | Persistent browser storage across scrape/interact sessions. |
+| `auditMetadata` | `{ username: string }` | User attribution for SIEM logging. |
+| `autoResume` | `boolean` | SDK-only. Automatically retry on `processing_continues` for large PDFs. Max 5 resumes / 20 min. Default: `true`. |
+| `threatProtection` | `ThreatProtectionOptions` | Per-request threat protection override (enterprise). |
+| `integration` | `string` | Integration identifier. |
+| `origin` | `string` | Origin tag for telemetry. |
+
+## Interact
+
+### Why use it
+
+Interact lets you execute code or natural-language prompts in a live browser session tied to a previous scrape job. Use it for clicking elements, filling forms, navigating multi-step flows, or extracting dynamic content.
+
+### Preferred SDK method
+
+```typescript
+client.interact(jobId, args)
+```
+
+To end the session:
+
+```typescript
+client.stopInteraction(jobId)
+```
+
+### Example
+
+```typescript
+// First, scrape a page with actions to get a jobId
+const doc = await client.scrape("https://example.com/login", {
+  formats: ["markdown"],
+});
+const jobId = doc.metadata?.jobId;
+
+// Interact with the live browser session
+const result = await client.interact(jobId, {
+  code: "document.querySelector('#submit').click();",
+  language: "node",
+  timeout: 30,
+});
+
+console.log(result.stdout);
+console.log(result.liveViewUrl);
+
+// When done, stop the session
+await client.stopInteraction(jobId);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `jobId` | `string` | The scrape job ID (required, first positional argument). |
+| `code` | `string` | Code to execute in the browser sandbox. One of `code` or `prompt` is required. Max 100000 characters. |
+| `prompt` | `string` | Natural-language prompt for the AI agent to execute. One of `code` or `prompt` is required. |
+| `language` | `"python" \| "node" \| "bash"` | Language of the code. Default: `"node"`. |
+| `timeout` | `number` | Execution timeout in seconds. Min: 1, Max: 300. Server default: 30. |
+| `origin` | `string` | Origin tag for telemetry. |
+
+### Response
+
+Returns `ScrapeExecuteResponse`:
+
+| Field | Type | Description |
+|---|---|---|
+| `success` | `boolean` | Whether execution succeeded. |
+| `cdpUrl` | `string?` | Chrome DevTools Protocol WebSocket URL. |
+| `liveViewUrl` | `string?` | Read-only live view URL. |
+| `interactiveLiveViewUrl` | `string?` | Interactive live view URL. |
+| `output` | `string?` | AI agent response (when using `prompt`). |
+| `stdout` | `string?` | Standard output from code execution. |
+| `result` | `string?` | Alias for stdout. |
+| `stderr` | `string?` | Standard error output. |
+| `exitCode` | `number?` | Exit code of the executed process. |
+| `killed` | `boolean?` | Whether the process was killed due to timeout. |
+| `error` | `string?` | Error message if execution failed. |
+
+## Notes
+
+- **Naming style**: All parameters use camelCase (e.g. `onlyMainContent`, `includeTags`, `skipTlsVerification`).
+- **Deprecated aliases**: `scrapeUrl()` → use `scrape()`. `scrapeExecute()` → use `interact()`. `stopInteractiveBrowser()` / `deleteScrapeBrowser()` → use `stopInteraction()`. All deprecated aliases still work but are marked for removal.
+- **Search response**: Access results via `.web`, `.news`, `.images`. The old `.data` accessor throws an error directing you to the new properties.
+- **autoResume**: The SDK automatically handles large-PDF continuation by default. Set `autoResume: false` to surface timeout errors immediately.
+
+## Source Of Truth
+
+- `firecrawl/apps/js-sdk/firecrawl/src/index.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/methods/scrape.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/methods/search.ts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/python.mdx
+++ b/agent-quickstart/python.mdx
@@ -1,0 +1,258 @@
+---
+title: "Python Agent Quickstart"
+description: "Canonical Firecrawl Python quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Python Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating Firecrawl via the Python SDK. It is generated from SDK source (`firecrawl-py`) and the Firecrawl OpenAPI spec.
+
+## Install
+
+```bash
+pip install firecrawl-py
+```
+
+## Authenticate
+
+```python
+from firecrawl import Firecrawl
+
+client = Firecrawl(api_key="fc-YOUR_API_KEY")
+# Or omit api_key to use FIRECRAWL_API_KEY env var
+# Or omit entirely for the free tier (rate-limited per IP)
+```
+
+Constructor options:
+
+| Parameter | Type | Default |
+|---|---|---|
+| `api_key` | `str` | `None` → falls back to `FIRECRAWL_API_KEY` env var |
+| `api_url` | `str` | `"https://api.firecrawl.dev"` |
+| `timeout` | `float` | `None` |
+| `max_retries` | `int` | `3` |
+| `backoff_factor` | `float` | `0.5` |
+
+An async variant is available as `AsyncFirecrawl`.
+
+## When To Use What
+
+- **`search`**: Start with a text query and need to discover relevant URLs and content across the web.
+- **`scrape`**: Already have a URL and want to extract page content (markdown, HTML, structured JSON, screenshots, etc.).
+- **`interact`**: The page needs post-scrape browser actions — clicking buttons, filling forms, executing code in the live browser session.
+
+## Search
+
+### Why use it
+
+Search lets you find relevant web pages, news, or images from a query string. Optionally scrape each result in the same call.
+
+### Preferred SDK method
+
+```python
+client.search(query, **options)
+```
+
+### Example
+
+```python
+results = client.search(
+    "latest firecrawl features",
+    limit=5,
+    scrape_options={"formats": ["markdown"]},
+)
+
+for page in results.web or []:
+    print(page.title, page.url)
+    print(page.markdown[:200] if page.markdown else "")
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `str` | The search query (required, first positional argument). Max 500 characters. |
+| `sources` | `list[str \| Source]` | Sources to search: `"web"`, `"news"`, `"images"`. Default: `["web"]`. |
+| `categories` | `list[str \| Category]` | Category filters: `"github"`, `"research"`, `"pdf"`, `"developer"`. |
+| `include_domains` | `list[str]` | Restrict results to these domains. Cannot combine with `exclude_domains`. |
+| `exclude_domains` | `list[str]` | Exclude results from these domains. Cannot combine with `include_domains`. |
+| `limit` | `int` | Max results to return. Server default: 10. |
+| `tbs` | `str` | Time-based search filter. Examples: `"qdr:d"` (past day), `"qdr:w"` (past week). |
+| `location` | `str` | Geographic location for results. |
+| `ignore_invalid_urls` | `bool` | Exclude invalid URLs from results. |
+| `timeout` | `int` | Timeout in ms. Server default: 60000. |
+| `highlights` | `bool` | Generate query-relevant highlights. Default: `True`. |
+| `scrape_options` | `ScrapeOptions \| dict` | Options applied when scraping each search result. See Scrape parameters. |
+| `enterprise` | `list[str]` | Enterprise zero data retention: `["zdr"]` or `["anon"]`. |
+| `threat_protection` | `ThreatProtectionOptions` | Per-request threat protection override (enterprise). |
+| `integration` | `str` | Integration identifier. |
+
+### Response shape
+
+Returns `SearchData` with optional attributes depending on requested sources:
+
+- `results.web` — list of `SearchResultWeb` or `Document` objects
+- `results.news` — list of `SearchResultNews` or `Document` objects
+- `results.images` — list of `SearchResultImages` or `Document` objects
+
+## Scrape
+
+### Why use it
+
+Scrape fetches a single URL and returns its content in one or more formats: markdown, HTML, structured JSON, screenshots, audio/video extraction, and more.
+
+### Preferred SDK method
+
+```python
+client.scrape(url, **options)
+```
+
+### Example
+
+```python
+doc = client.scrape(
+    "https://example.com",
+    formats=["markdown", "links"],
+    only_main_content=True,
+    timeout=30000,
+)
+
+print(doc.markdown)
+print(doc.links)
+```
+
+#### JSON extraction example
+
+```python
+doc = client.scrape(
+    "https://example.com/product",
+    formats=[
+        {
+            "type": "json",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "title": {"type": "string"},
+                    "price": {"type": "number"},
+                },
+            },
+        }
+    ],
+)
+
+print(doc.json)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `str` | The URL to scrape (required, first positional argument). |
+| `formats` | `list[FormatOption]` | Output formats. Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`. Or config dicts like `{"type": "json", "schema": ..., "prompt": ...}`. Default: `["markdown"]`. |
+| `headers` | `dict[str, str]` | Custom HTTP headers to send with the request. |
+| `include_tags` | `list[str]` | HTML tags to include in the output. |
+| `exclude_tags` | `list[str]` | HTML tags to exclude from the output. |
+| `only_main_content` | `bool` | Only return main content, excluding headers/navs/footers. Server default: `True`. |
+| `timeout` | `int` | Timeout in ms. Min: 1000, Max: 300000. Server default: 60000. |
+| `wait_for` | `int` | Extra delay in ms before fetching content. |
+| `mobile` | `bool` | Emulate a mobile device. |
+| `parsers` | `list[str \| PDFParser]` | Parser configs. `PDFParser`: `{"type": "pdf", "mode": "fast" \| "auto" \| "ocr", "maxPages": int, "pages": bool, "blocks": bool, "pageMarkers": bool}`. |
+| `actions` | `list[Action]` | Browser actions before grabbing content. Types: `WaitAction`, `ScreenshotAction`, `ClickAction`, `WriteAction`, `PressAction`, `ScrollAction`, `ScrapeAction`, `ExecuteJavascriptAction`, `PDFAction`. |
+| `location` | `Location` | Geolocation: `{"country": "US", "languages": ["en"]}`. |
+| `skip_tls_verification` | `bool` | Skip TLS certificate verification. |
+| `remove_base64_images` | `bool` | Remove base64 images from markdown. Server default: `True`. |
+| `fast_mode` | `bool` | Quick scrape mode. |
+| `block_ads` | `bool` | Block ads and cookie popups. Server default: `True`. |
+| `proxy` | `str` | Proxy type: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. Server default: `"auto"`. |
+| `max_age` | `int` | Use cached result if younger than this many ms. Server default: 172800000 (2 days). |
+| `store_in_cache` | `bool` | Whether to cache the result. Server default: `True`. |
+| `lockdown` | `bool` | Serve only cached results, never make outbound requests. |
+| `redact_pii` | `bool \| RedactPIIOptions` | Redact PII. Options: `{"mode": "accurate" \| "aggressive" \| "fast", "entities": [...], "replaceStyle": "tag" \| "mask" \| "remove"}`. |
+| `profile` | `dict` | Persistent browser storage: `{"name": "my-profile", "saveChanges": True}`. |
+| `audit_metadata` | `AuditMetadata` | User attribution: `{"username": "agent-1"}`. |
+| `auto_resume` | `bool` | SDK-only. Auto-retry on large PDFs. Default: `None` (enabled). |
+| `threat_protection` | `ThreatProtectionOptions` | Per-request threat protection override (enterprise). |
+| `integration` | `str` | Integration identifier. |
+
+## Interact
+
+### Why use it
+
+Interact lets you execute code or natural-language prompts in a live browser session tied to a previous scrape job. Use it for clicking elements, filling forms, navigating multi-step flows, or extracting dynamic content.
+
+### Preferred SDK method
+
+```python
+client.interact(job_id, code=None, *, prompt=None, language="node", timeout=None)
+```
+
+To end the session:
+
+```python
+client.stop_interaction(job_id)
+```
+
+### Example
+
+```python
+# First, scrape a page to get a job_id
+doc = client.scrape("https://example.com/login", formats=["markdown"])
+job_id = doc.metadata.get("jobId") if doc.metadata else None
+
+# Interact with the live browser session
+result = client.interact(
+    job_id,
+    code="document.querySelector('#submit').click();",
+    language="node",
+    timeout=30,
+)
+
+print(result.stdout)
+print(result.live_view_url)
+
+# When done, stop the session
+client.stop_interaction(job_id)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `str` | The scrape job ID (required, first positional argument). |
+| `code` | `str` | Code to execute in the browser sandbox. One of `code` or `prompt` is required. |
+| `prompt` | `str` | Natural-language prompt for the AI agent. One of `code` or `prompt` is required. |
+| `language` | `Literal["python", "node", "bash"]` | Language of the code. Default: `"node"`. |
+| `timeout` | `int` | Execution timeout in seconds (1-300). |
+| `origin` | `str` | Origin tag for telemetry. |
+
+### Response
+
+Returns `BrowserExecuteResponse`:
+
+| Field | Type | Description |
+|---|---|---|
+| `success` | `bool` | Whether execution succeeded. |
+| `live_view_url` | `str?` | Read-only live view URL. |
+| `interactive_live_view_url` | `str?` | Interactive live view URL. |
+| `output` | `str?` | AI agent response (when using `prompt`). |
+| `stdout` | `str?` | Standard output from code execution. |
+| `result` | `str?` | Alias for stdout. |
+| `stderr` | `str?` | Standard error output. |
+| `exit_code` | `int?` | Exit code of the executed process. |
+| `killed` | `bool?` | Whether the process was killed due to timeout. |
+| `error` | `str?` | Error message if execution failed. |
+
+## Notes
+
+- **Naming style**: All parameters use snake_case (e.g. `only_main_content`, `include_tags`, `skip_tls_verification`). Format string values use camelCase to match the API (e.g. `"rawHtml"`, `"changeTracking"`).
+- **Deprecated aliases**: `scrape_url()` → use `scrape()`. `scrape_execute()` → use `interact()`. `stop_interactive_browser()` / `delete_scrape_browser()` → use `stop_interaction()`. All deprecated aliases still work but are marked for removal.
+- **Backward compat alias**: `FirecrawlApp` is an alias for `Firecrawl`. `AsyncFirecrawlApp` is an alias for `AsyncFirecrawl`.
+- **Search response**: Access results via `.web`, `.news`, `.images`. The old `.data` accessor raises `AttributeError` directing you to the new properties.
+- **Interact timeout**: The `timeout` parameter for `interact` is in **seconds** (1-300), not milliseconds.
+
+## Source Of Truth
+
+- `firecrawl/apps/python-sdk/firecrawl/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/rust.mdx
+++ b/agent-quickstart/rust.mdx
@@ -1,0 +1,279 @@
+---
+title: "Rust Agent Quickstart"
+description: "Canonical Firecrawl Rust quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Rust Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating Firecrawl via the Rust SDK. It is generated from SDK source (`firecrawl` crate v2.18.0) and the Firecrawl OpenAPI spec.
+
+## Install
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+firecrawl = "2.18"
+tokio = { version = "1", features = ["full"] }
+```
+
+## Authenticate
+
+```rust
+use firecrawl::Client;
+
+// Cloud client (API key required)
+let client = Client::new("fc-YOUR_API_KEY")?;
+
+// Self-hosted (API key optional)
+let client = Client::new_selfhosted(
+    "https://your-instance.com",
+    Some("fc-YOUR_API_KEY"),
+)?;
+
+// Self-hosted without a key (free tier, rate-limited per IP)
+let client = Client::new_selfhosted(
+    "https://your-instance.com",
+    None::<String>,
+)?;
+```
+
+## When To Use What
+
+- **`search`**: Start with a text query and need to discover relevant URLs and content across the web.
+- **`scrape`**: Already have a URL and want to extract page content (markdown, HTML, structured JSON, screenshots, etc.).
+- **`interact`**: The page needs post-scrape browser actions — clicking buttons, filling forms, executing code in the live browser session.
+
+## Search
+
+### Why use it
+
+Search lets you find relevant web pages, news, or images from a query string. Optionally scrape each result in the same call.
+
+### Preferred SDK method
+
+```rust
+client.search(query, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, SearchOptions};
+
+let client = Client::new("fc-YOUR_API_KEY")?;
+
+let response = client.search("latest firecrawl features", SearchOptions {
+    limit: Some(5),
+    ..Default::default()
+}).await?;
+
+if let Some(web_results) = response.data.web {
+    for result in web_results {
+        println!("{:?}", result);
+    }
+}
+```
+
+### Parameters
+
+All fields on `SearchOptions` are `Option` and default to `None` (not sent to the API).
+
+| Parameter | Type | Description |
+|---|---|---|
+| `limit` | `Option<u32>` | Max results to return. Default: 5, Max: 20. |
+| `sources` | `Option<Vec<SearchSource>>` | Sources: `Web`, `News`, `Images`. Default: `[Web]`. |
+| `categories` | `Option<Vec<SearchCategory>>` | Categories: `Github`, `Research`, `Pdf`. |
+| `include_domains` | `Option<Vec<String>>` | Restrict results to these domains. |
+| `exclude_domains` | `Option<Vec<String>>` | Exclude results from these domains. |
+| `tbs` | `Option<String>` | Time-based search filter (e.g. `"qdr:d"`). |
+| `location` | `Option<String>` | Geographic location for results. |
+| `ignore_invalid_urls` | `Option<bool>` | Exclude invalid URLs from results. |
+| `timeout` | `Option<u32>` | Timeout in ms. |
+| `highlights` | `Option<bool>` | Generate highlights. Default (server): `true`. |
+| `scrape_options` | `Option<ScrapeOptions>` | Options applied when scraping each result. See Scrape parameters. |
+| `integration` | `Option<String>` | Integration identifier. |
+| `origin` | `Option<String>` | Auto-set to `"rust-sdk@<version>"`. |
+
+### Response shape
+
+Returns `SearchResponse` with `data: SearchData`:
+
+- `data.web` — `Option<Vec<SearchResultOrDocument>>` (either `WebResult` or full `Document`)
+- `data.news` — `Option<Vec<SearchResultNews>>`
+- `data.images` — `Option<Vec<SearchResultImage>>`
+
+A convenience method `client.search_and_scrape(query, limit)` returns only `Vec<Document>` by automatically setting `scrape_options`.
+
+## Scrape
+
+### Why use it
+
+Scrape fetches a single URL and returns its content in one or more formats: markdown, HTML, structured JSON, screenshots, audio/video extraction, and more.
+
+### Preferred SDK method
+
+```rust
+client.scrape(url, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, Format};
+
+let client = Client::new("fc-YOUR_API_KEY")?;
+
+let doc = client.scrape("https://example.com", ScrapeOptions {
+    formats: Some(vec![Format::Markdown, Format::Links]),
+    only_main_content: Some(true),
+    timeout: Some(30000),
+    ..Default::default()
+}).await?;
+
+println!("{}", doc.markdown.unwrap_or_default());
+println!("{:?}", doc.links);
+```
+
+#### JSON extraction example
+
+```rust
+use firecrawl::{Client, JsonOptions};
+use serde_json::json;
+
+let client = Client::new("fc-YOUR_API_KEY")?;
+
+let value = client.scrape_with_schema(
+    "https://example.com/product",
+    json!({
+        "type": "object",
+        "properties": {
+            "title": { "type": "string" },
+            "price": { "type": "number" }
+        }
+    }),
+    None::<String>,
+).await?;
+
+println!("{}", value);
+```
+
+### Parameters
+
+All fields on `ScrapeOptions` are `Option` and default to `None`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `formats` | `Option<Vec<Format>>` | Output formats. Variants: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `ChangeTracking`, `Json`, `Attributes`, `Branding`, `Product`, `Menu`, `Audio`, `Video`, `Question(QuestionFormat)`, `Highlights(HighlightsFormat)`. Default: `[Markdown]`. |
+| `headers` | `Option<HashMap<String, String>>` | Custom HTTP headers. |
+| `include_tags` | `Option<Vec<String>>` | HTML tags to include. |
+| `exclude_tags` | `Option<Vec<String>>` | HTML tags to exclude. |
+| `only_main_content` | `Option<bool>` | Main content only. Server default: `true`. |
+| `timeout` | `Option<u32>` | Timeout in ms. Server default: 60000. |
+| `wait_for` | `Option<u32>` | Extra delay in ms before fetching. |
+| `mobile` | `Option<bool>` | Emulate mobile device. |
+| `parsers` | `Option<Vec<ParserConfig>>` | Parser configs. `ParserConfig::Pdf { mode, max_pages, pages, blocks, page_markers }`. |
+| `actions` | `Option<Vec<Action>>` | Browser actions before grabbing content. |
+| `location` | `Option<LocationConfig>` | Geolocation: `{ country, languages }`. |
+| `skip_tls_verification` | `Option<bool>` | Skip TLS verification. |
+| `remove_base64_images` | `Option<bool>` | Strip base64 images from markdown. |
+| `fast_mode` | `Option<bool>` | Quick scrape mode. |
+| `block_ads` | `Option<bool>` | Block ads. Server default: `true`. |
+| `proxy` | `Option<ProxyType>` | Proxy type: `Basic`, `Stealth`, `Enhanced`, `Auto`. Server default: `Auto`. |
+| `max_age` | `Option<u32>` | Max cache age in seconds. |
+| `min_age` | `Option<u32>` | Min cache age in seconds (cache-only mode). |
+| `store_in_cache` | `Option<bool>` | Cache the result. Server default: `true`. |
+| `lockdown` | `Option<bool>` | Serve only cached results. |
+| `redact_pii` | `Option<bool>` | Redact PII (serialized as `redactPII`). |
+| `profile` | `Option<ProfileConfig>` | Persistent browser storage: `{ name, save_changes }`. |
+| `audit_metadata` | `Option<AuditMetadata>` | User attribution for SIEM logging. |
+| `json_options` | `Option<JsonOptions>` | JSON extraction: `{ schema, system_prompt, prompt, check_prompt_injection }`. |
+| `screenshot_options` | `Option<ScreenshotOptions>` | Screenshot config: `{ full_page, quality, viewport }`. |
+| `change_tracking_options` | `Option<ChangeTrackingOptions>` | Change tracking: `{ modes, schema, prompt, tag }`. |
+| `attribute_selectors` | `Option<Vec<AttributeSelector>>` | Attribute extraction: `{ selector, attribute }`. |
+| `integration` | `Option<String>` | Integration identifier. |
+| `origin` | `Option<String>` | Auto-set to `"rust-sdk@<version>"`. |
+
+## Interact
+
+### Why use it
+
+Interact lets you execute code or natural-language prompts in a live browser session tied to a previous scrape job.
+
+### Preferred SDK method
+
+```rust
+client.interact(job_id, options).await
+```
+
+To end the session:
+
+```rust
+client.stop_interaction(job_id).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeExecuteOptions, ScrapeExecuteLanguage};
+
+let client = Client::new("fc-YOUR_API_KEY")?;
+
+let result = client.interact("job-id-here", ScrapeExecuteOptions {
+    code: Some("document.querySelector('#submit').click();".into()),
+    language: Some(ScrapeExecuteLanguage::Node),
+    timeout: Some(30),
+    ..Default::default()
+}).await?;
+
+println!("{:?}", result.stdout);
+
+// End the session
+client.stop_interaction("job-id-here").await?;
+```
+
+### Parameters
+
+`ScrapeExecuteOptions` fields:
+
+| Parameter | Type | Description |
+|---|---|---|
+| `code` | `Option<String>` | Code to execute. One of `code` or `prompt` required. |
+| `prompt` | `Option<String>` | Natural-language prompt. One of `code` or `prompt` required. |
+| `language` | `Option<ScrapeExecuteLanguage>` | `Python`, `Node`, or `Bash`. Default: `Node`. |
+| `timeout` | `Option<u32>` | Execution timeout in seconds (1-300). Server default: 30. |
+| `origin` | `Option<String>` | Auto-set to `"rust-sdk@<version>"`. |
+
+### Response
+
+Returns `ScrapeExecuteResponse`:
+
+| Field | Type | Description |
+|---|---|---|
+| `success` | `bool` | Whether execution succeeded. |
+| `live_view_url` | `Option<String>` | Read-only live view URL. |
+| `interactive_live_view_url` | `Option<String>` | Interactive live view URL. |
+| `output` | `Option<String>` | AI agent response (when using `prompt`). |
+| `stdout` | `Option<String>` | Standard output. |
+| `result` | `Option<String>` | Alias for stdout. |
+| `stderr` | `Option<String>` | Standard error. |
+| `exit_code` | `Option<i32>` | Exit code. |
+| `killed` | `Option<bool>` | Whether killed due to timeout. |
+| `error` | `Option<String>` | Error message. |
+
+## Notes
+
+- **Naming style**: All struct fields use snake_case (e.g. `only_main_content`, `include_tags`). Serialization to the API uses camelCase automatically via serde rename attributes.
+- **Deprecated aliases**: `scrape_execute()` → use `interact()`. `stop_interactive_browser()` / `delete_scrape_browser()` → use `stop_interaction()`.
+- **Async**: All methods are async and require a Tokio runtime.
+- **`max_age` / `min_age`**: In the Rust SDK these are in **seconds**, while the OpenAPI spec uses milliseconds. Check the current source if precision matters.
+- **`scrape_with_schema`**: Convenience method that sets up `JsonOptions` for you and returns the extracted `serde_json::Value` directly.
+
+## Source Of Truth
+
+- `firecrawl/apps/rust-sdk/src/client.rs`
+- `firecrawl/apps/rust-sdk/src/scrape.rs`
+- `firecrawl/apps/rust-sdk/src/search.rs`
+- `firecrawl/apps/rust-sdk/src/types.rs`
+- `firecrawl/apps/rust-sdk/Cargo.toml`
+- `firecrawl-docs/api-reference/v2-openapi.json`


### PR DESCRIPTION
## Summary

- Adds one canonical agent quickstart document per SDK language in `agent-quickstart/`: Node.js, Python, Rust, Java, and Elixir
- Each file covers `search`, `scrape`, and `interact` endpoints with install instructions, auth patterns, preferred method names, working examples, and every confirmed parameter with descriptions
- Generated from SDK source code (JS SDK v4.38.0, Python SDK firecrawl-py, Rust crate v2.18.0, Java SDK v1.17.0, Elixir hex v1.11.0) and the OpenAPI spec (`api-reference/v2-openapi.json`)
- Includes deprecated alias migration notes and language-specific caveats
- Mintlify-compatible MDX with valid YAML frontmatter

## New files

| File | Language | SDK version |
|---|---|---|
| `agent-quickstart/node.mdx` | Node.js / TypeScript | `@mendable/firecrawl-js` v4.38.0 |
| `agent-quickstart/python.mdx` | Python | `firecrawl-py` |
| `agent-quickstart/rust.mdx` | Rust | `firecrawl` crate v2.18.0 |
| `agent-quickstart/java.mdx` | Java | `com.firecrawl:firecrawl-java` v1.17.0 |
| `agent-quickstart/elixir.mdx` | Elixir | `:firecrawl` hex v1.11.0 |

## Test plan

- [ ] Verify each `.mdx` file renders correctly in Mintlify dev preview
- [ ] Confirm parameter lists match current SDK source
- [ ] Confirm code examples are syntactically valid
- [ ] Verify no localized files were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NX4ekAyhRtSupKt4vLphng

---
_Generated by [Claude Code](https://claude.ai/code/session_01NX4ekAyhRtSupKt4vLphng)_