### PR TITLE
Document crawl execution and result accounting as current behavior

### DIFF
--- a/api-reference/endpoint/crawl-get-errors.mdx
+++ b/api-reference/endpoint/crawl-get-errors.mdx
@@ -3,4 +3,8 @@ title: 'Get Crawl Errors'
 openapi: '/api-reference/v2-openapi.json GET /crawl/{id}/errors'
 ---
 
+<Info>
+  This endpoint records pages that did not make it into the crawl's `data` array: `errors` for scrapes Firecrawl failed, and `robotsBlocked` for URLs blocked by robots.txt. Failed pages appear nowhere in the [crawl status](/api-reference/endpoint/crawl-get) counters, so this is the only place to find them — but the list is not guaranteed complete, because some internal failure classes are filtered out before the response is built. See [Execution and result accounting](/features/crawl#execution-and-result-accounting) for how to read it alongside the status counters.
+</Info>
+
 > Are you an AI agent that needs a Firecrawl API key? See [firecrawl.dev/agent-onboarding/SKILL.md](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for automated onboarding instructions.

--- a/api-reference/endpoint/crawl-get.mdx
+++ b/api-reference/endpoint/crawl-get.mdx
@@ -3,4 +3,8 @@ title: 'Get Crawl Status'
 openapi: '/api-reference/v2-openapi.json GET /crawl/{id}'
 ---
 
+<Info>
+  `total` counts completed, active, queued, and backlogged pages and excludes failed ones, so `completed == total` on a finished crawl does not mean every discovered page succeeded. Pair the counters with [Get Crawl Errors](/api-reference/endpoint/crawl-get-errors) to see pages that were attempted but not returned, and see [Execution and result accounting](/features/crawl#execution-and-result-accounting) for how to read them together and when to stop paging with `next`.
+</Info>
+
 > Are you an AI agent that needs a Firecrawl API key? See [firecrawl.dev/agent-onboarding/SKILL.md](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for automated onboarding instructions.

--- a/features/crawl.mdx
+++ b/features/crawl.mdx
@@ -242,6 +242,84 @@ Every webhook request from Firecrawl includes an `X-Firecrawl-Signature` header 
 
 For complete implementation examples in JavaScript and Python, see the [Webhook Security documentation](/webhooks/security). For comprehensive webhook documentation including detailed event payloads, payload structure, advanced configuration, and troubleshooting, see the [Webhooks documentation](/webhooks/overview).
 
+## Execution and result accounting
+
+A crawl that finishes is not the same as a crawl that reached every page. This section describes what the crawl endpoints currently report about a run — the counters, the paging contract, the failure records, and the scope limits — so you can judge for yourself whether a run is complete enough to act on. None of these records is a guarantee of completeness.
+
+### Reading the status counters
+
+Every response from [Get Crawl Status](/api-reference/endpoint/crawl-get) (`GET /v2/crawl/{id}`) carries the counters that describe the run:
+
+| Field | Meaning |
+|-------|---------|
+| `status` | One of `scraping`, `completed`, `failed`, or `cancelled` |
+| `total` | `completed` plus the pages still in flight: active, queued, and backlogged. **Failed pages are not counted.** |
+| `completed` | The number of pages that have been successfully crawled |
+| `creditsUsed` | Credits consumed by the crawl so far |
+| `createdAt` / `completedAt` / `duration` | Start time, finish time (terminal states only), and elapsed seconds |
+| `expiresAt` | When the results stop being retrievable from the API |
+| `next` | URL for the next 10MB page of results. Also emitted whenever `status` is not `completed` — see [Paging through results](#paging-through-results). |
+
+<Warning>
+  `completed == total` on a finished crawl does **not** mean every discovered page succeeded. Because `total` sums completed, active, queued, and backlogged pages and excludes failed ones, a terminal crawl always has `active`, `queued`, and `backlog` at zero — so the two counters converge whether or not pages failed. The status counters cannot tell you that anything failed. Failed pages are enumerated only by [Get Crawl Errors](#failed-and-blocked-pages).
+</Warning>
+
+The `data` array holds only pages Firecrawl successfully scraped. Pages that were attempted but never produced a result are not in `data` — read them from Get Crawl Errors, below.
+
+### Paging through results
+
+Responses are capped at 10MB. When a response is truncated, `next` carries the URL for the following page of results.
+
+`next` is not purely a "more data remains" signal: it is also emitted whenever `status` is not `completed`, so a terminal `failed` or `cancelled` crawl can return a `next` URL even though no further results exist. Do not use the absence of `next` as your loop's exit condition — on a failed or cancelled crawl it never disappears.
+
+The terminal condition is the status field. To read a run to the end:
+
+1. Poll `GET /v2/crawl/{id}` until `status` is one of `completed`, `failed`, or `cancelled`.
+2. While `next` is present **and** the last page returned a non-empty `data` array, follow `next` to collect the remaining results.
+3. Stop when `next` is absent, or when a page returns no new documents.
+
+The official SDKs handle this paging for you and return all results at once.
+
+### Failed and blocked pages
+
+[Get Crawl Errors](/api-reference/endpoint/crawl-get-errors) (`GET /v2/crawl/{id}/errors`) records pages that did not make it into `data`. It returns two arrays:
+
+- `errors` — errored scrape jobs, each with `id`, `url`, `error` (the error message), and a `timestamp` of the failure. These are pages Firecrawl itself failed to scrape: network errors, timeouts, and similar. Links to an external site's homepage that were intentionally skipped are reported here with an error code of `EXTERNAL_LINK`.
+- `robotsBlocked` — URLs that were attempted but blocked by the site's robots.txt.
+
+<Note>
+  This list is not guaranteed to be a complete enumeration of every failure: some internal failure classes are currently filtered out of `errors` before the response is built. Treat it as the record of failures Firecrawl reports, not as a proof that nothing else went wrong. The error code referenced above (`EXTERNAL_LINK`) is returned on error objects today but is not yet part of the published `GET /crawl/{id}/errors` schema; it is pending an API reference update.
+</Note>
+
+A page where the target site returned an HTTP error such as 404 is *not* a crawl error: Firecrawl scraped it successfully, so it appears in `data` with the site's status code in `metadata.statusCode`.
+
+### What the crawler is scoped to reach
+
+Coverage is bounded by the scope parameters you set, all documented in the [configuration reference](#configuration-reference) and the [Crawl endpoint reference](/api-reference/endpoint/crawl-post):
+
+- **Children only by default.** Crawl ignores sublinks that are not children of the URL you provide. Use `crawlEntireDomain` for sibling and parent paths, `allowSubdomains` for subdomains, and `allowExternalLinks` to follow links off the domain.
+- **`includePaths` / `excludePaths` match the URL pathname**, as regex patterns — not the full URL, and not query parameters. Set `regexOnFullURL: true` to match against the full URL including query strings instead. The starting URL is also checked against `includePaths`: if it does not match, the crawl may return 0 pages.
+- **Sitemap mode.** With the default `sitemap: "include"`, URLs come from the sitemap plus recursive link discovery. `"skip"` uses HTML links only, so sitemap-only pages such as PDFs or deeply nested pages are missed. `"only"` crawls the sitemap plus the start URL and does not discover links from HTML.
+- **`maxDiscoveryDepth`** caps how many link-discovery hops from the root are followed. Pages at the maximum depth are still scraped, but links found on them are not followed.
+- **`limit`** caps the number of pages, and defaults to `10000`. The crawl endpoint checks up front that your remaining credits cover the `limit` and returns **402 (Payment Required)** if they do not.
+- **`ignoreQueryParameters`** avoids re-scraping the same path with different query parameters.
+- **robots.txt is respected** unless `ignoreRobotsTxt` is enabled (Enterprise only).
+
+`maxConcurrency` defaults to your team's concurrency limit, which is set by your plan — see [Rate limits](/rate-limits).
+
+### When results vary between runs
+
+Crawl results may vary between runs of the same configuration. Pages are scraped concurrently, so the order in which links are discovered depends on network timing and which pages finish loading first. This means different branches of a site may be explored to different extents near the depth boundary, especially at higher `maxDiscoveryDepth` values.
+
+To make a run more reproducible:
+
+- Set `maxConcurrency` to `1`. As the [configuration reference](#configuration-reference) states, `maxConcurrency` is the "maximum concurrent scrapes" — it caps how many requests are in flight at once. That reduces timing-dependent interleaving, but it does not remove run-to-run variation: sitemap discovery is enqueued outside the cap, nested sitemaps are fetched as independent jobs, and the returned `data` array is ordered by finish time rather than discovery order. Setting `delay` also forces concurrency to 1.
+- Use `sitemap: "only"` if the site has a comprehensive sitemap, so the URL set comes from the sitemap rather than from link discovery.
+
+### Knowing when a crawl is done
+
+If you are not polling, the [webhook events](#event-types) tell you the same thing: `crawl.page` fires for each page successfully scraped, and `crawl.completed` (or `crawl.failed`) fires when the run ends. Job results stay retrievable from the API for 24 hours after completion; after that, view them in the [activity logs](https://www.firecrawl.dev/app/logs).
+
 ## Configuration reference
 
 The full set of parameters available when submitting a crawl job:
@@ -278,6 +356,6 @@ The full set of parameters available when submitting a crawl job:
 - **Result expiration**: Job results are available via the API for 24 hours after completion. After that, view results in the [activity logs](https://www.firecrawl.dev/app/logs).
 - **Crawl errors**: The `data` array contains pages Firecrawl successfully scraped. Use the [Get Crawl Errors](/api-reference/endpoint/crawl-get-errors) endpoint to retrieve pages that failed due to network errors, timeouts, or robots.txt blocks.
 - <a id="external-links"></a>**External links**: With `allowExternalLinks: true`, the crawler follows links pointing off your domain and scrapes each linked page once — it does not then crawl the links found on those external pages. Links to an external site's **homepage** (a root URL with no path, e.g. `https://example.com/`) are intentionally skipped to avoid pulling in an entire unrelated site; these appear in [Get Crawl Errors](/api-reference/endpoint/crawl-get-errors) with the code `EXTERNAL_LINK`. Redirects are followed to their destination — including a link that resolves to its canonical URL (for example `http → https` or the `www` variant) — so only redirects that land on an external homepage are skipped.
-- **Non-deterministic results**: Crawl results may vary between runs of the same configuration. Pages are scraped concurrently, so the order in which links are discovered depends on network timing and which pages finish loading first. This means different branches of a site may be explored to different extents near the depth boundary, especially at higher `maxDiscoveryDepth` values. To get more deterministic results, set `maxConcurrency` to `1` or use `sitemap: "only"` if the site has a comprehensive sitemap.
+- **Non-deterministic results**: Crawl results may vary between runs of the same configuration, because pages are scraped concurrently and link-discovery order depends on network timing. See [Execution and result accounting](#execution-and-result-accounting) for what varies and how to make a run more reproducible.
 
 > Are you an AI agent that needs a Firecrawl API key? See [firecrawl.dev/agent-onboarding/SKILL.md](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for automated onboarding instructions.

--- a/features/crawl.mdx
+++ b/features/crawl.mdx
@@ -301,7 +301,7 @@ Coverage is bounded by the scope parameters you set, all documented in the [conf
 - **`includePaths` / `excludePaths` match the URL pathname**, as regex patterns — not the full URL, and not query parameters. Set `regexOnFullURL: true` to match against the full URL including query strings instead. The starting URL is also checked against `includePaths`: if it does not match, the crawl may return 0 pages.
 - **Sitemap mode.** With the default `sitemap: "include"`, URLs come from the sitemap plus recursive link discovery. `"skip"` uses HTML links only, so sitemap-only pages such as PDFs or deeply nested pages are missed. `"only"` crawls the sitemap plus the start URL and does not discover links from HTML.
 - **`maxDiscoveryDepth`** caps how many link-discovery hops from the root are followed. Pages at the maximum depth are still scraped, but links found on them are not followed.
-- **`limit`** caps the number of pages, and defaults to `10000`. The crawl endpoint checks up front that your remaining credits cover the `limit` and returns **402 (Payment Required)** if they do not.
+- **`limit`** caps the number of pages, and defaults to `10000`.
 - **`ignoreQueryParameters`** avoids re-scraping the same path with different query parameters.
 - **robots.txt is respected** unless `ignoreRobotsTxt` is enabled (Enterprise only).
 

--- a/features/map.mdx
+++ b/features/map.mdx
@@ -139,4 +139,6 @@ For more details about supported locations, refer to the [Proxies documentation]
 
 This endpoint prioritizes speed, so it may not capture all website links. It primarily relies on the website's sitemap, supplemented by cached crawl data and search engine results. For a more thorough and up-to-date list of URLs, consider using the [/crawl](/features/crawl) endpoint instead.
 
+If you need more thorough recursive discovery with auditable result and error records rather than a fast approximation, use [/crawl](/features/crawl), which discovers pages by recursive link traversal as well as the sitemap and reports what it returned and what it failed to fetch — see [Execution and result accounting](/features/crawl#execution-and-result-accounting). For the links on one specific page, request the [`links` format](/features/scrape#scrape-formats) from [/scrape](/features/scrape).
+
 > Are you an AI agent that needs a Firecrawl API key? See [firecrawl.dev/agent-onboarding/SKILL.md](https://www.firecrawl.dev/agent-onboarding/SKILL.md) for automated onboarding instructions.


### PR DESCRIPTION
### Summary

The crawl docs presented `completed` and `total` as a coverage receipt, told callers to page until
`next` is absent, listed three crawl statuses where Core returns four, and described
`maxConcurrency: 1` as removing run-to-run variation. Each of those is contradicted by Core. This
branch rewrites the section to describe what the endpoints actually report, with a Core file and
line behind every behavioral claim, and states plainly that none of the records is a guarantee of
completeness.

### Why (evidence)

Source reports: Developer-bank positioning read
(`analysis/loop/run/DEVELOPER-POSITIONING-READ.txt`, 2026-08-31) and Weekly Deep Insights
`DI-2026-08-30-WEEKLY` (2026-08-30).

Findings: the developer read's verdict, "The developer bank rejects Firecrawl on PROOF OF COVERAGE".
14 of 59 named traces carry a negative, decline or competitor-advantage verdict, 10 of them in the
`interact` bucket, including 9 of 10 `interactive_traversal` prompts. Hypothesis **H1**: a
documented coverage receipt on actions-bearing scrapes converts the decline. Adjudications: **D7
TRUE** (map is not exhaustive, in Firecrawl's own words), **D8 STALE**, **D2 STALE**, and D1, D3, D5
owner-required. **OB-02-completeness-objection-is-first-party**, grade **A minus** in the 2026-09-03
review: "quotable verbatim from Firecrawl's own docs, with no coverage contract alongside it."

Verified evidence: `docs.firecrawl.dev/features/crawl` "Crawl results may vary between runs of the
same configuration" and "By default, crawl ignores sublinks that are not children of the URL you
provide"; `/features/map` "This endpoint prioritizes speed, so it may not capture all website
links"; developer traces VDEV-201 ("All are convenient and all have the same silent-truncation
failure mode"), VDEV-210, VDEV-213, VDEV-222 ("less control over scroll termination, which is the
crux of your task"), VDEV-226 ("you need exhaustive link enumeration with an audit trail") and
VDEV-953 ("reintroduce exactly the silent-partial-result problem").

Core verification, read-only, each statement checked against source:

- `apps/api/src/controllers/v2/crawl-status.ts:215-245` computes
  `total = completed + active + queued + backlog`. The stats map carries a distinct `failed` bucket
  that is never summed (`apps/api/src/services/worker/nuq-fdb/queue.ts:1230-1251`).
- `crawl-status.ts:324-331`:
  `next = (outputBulkA.total ?? 0) > start + iteratedOver || outputBulkA.status !== "completed" ? <url> : undefined`.
  The second disjunct emits `next` for every non-`completed` status, including terminal `failed` and
  `cancelled`.
- `apps/api/src/controllers/v2/types.ts:1477-1505`:
  `status: "scraping" | "completed" | "failed" | "cancelled"`. `cancelled` is reachable via
  `sc?.cancelled` at `crawl-status.ts:233-237`.
- `apps/api/src/controllers/v2/crawl-errors.ts:44-77` returns `null` for
  `error?.code === "SCRAPE_RACED_REDIRECT_ERROR"`, plus a `.filter(x => x.failedReason)` and a
  `mode !== "single_urls"` drop.
- Concurrency enforcement is an active-job counter, not a serializer
  (`apps/api/src/lib/concurrency-limit.ts:244-262`,
  `apps/api/src/services/worker/nuq-fdb/queue.ts:439-455`). Surviving variation sources: bulk sitemap
  kickoff `scrape-worker.ts:1296-1341`, nested sitemap fan-out `:1506-1512`, priority dequeue
  `:590-595`, finish-time result ordering `nuq-fdb/queue.ts:1291-1300`. `delay > 0` forcing
  concurrency to 1 is confirmed at `concurrency-limit.ts:248-251` and `queue-jobs.ts:381-384`.
- `types.ts:1110` and `:1148`: `limit` default is `z.number().prefault(10000)`. `crawl-status.ts:291`:
  `bytesLimit = 10485760`.

Final verdict: **APPROVE** per the resolution addendum to
`review-grounding/FINAL-REVIEW-docs-mcp.md` (the review body records APPROVE-WITH-NITS; the acted-on
nit was resolved in commit `0ce9a8ed`).

### Changes

- `features/crawl.mdx`. The section `## Coverage and determinism` becomes
  `## Execution and result accounting`, and its opener states that the section describes what the
  endpoints currently report and that "None of these records is a guarantee of completeness." The
  strings "coverage receipt" and "proof of coverage" return 0 hits repository-wide.
- The `total` row becomes "`completed` plus the pages still in flight: active, queued, and
  backlogged. **Failed pages are not counted.**", with a new `<Warning>` explaining why
  `completed == total` is uninformative: a terminal crawl has active, queued and backlog at zero, so
  the counters converge whether or not pages failed, and failed pages are enumerated only by Get
  Crawl Errors.
- The `status` row lists four values including `cancelled`.
- The `next` row states it is also emitted whenever `status` is not `completed`, and the old
  `<Warning>` is replaced by a new `### Paging through results` subsection. Behavior contract: the
  terminal condition is the status field, not the absence of `next`. The documented loop is poll
  `GET /v2/crawl/{id}` until `status` is one of `completed`, `failed` or `cancelled`; while `next` is
  present and the last page returned a non-empty `data` array, follow it; stop when `next` is absent
  or a page returns no new documents.
- The Get Crawl Errors lead-in changes from "is the list of" to "records", `EXTERNAL_LINK` is
  reworded off the undocumented field name, and a new `<Note>` states the list is not guaranteed to
  be a complete enumeration because some internal failure classes are filtered out before the
  response is built, and that `EXTERNAL_LINK` is returned today but is not yet part of the published
  schema. Per the "public docs, no internals" rule the note names the behavior, not the internal
  error constant.
- The `maxConcurrency: 1` bullet no longer claims determinism. It cites this repo's own
  configuration table (`features/crawl.mdx:325`, "Maximum concurrent scrapes") and states that
  capping in-flight requests reduces timing-dependent interleaving but does not remove run-to-run
  variation, because sitemap discovery is enqueued outside the cap, nested sitemaps are fetched as
  independent jobs, and the returned `data` array is ordered by finish time rather than discovery
  order. The caveats cross-reference at `:359` was retargeted and "how to make a run reproducible"
  softened to "more reproducible".
- The restated "returns 402 if credits don't cover the limit" clause was removed from the new scope
  section's `limit` bullet (commit `0ce9a8ed`), because Core clamps rather than rejects:
  `apps/api/src/controllers/v2/crawl.ts:248-252`,
  `finalCrawlerOptions.limit = Math.min(remainingCredits, finalCrawlerOptions.limit)`, with
  `checkCreditsMiddleware` named as the actual 402 source.
- `features/map.mdx:142`. "If you need exhaustive enumeration rather than a fast approximation"
  becomes "If you need more thorough recursive discovery with auditable result and error records
  rather than a fast approximation", pointing at the renamed section. The `links` scrape-format
  pointer is preserved verbatim.
- `api-reference/endpoint/crawl-get.mdx` and `api-reference/endpoint/crawl-get-errors.mdx` callouts
  rewritten to state the `total` exclusion and the incompleteness of the error list directly, rather
  than deferring to a "coverage receipt".
- The anchor `#coverage-and-determinism` was retargeted to `#execution-and-result-accounting` in all
  four referring locations: `features/crawl.mdx:359`, `features/map.mdx:142`,
  `api-reference/endpoint/crawl-get.mdx:7`, `api-reference/endpoint/crawl-get-errors.mdx:7`.
- `openapi.json` and its mirror `api-reference/v2-openapi.json` were deliberately not edited; they
  are recorded as Core/OpenAPI defects below.

Diffstat: 4 files changed, 89 insertions, 1 deletion.

### Verification

Independent re-verification against Core during final review confirmed every statement above, and
separately confirmed the stale artifacts the branch declines to touch:
`CrawlStatusResponseObj.status.description` in `api-reference/v2-openapi.json` still reads "Can be
`scraping`, `completed`, or `failed`", and `CrawlErrorsResponseObj` has no `code` property, its
`errors.items.properties` being exactly `id`, `timestamp`, `url`, `error`. `EXTERNAL_LINK` appears in
the OpenAPI file exactly once, in the `allowExternalLinks` prose at line 1793, not in the errors
schema, so the page's claim that it is not yet published is accurate.

Grep negative controls: "coverage receipt" and "proof of coverage" return 0 hits across `*.mdx`,
`*.md` and `*.json` in the worktree; "exhaustive enumeration" is gone from `map.mdx`.

Anchors. All new intra-page anchors resolve: `#execution-and-result-accounting` (`:245`),
`#paging-through-results` (`:269`), `#failed-and-blocked-pages` (`:283`),
`#configuration-reference` (`:323`), `#event-types` (`:208`), plus
`/features/scrape#scrape-formats` (`## Scrape Formats` at `:138`) and `/rate-limits`. The renamed
anchor introduced no dangling references: all four in-repo links were retargeted in the same commit,
and no localized tree referenced it.

`mintlify broken-links` under Node 22 (the default Node 26.4.0 is rejected by the CLI): 208 broken
links repo-wide, all pre-existing, and zero in any file this branch touches. Filtering the report for
`features/crawl.mdx`, `features/map.mdx`, `api-reference/endpoint/crawl-get.mdx` and
`api-reference/endpoint/crawl-get-errors.mdx` returns no entries. The only non-localized English
files in the report are unrelated and pre-existing: `api-reference/v1-endpoint/llmstxt.mdx`,
`api-reference/v2-introduction.mdx`, `features/alpha/llmstxt.mdx`. `mint validate`: the same 17
pre-existing locale snippet warnings, no touched file.

Core was not modified. No localized file was touched.

### Not in this PR

**A Core PR, drafted but not filed.** Title:
`fix(api): correct crawl status/errors OpenAPI schema and drop silent error-class filter`. Scope:
`apps/api/openapi.json` (mirrored to `firecrawl-docs/api-reference/v2-openapi.json`) and
`apps/api/src/controllers/v2/crawl-errors.ts`. Five items:

1. Stale status enum at `apps/api/openapi.json:2810-2813`: three values, no `enum`, while Core
   returns four. The same schema object contradicts itself two properties later, since
   `completedAt.description` names `cancelled` as a terminal state, and sibling schemas in the same
   file already carry `cancelled` in a real `enum`. Fix: add
   `"enum": ["scraping", "completed", "failed", "cancelled"]`.
2. `CrawlStatusResponseObj.total.description` says "The total number of pages that were attempted to
   be crawled", which is wrong. Fix: describe it as completed plus in-flight, excluding failed. v1 is
   byte-identical at `apps/api/src/controllers/v1/crawl-status.ts:205-222` and needs the same
   treatment.
3. `CrawlErrorsResponseObj` omits `code`, which the response type declares (`types.ts:1520-1531`) and
   the controller populates. Clients rely on `EXTERNAL_LINK`, a field the spec denies exists.
4. `crawl-errors.ts:44-77` silently drops `SCRAPE_RACED_REDIRECT_ERROR`. Combined with item 2, such a
   page appears in neither the counters nor the error list. Preference order: stop filtering; or move
   those URLs into a third explicitly named array; or at minimum document the omission.
5. `features/crawl.mdx:68`, already on `origin/main` and left untouched here, claims a 402 rejection
   when remaining credits cannot cover the `limit`. Core clamps instead
   (`crawl.ts:248-252`). Fix: correct the doc line once Core confirms the clamp is intended, or make
   Core reject if the clamp was unintentional.

Also noted for whoever picks that up: the DB-backed fallback branch (`crawl-errors.ts:78-159`, used
once the Redis crawl record has expired) derives `timestamp` from `created_at` rather than finish
time, so `timestamp` semantics differ between the two paths.

Remaining docs nits, not acted on: "auditable" in `map.mdx` is slightly warmer than the same
branch's own Note admitting the error list is incomplete; and the new scope section restates the
`limit` default of 10000, which also appears at line 68 and in the configuration table.

Out of scope entirely: `/extract` and scrape `actions` have no documented partial-result signal
anywhere (developer read D1, D3, D5). That is a product decision, not a docs one.

### Links

Files changed:

- `features/crawl.mdx`
- `features/map.mdx`
- `api-reference/endpoint/crawl-get.mdx`
- `api-reference/endpoint/crawl-get-errors.mdx`

Evidence packet:
`agent-experience-deepinsights-cleanroom/artifacts/deep-insights-sep3-verification-20260904/`
