### PR TITLE
Date the v0 deprecation notice and canonicalize v0 pages

### DIFF
--- a/v0/advanced-scraping-guide.mdx
+++ b/v0/advanced-scraping-guide.mdx
@@ -51,7 +51,7 @@ func main() {
 
   content, err := app.ScrapeURL("docs.firecrawl.dev", nil)
   if err != nil {
-    log.Fatalf("Failed)
+    log.Fatalf("Failed to scrape URL: %v", err)
   }
 }
 ```

--- a/v0/advanced-scraping-guide.mdx
+++ b/v0/advanced-scraping-guide.mdx
@@ -3,7 +3,15 @@ title: "Advanced Scraping Guide"
 description: "Learn how to improve your Firecrawl scraping with advanced options."
 og:title: "Advanced Scraping Guide | Firecrawl"
 og:description: "Learn how to improve your Firecrawl scraping with advanced options."
+canonical: "https://docs.firecrawl.dev/advanced-scraping-guide"
 ---
+
+<Warning>
+  **This page documents the v0 API, deprecated on April 1, 2025.** It is kept for
+  historical reference and does not describe how Firecrawl works today. Current
+  documentation: [Advanced Scraping Guide](/advanced-scraping-guide). To move an existing v0 integration, see
+  [Migrating from v0](/migrating-from-v0).
+</Warning>
 
 This guide will walk you through the different endpoints of Firecrawl and how to use them fully with all its parameters.
 

--- a/v0/api-reference/endpoint/crawl-cancel.mdx
+++ b/v0/api-reference/endpoint/crawl-cancel.mdx
@@ -1,4 +1,13 @@
 ---
 title: 'Cancel Crawl Job'
 openapi: '/v0/api-reference/v0-openapi.json DELETE /crawl/cancel/{jobId}'
+canonical: "https://docs.firecrawl.dev/api-reference/endpoint/crawl-delete"
 ---
+
+<Warning>
+  **This page documents the v0 API, deprecated on April 1, 2025.** It is kept for
+  historical reference and does not describe how Firecrawl works today. Current
+  documentation: [Cancel Crawl](/api-reference/endpoint/crawl-delete). To move an existing v0 integration, see
+  [Migrating from v0](/migrating-from-v0).
+</Warning>
+

--- a/v0/api-reference/endpoint/crawl.mdx
+++ b/v0/api-reference/endpoint/crawl.mdx
@@ -1,4 +1,13 @@
 ---
 title: 'Crawl'
 openapi: '/v0/api-reference/v0-openapi.json POST /crawl'
+canonical: "https://docs.firecrawl.dev/api-reference/endpoint/crawl-post"
 ---
+
+<Warning>
+  **This page documents the v0 API, deprecated on April 1, 2025.** It is kept for
+  historical reference and does not describe how Firecrawl works today. Current
+  documentation: [Crawl](/api-reference/endpoint/crawl-post). To move an existing v0 integration, see
+  [Migrating from v0](/migrating-from-v0).
+</Warning>
+

--- a/v0/api-reference/endpoint/scrape.mdx
+++ b/v0/api-reference/endpoint/scrape.mdx
@@ -1,4 +1,13 @@
 ---
 title: 'Scrape'
 openapi: '/v0/api-reference/v0-openapi.json POST /scrape'
+canonical: "https://docs.firecrawl.dev/api-reference/endpoint/scrape"
 ---
+
+<Warning>
+  **This page documents the v0 API, deprecated on April 1, 2025.** It is kept for
+  historical reference and does not describe how Firecrawl works today. Current
+  documentation: [Scrape](/api-reference/endpoint/scrape). To move an existing v0 integration, see
+  [Migrating from v0](/migrating-from-v0).
+</Warning>
+

--- a/v0/api-reference/endpoint/search.mdx
+++ b/v0/api-reference/endpoint/search.mdx
@@ -1,9 +1,15 @@
 ---
 title: 'Search (Beta)'
 openapi: '/v0/api-reference/v0-openapi.json POST /search'
+canonical: "https://docs.firecrawl.dev/api-reference/endpoint/search"
 ---
 
-
+<Warning>
+  **This page documents the v0 API, deprecated on April 1, 2025.** It is kept for
+  historical reference and does not describe how Firecrawl works today. Current
+  documentation: [Search](/api-reference/endpoint/search). To move an existing v0 integration, see
+  [Migrating from v0](/migrating-from-v0).
+</Warning>
 
 The search endpoint combines a search API with the power of Firecrawl to provide a powerful search experience for whatever query. 
 

--- a/v0/api-reference/endpoint/status.mdx
+++ b/v0/api-reference/endpoint/status.mdx
@@ -1,8 +1,15 @@
 ---
 title: 'Get Crawl Status'
 openapi: '/v0/api-reference/v0-openapi.json GET /crawl/status/{jobId}'
+canonical: "https://docs.firecrawl.dev/api-reference/endpoint/crawl-get"
 ---
 
+<Warning>
+  **This page documents the v0 API, deprecated on April 1, 2025.** It is kept for
+  historical reference and does not describe how Firecrawl works today. Current
+  documentation: [Get Crawl Status](/api-reference/endpoint/crawl-get). To move an existing v0 integration, see
+  [Migrating from v0](/migrating-from-v0).
+</Warning>
 
 This endpoint retrieves the status of a crawl job. If the job is not completed, the response includes content within `partial_data`. Once the job is completed, the content is available under `data`.
 

--- a/v0/api-reference/introduction.mdx
+++ b/v0/api-reference/introduction.mdx
@@ -1,7 +1,15 @@
 ---
 title: 'Introduction'
 description: 'Firecrawl API Reference'
+canonical: "https://docs.firecrawl.dev/api-reference/introduction"
 ---
+
+<Warning>
+  **This page documents the v0 API, deprecated on April 1, 2025.** It is kept for
+  historical reference and does not describe how Firecrawl works today. Current
+  documentation: [API Reference](/api-reference/introduction). To move an existing v0 integration, see
+  [Migrating from v0](/migrating-from-v0).
+</Warning>
 
 ## Base URL
 

--- a/v0/features/crawl.mdx
+++ b/v0/features/crawl.mdx
@@ -4,7 +4,15 @@ description: 'Firecrawl can recursively search through a urls subdomains, and ga
 icon: 'spider'
 og:title: "Crawl | Firecrawl"
 og:description: "Firecrawl can recursively search through a urls subdomains, and gather the content"
+canonical: "https://docs.firecrawl.dev/features/crawl"
 ---
+
+<Warning>
+  **This page documents the v0 API, deprecated on April 1, 2025.** It is kept for
+  historical reference and does not describe how Firecrawl works today. Current
+  documentation: [Crawl](/features/crawl). To move an existing v0 integration, see
+  [Migrating from v0](/migrating-from-v0).
+</Warning>
 
 Firecrawl thoroughly crawls websites, ensuring comprehensive data extraction while handling complex web infrastructure. Here's how it works:
 
@@ -12,7 +20,7 @@ Firecrawl thoroughly crawls websites, ensuring comprehensive data extraction whi
    Begins with a specified URL, identifying links by looking at the sitemap and then crawling the website. If no sitemap is found, it will crawl the website following the links.
 
 2. **Recursive Traversal:**
-   Recursively follows each link to uncover all subpages.
+   Recursively follows each link to uncover all subpages. This describes the v0 crawl model only. For how crawl discovers and covers URLs today, see [Crawl](/features/crawl).
 
 3. **Content Scraping:**
    Gathers content from every visited page while handling any complexities like JavaScript rendering or rate limits.

--- a/v0/features/extract.mdx
+++ b/v0/features/extract.mdx
@@ -4,8 +4,15 @@ description: 'Extract structured data from pages via LLMs'
 icon: 'file-export'
 og:title: "Extract | Firecrawl"
 og:description: "Extract structured data from pages via LLMs"
+canonical: "https://docs.firecrawl.dev/features/extract"
 ---
 
+<Warning>
+  **This page documents the v0 API, deprecated on April 1, 2025.** It is kept for
+  historical reference and does not describe how Firecrawl works today. Current
+  documentation: [Extract](/features/extract). To move an existing v0 integration, see
+  [Migrating from v0](/migrating-from-v0).
+</Warning>
 
 ## Scrape and extract structured data with Firecrawl
 

--- a/v0/features/scrape.mdx
+++ b/v0/features/scrape.mdx
@@ -4,7 +4,15 @@ description: "Turn any url into clean data"
 icon: "markdown"
 og:title: "Scrape | Firecrawl"
 og:description: "Turn any url into clean data"
+canonical: "https://docs.firecrawl.dev/features/scrape"
 ---
+
+<Warning>
+  **This page documents the v0 API, deprecated on April 1, 2025.** It is kept for
+  historical reference and does not describe how Firecrawl works today. Current
+  documentation: [Scrape](/features/scrape). To move an existing v0 integration, see
+  [Migrating from v0](/migrating-from-v0).
+</Warning>
 
 ## Scraping with Firecrawl
 

--- a/v0/introduction.mdx
+++ b/v0/introduction.mdx
@@ -3,7 +3,15 @@ title: Quickstart
 description: "Firecrawl allows you to turn entire websites into LLM-ready markdown"
 og:title: "Quickstart | Firecrawl"
 og:description: "Firecrawl allows you to turn entire websites into LLM-ready markdown"
+canonical: "https://docs.firecrawl.dev/quickstart"
 ---
+
+<Warning>
+  **This page documents the v0 API, deprecated on April 1, 2025.** It is kept for
+  historical reference and does not describe how Firecrawl works today. Current
+  documentation: [Quickstart](/quickstart). To move an existing v0 integration, see
+  [Migrating from v0](/migrating-from-v0).
+</Warning>
 
 <img className="block" src="/images/turn-websites-into-llm-ready-data--firecrawl.jpg" alt="Hero Light" />
 

--- a/v0/sdks/go.mdx
+++ b/v0/sdks/go.mdx
@@ -4,9 +4,15 @@ description: 'Firecrawl Go SDK is a wrapper around the Firecrawl API to help you
 icon: 'golang'
 og:title: "Go SDK | Firecrawl"
 og:description: "Firecrawl Go SDK is a wrapper around the Firecrawl API to help you easily turn websites into markdown."
+canonical: "https://docs.firecrawl.dev/sdks/go"
 ---
 
-> Note: this is using [v0 version of the Firecrawl API](/v0/introduction) which is being deprecated. We recommend switching to [v1](/sdks/go).
+<Warning>
+  **This page documents the v0 API, deprecated on April 1, 2025.** It is kept for
+  historical reference and does not describe how Firecrawl works today. Current
+  documentation: [Go SDK](/sdks/go). To move an existing v0 integration, see
+  [Migrating from v0](/migrating-from-v0).
+</Warning>
 
 ## Installation
 

--- a/v0/sdks/node.mdx
+++ b/v0/sdks/node.mdx
@@ -4,9 +4,15 @@ description: 'Firecrawl Node SDK is a wrapper around the Firecrawl API to help y
 icon: 'node'
 og:title: "Node SDK | Firecrawl"
 og:description: "Firecrawl Node SDK is a wrapper around the Firecrawl API to help you easily turn websites into markdown."
+canonical: "https://docs.firecrawl.dev/sdks/node"
 ---
 
-> Note: this is using [v0 version of the Firecrawl API](/v0/introduction) which is being deprecated. We recommend switching to [v1](/sdks/node).
+<Warning>
+  **This page documents the v0 API, deprecated on April 1, 2025.** It is kept for
+  historical reference and does not describe how Firecrawl works today. Current
+  documentation: [Node SDK](/sdks/node). To move an existing v0 integration, see
+  [Migrating from v0](/migrating-from-v0).
+</Warning>
 
 ## Installation
 

--- a/v0/sdks/overview.mdx
+++ b/v0/sdks/overview.mdx
@@ -3,7 +3,15 @@ title: 'Overview'
 description: 'Firecrawl SDKs are wrappers around the Firecrawl API to help you easily turn websites into markdown.'
 og:title: "SDKs | Firecrawl"
 og:description: "Firecrawl SDKs are wrappers around the Firecrawl API to help you easily turn websites into markdown."
+canonical: "https://docs.firecrawl.dev/sdks/overview"
 ---
+
+<Warning>
+  **This page documents the v0 API, deprecated on April 1, 2025.** It is kept for
+  historical reference and does not describe how Firecrawl works today. Current
+  documentation: [SDKs](/sdks/overview). To move an existing v0 integration, see
+  [Migrating from v0](/migrating-from-v0).
+</Warning>
 
 <CardGroup cols={2}>
   <Card title="Python SDK" icon="python" href="python">

--- a/v0/sdks/python.mdx
+++ b/v0/sdks/python.mdx
@@ -4,9 +4,15 @@ description: 'Firecrawl Python SDK is a wrapper around the Firecrawl API to help
 icon: 'python'
 og:title: "Python SDK | Firecrawl"
 og:description: "Firecrawl Python SDK is a wrapper around the Firecrawl API to help you easily turn websites into markdown."
+canonical: "https://docs.firecrawl.dev/sdks/python"
 ---
 
-> Note: this is using [v0 version of the Firecrawl API](/v0/introduction) which is being deprecated. We recommend switching to [v1](/sdks/python).
+<Warning>
+  **This page documents the v0 API, deprecated on April 1, 2025.** It is kept for
+  historical reference and does not describe how Firecrawl works today. Current
+  documentation: [Python SDK](/sdks/python). To move an existing v0 integration, see
+  [Migrating from v0](/migrating-from-v0).
+</Warning>
 
 ## Installation
 

--- a/v0/sdks/rust.mdx
+++ b/v0/sdks/rust.mdx
@@ -4,9 +4,15 @@ description: 'Firecrawl Rust SDK is a library to help you easily scrape and craw
 icon: 'rust'
 og:title: "Rust SDK | Firecrawl"
 og:description: "Firecrawl Rust SDK is a library to help you easily scrape and crawl websites, and output the data in a format ready for use with language models (LLMs)."
+canonical: "https://docs.firecrawl.dev/sdks/rust"
 ---
 
-> Note: this is using [v0 version of the Firecrawl API](/v0/introduction) which is being deprecated. We recommend switching to [v1](/sdks/rust).
+<Warning>
+  **This page documents the v0 API, deprecated on April 1, 2025.** It is kept for
+  historical reference and does not describe how Firecrawl works today. Current
+  documentation: [Rust SDK](/sdks/rust). To move an existing v0 integration, see
+  [Migrating from v0](/migrating-from-v0).
+</Warning>
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Every page under `v0/` now opens with the same dated deprecation notice, links the current page that
replaces it, and sets a per-page canonical to that successor. The broken Go sample on the v0 advanced
scraping guide is fixed.

## Why

Finding OB-07 in DI-2026-09-04-WEEKLY, claim 3, and confirmed live on 2026-09-06.

The whole `v0/` tree is served at HTTP 200 with a self-referential canonical and no robots directive,
even though `docs.json` has no v0 navigation entry and `sitemap.xml` lists no v0 URL. The pages are
orphaned in navigation but fully reachable and indexable, and nothing on them says how old they are.

`curl -sL https://docs.firecrawl.dev/v0/features/crawl` returns 200 with
`<link rel="canonical" href="https://docs.firecrawl.dev/v0/features/crawl"/>` and no
`<meta name="robots">`.

One of these pages teaches a crawl model we no longer describe. `v0/features/crawl.mdx` line 15 says
"Recursively follows each link to uncover all subpages." The published copy is snapshot
`119762e3` in the report's page bundle.

Only the four v0 SDK pages carried any notice, and it was undated: "this is using [v0 version of the
Firecrawl API](/v0/introduction) which is being deprecated."

Claim 4 of the same finding: `v0/advanced-scraping-guide.mdx` line 54 is `log.Fatalf("Failed)`, an
unterminated Go string literal. A reader who copies that snippet gets code that does not compile.
Published copy: snapshot `37c04beb` line 63.

## Changes

- A `<Warning>` at the top of all 16 v0 pages with content. It states that the page documents the v0
  API, deprecated on April 1, 2025, that it is kept for historical reference, and it links the
  current successor page and `/migrating-from-v0`. The date is the one already published on
  `v1-welcome.mdx` line 175, so the docs stay consistent with themselves.
- `canonical` frontmatter on the same 16 pages, pointing at the successor URL on
  `docs.firecrawl.dev`. Mintlify supports a per-page canonical through this key, and it overrides the
  auto-generated self-canonical.
- The four undated SDK notes are removed and replaced by the same Warning.
- `v0/features/crawl.mdx`: the "Recursively follows each link" sentence now says it describes the v0
  model only and points at `/features/crawl` for how crawl discovers URLs today. The rest of the v0
  text is unchanged. These pages are a historical record, so they are marked, not rewritten.
- `v0/advanced-scraping-guide.mdx`: `log.Fatalf("Failed)` becomes
  `log.Fatalf("Failed to scrape URL: %v", err)`, matching the format the same sample uses one call
  earlier.

Localized v0 trees under `es`, `fr`, `ja`, `pt-BR` and `zh` are untouched, per the repo's
"do not modify localized files" rule. Locadex picks the change up on the next translation run.

`v0/api-reference/endpoint/llm-extract.mdx` is a zero-byte file on main and is left alone.

## Owner decision

The banner is the reversible default: it does not remove anything, and it can be reverted with one
revert. Two stronger options are deliberately not taken here.

1. Add `noindex: true` to the v0 tree. That drops the pages out of search entirely rather than
   consolidating them onto the successor. The repo already uses this key elsewhere, so it is one line
   per file if you want it.
2. Retire the v0 tree behind `docs.json` redirects. That deletes the historical record for anyone
   following an old link.

Say which one you want and it can go on top of this branch.

## Verification

- `mintlify broken-links` (Mintlify CLI 4.2.773, Node 22.23.2): none of the links added by this
  change are reported. The report lists 208 pre-existing broken links across the repo, unchanged by
  this branch. The only English v0 entry is `v0/sdks/overview.mdx` with four relative `Card` hrefs
  (`python`, `node`, `go`, `rust`) that exist on main and are not touched here.
- `mintlify validate`: 17 warnings, all missing snippet imports, byte-identical to the same run on
  `origin/main`.
- Live checks on 2026-09-06 with `curl -sIL -A "Mozilla/5.0"`: `/v0/features/crawl`,
  `/v0/introduction`, `/v0/advanced-scraping-guide`, `/v0/sdks/python`,
  `/v0/api-reference/introduction` and `/es/v0/features/crawl` all return 200 with a self-canonical
  and no robots meta.
- Every successor path named in the new notices exists on `origin/main`.
- `git diff --name-only origin/main...HEAD` lists only files under `v0/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SL5chNkWnr4Gy6uuB8PeKS
