### PR TITLE
Show MCP API key setup as client config JSON

### DIFF
--- a/mcp-server.mdx
+++ b/mcp-server.mdx
@@ -22,11 +22,20 @@ Choose how the connection will authenticate. Signing in and adding an API key ar
 
 ## Add an API key
 
-[Create a Firecrawl API key](https://www.firecrawl.dev/app/api-keys), then send it as a bearer token:
+[Create a Firecrawl API key](https://www.firecrawl.dev/app/api-keys), then add it as a bearer token in your client config:
 
-```text
-URL: https://mcp.firecrawl.dev/v2/mcp
-Authorization: Bearer <FIRECRAWL_API_KEY>
+```json
+{
+  "mcpServers": {
+    "firecrawl": {
+      "type": "http",
+      "url": "https://mcp.firecrawl.dev/v2/mcp",
+      "headers": {
+        "Authorization": "Bearer <FIRECRAWL_API_KEY>"
+      }
+    }
+  }
+}
 ```
 
 Configure the key through an environment variable or your client's secret storage, never in the MCP URL.

--- a/mcp-server/keyless.mdx
+++ b/mcp-server/keyless.mdx
@@ -31,11 +31,20 @@ Keyless MCP is rate limited and exposes Search, Scrape, and Parse. Add an API ke
 
 ## Add an API key
 
-[Create a Firecrawl API key](https://www.firecrawl.dev/app/api-keys), then send it as a bearer token to the same endpoint:
+[Create a Firecrawl API key](https://www.firecrawl.dev/app/api-keys), then add it as a bearer token on the same endpoint in your client config:
 
-```text
-URL: https://mcp.firecrawl.dev/v2/mcp
-Authorization: Bearer <FIRECRAWL_API_KEY>
+```json
+{
+  "mcpServers": {
+    "firecrawl": {
+      "type": "http",
+      "url": "https://mcp.firecrawl.dev/v2/mcp",
+      "headers": {
+        "Authorization": "Bearer <FIRECRAWL_API_KEY>"
+      }
+    }
+  }
+}
 ```
 
 ## Verify your connection


### PR DESCRIPTION
## Why

The hosted MCP API-key path uses `https://mcp.firecrawl.dev/v2/mcp` with `Authorization: Bearer`. Client configs store that as a `mcpServers` entry (`type`, `url`, `headers`), not as HTTP request lines. The previous snippet could not be pasted into a client config file.

## Summary

- Replace the Get Started and For Agents API-key snippets with Streamable HTTP `mcpServers` JSON that sets the bearer token on `/v2/mcp`.
- Leave For Humans unchanged. That page configures `/v2/mcp-oauth` and browser sign-in. It already links to For Agents for a static key.

## Test plan

- [ ] https://docs.firecrawl.dev/mcp-server#add-an-api-key shows the JSON block with `type`, `url`, and `headers.Authorization`.
- [ ] https://docs.firecrawl.dev/mcp-server/keyless#add-an-api-key matches.
- [ ] For Agents keyless install commands and url-only JSON are unchanged.
- [ ] https://docs.firecrawl.dev/mcp-server/oauth still uses `/v2/mcp-oauth` with no API key header, and the API-key card still links to For Agents.
- [ ] The `.md` agent views of Get Started and For Agents include `Bearer <FIRECRAWL_API_KEY>` inside `headers`.