### PR TITLE
Correct the AIMultiple benchmark date, scope, and tier framing

### DIFF
--- a/features/extract.mdx
+++ b/features/extract.mdx
@@ -218,7 +218,7 @@ curl -X POST https://api.firecrawl.dev/v2/extract \
 
 ## Billing and Usage Tracking
 
-We've simplified billing so that Extract now uses credits, just like all of the other endpoints. Each credit is worth 15 tokens.
+We've simplified billing so that Extract now uses credits, just like all of the other endpoints. Each credit is worth 15 tokens. See [Billing](/billing) for how credits map to plan pricing; scrape and crawl are billed at 1 credit per page ([Scrape cost](/features/scrape#scraping-a-url-with-firecrawl)).
 
 You can monitor Extract usage via the [dashboard](https://www.firecrawl.dev/app/extract).
 

--- a/features/extract.mdx
+++ b/features/extract.mdx
@@ -38,7 +38,7 @@ import ExtractWithoutURLsCURL from "/snippets/v2/extract/without-urls/curl.mdx";
 
 The `/extract` endpoint simplifies collecting structured data from any number of URLs or entire domains. Provide a list of URLs, optionally with wildcards (e.g., `example.com/*`), and a prompt or schema describing the information you want. Firecrawl handles the details of crawling, parsing, and collating large or small datasets.
 
-<Info>We've simplified billing so that Extract now uses credits, just like all of the other endpoints. Each credit is worth 15 tokens.</Info>
+<Info>We've simplified billing so that Extract now uses credits, just like all of the other endpoints. Each credit is worth 15 tokens. See [Billing](/billing) for how credits map to plan pricing; scrape and crawl are billed at 1 credit per page ([Scrape cost](/features/scrape#scraping-a-url-with-firecrawl)).</Info>
 
 ## Using `/extract`
 

--- a/features/search.mdx
+++ b/features/search.mdx
@@ -617,7 +617,7 @@ Independent evaluators have benchmarked Firecrawl Search against other search AP
 
 | Metric | Value | Source | Date | n / ± |
 | --- | --- | --- | --- | --- |
-| Agent Score (Mean Relevant × Quality) | 14.58, rank 2 of 8 (Mean Relevant 4.30/5, Quality 3.39/5) | [AIMultiple — Agentic Search Benchmark](https://aimultiple.com/agentic-search) | Dec 2025 (source updated May 25, 2026) | 95% CI 13.12–15.98, n=100 AI/LLM-domain queries (10,000 bootstrap resamples); the source notes results don't generalize to other domains |
+| Agent Score (Mean Relevant × Quality) | 14.58, rank 2 of 8 (Mean Relevant 4.30/5, Quality 3.39/5) | [AIMultiple — Agentic Search Benchmark](https://aimultiple.com/agentic-search) | Dec 2025 (source updated May 25, 2026) | 95% CI 13.12–15.98, n=100 AI/LLM-domain queries drawn from AIMultiple's own organic search traffic (10,000 bootstrap resamples); the source notes results don't generalize to other domains |
 
 <Note>
 These are third-party measurements, each with its own harness, task set, and methodology — they are not directly comparable to one another or to Firecrawl's own benchmarks. Point-estimate rank 2 of 8; paired-bootstrap testing found no statistically significant gap versus Brave, Exa, or Parallel Search Pro. Firecrawl's own first-party benchmark pages, including the open-source Developer Index evaluation, live at [firecrawl.dev/benchmarks](https://www.firecrawl.dev/benchmarks).

--- a/features/search.mdx
+++ b/features/search.mdx
@@ -617,10 +617,10 @@ Independent evaluators have benchmarked Firecrawl Search against other search AP
 
 | Metric | Value | Source | Date | n / ± |
 | --- | --- | --- | --- | --- |
-| Agent Score (Mean Relevant × Quality) | 14.58, rank 2 of 8 (Mean Relevant 4.30/5, Quality 3.39/5) | [AIMultiple — Agentic Search Benchmark](https://aimultiple.com/agentic-search) | 2026 | 95% CI 13.12–15.98, n=100 queries (10,000 bootstrap resamples) |
+| Agent Score (Mean Relevant × Quality) | 14.58, rank 2 of 8 (Mean Relevant 4.30/5, Quality 3.39/5) | [AIMultiple — Agentic Search Benchmark](https://aimultiple.com/agentic-search) | Dec 2025 (source updated May 25, 2026) | 95% CI 13.12–15.98, n=100 AI/LLM-domain queries (10,000 bootstrap resamples); the source notes results don't generalize to other domains |
 
 <Note>
-These are third-party measurements, each with its own harness, task set, and methodology — they are not directly comparable to one another or to Firecrawl's own benchmarks. AIMultiple's results place Firecrawl within the top statistical tier alongside Brave, Exa, and Parallel Search Pro (the ~0.3-point gaps between them fall inside the reported confidence intervals and are ties, not a ranking). Firecrawl's own first-party benchmark pages, including the open-source Developer Index evaluation, live at [firecrawl.dev/benchmarks](https://www.firecrawl.dev/benchmarks).
+These are third-party measurements, each with its own harness, task set, and methodology — they are not directly comparable to one another or to Firecrawl's own benchmarks. Point-estimate rank 2 of 8; paired-bootstrap testing found no statistically significant gap versus Brave, Exa, or Parallel Search Pro. Firecrawl's own first-party benchmark pages, including the open-source Developer Index evaluation, live at [firecrawl.dev/benchmarks](https://www.firecrawl.dev/benchmarks).
 </Note>
 
 ## Search feedback

--- a/features/search.mdx
+++ b/features/search.mdx
@@ -611,6 +611,18 @@ For more details about the scraping options, refer to the [Scrape Feature docume
 > Are you an AI agent that needs a Firecrawl API key? See [firecrawl.dev/agent-onboarding/SKILL.md](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for automated onboarding instructions.
 
 
+## Measured Performance
+
+Independent evaluators have benchmarked Firecrawl Search against other search APIs. The figures below are pulled directly from each evaluator's published results as of the date shown.
+
+| Metric | Value | Source | Date | n / ± |
+| --- | --- | --- | --- | --- |
+| Agent Score (Mean Relevant × Quality) | 14.58, rank 2 of 8 (Mean Relevant 4.30/5, Quality 3.39/5) | [AIMultiple — Agentic Search Benchmark](https://aimultiple.com/agentic-search) | 2026 | 95% CI 13.12–15.98, n=100 queries (10,000 bootstrap resamples) |
+
+<Note>
+These are third-party measurements, each with its own harness, task set, and methodology — they are not directly comparable to one another or to Firecrawl's own benchmarks. AIMultiple's results place Firecrawl within the top statistical tier alongside Brave, Exa, and Parallel Search Pro (the ~0.3-point gaps between them fall inside the reported confidence intervals and are ties, not a ranking). Firecrawl's own first-party benchmark pages, including the open-source Developer Index evaluation, live at [firecrawl.dev/benchmarks](https://www.firecrawl.dev/benchmarks).
+</Note>
+
 ## Search feedback
 
 When a search result is useful or misses important content, submit feedback with `POST /v2/search/{jobId}/feedback`. The first feedback submission for a search job can refund 1 credit, subject to team limits, and helps improve Firecrawl search quality. See [Search Feedback](/api-reference/endpoint/search-feedback).


### PR DESCRIPTION
### Summary

The measured-performance table added to `features/search.mdx` dated the AIMultiple study by the
article's update date rather than the measurement, omitted that its query set is AI/LLM-domain only,
and carried a Note whose "ties, not a ranking" sentence contradicted the table's own "rank 2 of 8".
This branch corrects all three against the source, and links the first "15 tokens" callout on
`features/extract.mdx` to the billing and per-page credit statements.

### Why (evidence)

Source report: Weekly Deep Insights `DI-2026-09-03-WEEKLY`, report date 2026-09-03.

Findings: **F6-SCALAR-ASYMMETRY**, grade **C minus**, verdict file `verdicts/deep-F6-benchmarks.md`
(docs.firecrawl.dev is the owned host agents actually reach per the exposure ledger, yet carried no
measured-performance information), and **F1-PRICING-UNIT**, grade **B minus**, verdict file
`verdicts/deep-F1-pricing.md` (disconnected credit statements).

Verified against the archived source at `review-grounding/aimultiple.md`:

- Line 536: "This reflects December 2025 snapshot only." Lines 175 and 667: "updated on May 25,
  2026" and "Retrieved May 25, 2026".
- Line 535: "All queries are AI/LLM-related. Results don't generalize to medical, legal, e-commerce,
  or general domains." Line 494: "10,000 new datasets by randomly sampling 100 queries with
  replacement."
- Line 248: "Ranked in the top tier, with no statistically significant difference compared to
  Firecrawl, Exa, or Parallel Search Pro." Line 500 confirms paired bootstrap.
- Line 521: Agent Score 14.58, 95% CI 13.12 to 15.98, Mean Relevant 4.30 of 5, Quality 3.39 of 5,
  rank 2 of 8. All match the table exactly.
- Line 422: "Source: Top 500 queries from AIMultiple.com organic search traffic (Dec 2024 to Jan
  2025)."

The removed phrase "the ~0.3-point gaps between them fall inside the reported confidence intervals"
also understated the actual tier span, which is Brave 14.89 to Parallel Pro 14.21, or 0.68. The
phrase is deleted entirely rather than corrected.

Final verdict: **APPROVE** per the resolution addendum to
`review-grounding/FINAL-REVIEW-docs-mcp.md` (the review body records APPROVE-WITH-NITS; the single
nit was resolved in commit `3c66fc32`).

### Changes

- `features/search.mdx`, Measured Performance table. The Date cell reads
  `Dec 2025 (source updated May 25, 2026)`. The `n / ±` cell reads
  `95% CI 13.12–15.98, n=100 AI/LLM-domain queries drawn from AIMultiple's own organic search
  traffic (10,000 bootstrap resamples); the source notes results don't generalize to other domains`.
- `features/search.mdx`, the Note below the table. The self-contradicting "ties, not a ranking"
  sentence is replaced with "Point-estimate rank 2 of 8; paired-bootstrap testing found no
  statistically significant gap versus Brave, Exa, or Parallel Search Pro." The link to
  `firecrawl.dev/benchmarks` is retained.
- `features/extract.mdx`, line 41, the top-of-page `<Info>` and the first "15 tokens" statement a
  reader hits. It now carries "See [Billing](/billing) for how credits map to plan pricing; scrape
  and crawl are billed at 1 credit per page
  ([Scrape cost](/features/scrape#scraping-a-url-with-firecrawl))." The second occurrence at roughly
  line 221, under "Billing and Usage Tracking", was already linked by the prior commit and is
  unchanged, so both occurrences now carry matching text.

Diffstat: 2 files changed, 14 insertions, 2 deletions.

### Verification

Anchors resolve: `billing.mdx` exists, and `## Scraping a URL with Firecrawl` is at
`features/scrape.mdx:76`.

`mint broken-links` under Node 22.23.2: 208 broken links in 95 files, identical to the pre-existing
baseline and byte-identical to the output on the other two docs worktrees after stripping spinner
frames. Neither `features/search.mdx` nor `features/extract.mdx` appears.

`mint validate`: fails with 17 warnings, all pre-existing "Could not find file" warnings for missing
locale snippet files under `/snippets/v2/extract/short/` and `/snippets/*/v1/scrape/agent-f1/`. No
touched file appears.

Every figure in the table was re-checked line by line against the archived source during the
independent final review, not taken from the fix report.

### Not in this PR

- The same "15 tokens" statement appears in `v1/features/extract.mdx`,
  `api-reference/endpoint/token-usage*.mdx` and
  `developer-guides/usage-guides/choosing-the-data-extractor.mdx`, all unlinked. Out of scope for
  this wave.
- All localized copies (`es/`, `fr/`, `pt-BR/`, `zh/`) are untouched; the repo `CLAUDE.md` prohibits
  modifying them.
- The F6 discrepancy "openbenchmarks 70.3 ± 1.5, 2nd of 11" is byte-verified from a snapshot but was
  not locatable live on 2026-09-04 (the nearest source, Artificial Analysis, shows Firecrawl roughly
  8th of 12). It is deliberately not quoted anywhere on this page and should be located or retired
  before it is quoted again.
- DevDex 63.1% Recall@10 is first-party, not third-party, and is deliberately excluded from a table
  of third-party measurements.

### Links

Files changed:

- `features/search.mdx`
- `features/extract.mdx`

Evidence packet:
`agent-experience-deepinsights-cleanroom/artifacts/deep-insights-sep3-verification-20260904/`
