### PR TITLE
Add agent quickstart docs for all SDK languages

### DIFF
--- a/agent-quickstart/elixir.mdx
+++ b/agent-quickstart/elixir.mdx
@@ -1,0 +1,228 @@
+---
+title: "Elixir Agent Quickstart"
+description: "Canonical Firecrawl Elixir quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Elixir Agent Quickstart
+
+Canonical quickstart for external agents integrating Firecrawl with Elixir. Generated from SDK source (`:firecrawl` hex package) and the Firecrawl OpenAPI spec.
+
+## Install
+
+```elixir
+# mix.exs
+defp deps do
+  [{:firecrawl, "~> 1.11"}]
+end
+```
+
+Dependencies: `req ~> 0.5`, `nimble_options ~> 1.1`.
+
+## Authenticate
+
+There is no client struct or constructor. Auth is configured via application config or per-request options.
+
+**Application config:**
+
+```elixir
+# config/config.exs
+config :firecrawl, api_key: "fc-your-api-key"
+```
+
+**Per-request override:**
+
+```elixir
+Firecrawl.scrape_and_extract_from_url(
+  [url: "https://example.com"],
+  api_key: "fc-your-api-key"
+)
+```
+
+Additional options:
+
+| Option | Type | Default |
+|---|---|---|
+| `api_key` | `String.t()` | Application config value |
+| `base_url` | `String.t()` | `"https://api.firecrawl.dev/v2"` |
+
+All remaining opts in the second argument are passed through to `Req`.
+
+## When To Use What
+
+- **`search_and_scrape`**: Start with a query and discover relevant URLs and content from the web.
+- **`scrape_and_extract_from_url`**: You already have a URL and want page content as markdown, HTML, structured JSON, or other formats.
+- **`interact_with_scrape_browser_session`**: The page needs post-scrape browser interaction — clicks, form fills, or code execution.
+
+## Search
+
+### Why use it
+
+Search takes a natural-language query and returns web, news, or image results with optional scraping of each result page. Use it for discovery when you don't have a specific URL.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.search_and_scrape(params, opts)
+```
+
+Bang variant: `Firecrawl.search_and_scrape!(params, opts)` raises on error.
+
+### Example
+
+```elixir
+{:ok, results} = Firecrawl.search_and_scrape(
+  query: "latest AI research papers",
+  limit: 5,
+  scrape_options: [formats: ["markdown"]]
+)
+```
+
+### Parameters
+
+All parameters are passed as a keyword list. Only `query` is required.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `:string` | The search query. Required |
+| `sources` | `list(any)` | Sources to search: `"web"`, `"news"`, `"images"`. Default: `["web"]` |
+| `categories` | `list(any)` | Filter results by category |
+| `include_domains` | `list(string)` | Restrict results to these domains. Cannot combine with `exclude_domains` |
+| `exclude_domains` | `list(string)` | Exclude results from these domains. Cannot combine with `include_domains` |
+| `limit` | `:integer` | Maximum results per source type. Default: `10` |
+| `tbs` | `:string` | Time-based search filter (e.g. `"qdr:d"` for past day) |
+| `location` | `:string` | Geographic location for results |
+| `country` | `:string` | ISO country code for geo-targeting (e.g. `"US"`) |
+| `ignore_invalid_urls` | `:boolean` | Exclude URLs invalid for other Firecrawl endpoints |
+| `timeout` | `:integer` | Timeout in milliseconds. Default: `60000` |
+| `highlights` | `:boolean` | Generate query-relevant highlights. Default: `true` |
+| `scrape_options` | `:keyword_list` | Options applied when scraping each result page |
+| `enterprise` | `list(string)` | Enterprise ZDR options: `"anon"`, `"zdr"` |
+
+## Scrape
+
+### Why use it
+
+Scrape extracts content from a known URL in your choice of formats — markdown, HTML, structured JSON, screenshots, and more. Use it when you have the URL and need the page content.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.scrape_and_extract_from_url(params, opts)
+```
+
+Bang variant: `Firecrawl.scrape_and_extract_from_url!(params, opts)` raises on error.
+
+### Example
+
+```elixir
+{:ok, doc} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown", "links"],
+  only_main_content: true
+)
+```
+
+### Parameters
+
+All parameters are passed as a keyword list. Only `url` is required.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `:string` | The URL to scrape. Required |
+| `formats` | `list(any)` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`. Also accepts typed objects for `"json"`, `"screenshot"`, `"question"`, `"highlights"`. Default: `["markdown"]` |
+| `only_main_content` | `:boolean` | Exclude headers, navs, and footers. Default: `true` |
+| `include_tags` | `list(string)` | HTML tags to include |
+| `exclude_tags` | `list(string)` | HTML tags to exclude |
+| `headers` | `:any` | Custom HTTP headers |
+| `timeout` | `:integer` | Timeout in milliseconds. Min: `1000`, max: `300000`. Default: `60000` |
+| `wait_for` | `:integer` | Delay in ms before fetching |
+| `mobile` | `:boolean` | Emulate mobile device |
+| `parsers` | `list(any)` | File parser control (e.g. PDF mode) |
+| `actions` | `list(any)` | Pre-scrape browser actions |
+| `location` | `:keyword_list` | Geolocation and language settings |
+| `skip_tls_verification` | `:boolean` | Skip TLS certificate verification |
+| `remove_base64_images` | `:boolean` | Strip base64 images from markdown |
+| `block_ads` | `:boolean` | Block ads and cookie popups |
+| `proxy` | `:basic \| :enhanced \| :auto` | Proxy type |
+| `max_age` | `:integer` | Cache max age in ms. Default: `172800000` (2 days) |
+| `min_age` | `:integer` | Cache-only mode minimum age in ms |
+| `store_in_cache` | `:boolean` | Store result in Firecrawl cache |
+| `lockdown` | `:boolean` | Cache-only mode, never makes outbound requests |
+| `redact_pii` | `:boolean` | Redact personally identifiable information |
+| `audit_metadata` | `:keyword_list` | SIEM logging user attribution. Key: `username` (required) |
+| `profile` | `:keyword_list` | Persistent browser storage across sessions |
+| `zero_data_retention` | `:boolean` | Enable zero data retention |
+
+## Interact
+
+### Why use it
+
+Interact runs code in the browser session of a scrape job. Use it after scraping a page when you need to click buttons, fill forms, navigate, or perform post-load browser actions.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.interact_with_scrape_browser_session(job_id, params, opts)
+```
+
+Bang variant: `Firecrawl.interact_with_scrape_browser_session!(job_id, params, opts)` raises on error.
+
+To end the session:
+
+```elixir
+Firecrawl.stop_interactive_scrape_browser_session(job_id, opts)
+```
+
+### Example
+
+```elixir
+# Scrape a page with actions to keep the browser session alive
+{:ok, doc} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com/app",
+  formats: ["markdown"],
+  actions: [%{"type" => "wait", "milliseconds" => 2000}]
+)
+
+job_id = get_in(doc, ["metadata", "jobId"])
+
+# Execute code in the browser session
+{:ok, result} = Firecrawl.interact_with_scrape_browser_session(job_id,
+  code: "document.querySelector('button.submit').click()",
+  language: :node,
+  timeout: 30
+)
+
+# Stop the session when done
+Firecrawl.stop_interactive_scrape_browser_session(job_id)
+```
+
+### Parameters
+
+The first argument is the `job_id` (string). Remaining parameters are a keyword list.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `String.t()` | The scrape job ID. Required, passed as the first positional argument |
+| `code` | `:string` | Code to execute in the browser sandbox. Required |
+| `language` | `:python \| :node \| :bash` | Language of the code. Default: `:node` |
+| `timeout` | `:integer` | Execution timeout in seconds. Min: `1`, max: `300` |
+| `origin` | `:string` | Origin label for telemetry |
+
+**Note:** The Elixir SDK does not support the `prompt` parameter for interact. Use `code` to execute browser commands directly.
+
+## Notes
+
+- **Auto-generated from OpenAPI**: The Elixir SDK is auto-generated from the Firecrawl OpenAPI spec. Function names follow the OpenAPI operation IDs exactly.
+- **Keyword list parameters**: All params are Elixir keyword lists, validated at runtime by `NimbleOptions`. Invalid keys are rejected with descriptive errors.
+- **snake_case to camelCase**: All Elixir parameters use snake_case. The SDK converts them to camelCase JSON keys automatically (e.g. `only_main_content` → `onlyMainContent`).
+- **Atom values become strings**: Atom values like `:basic` for proxy are converted to their string equivalents in JSON.
+- **Origin auto-injected**: Every request body includes `"origin": "elixir-sdk@{version}"` for telemetry.
+- **Bang variants**: Every function has a `!` variant (e.g. `scrape_and_extract_from_url!`) that raises `Firecrawl.Error` on HTTP 4xx/5xx responses instead of returning `{:error, ...}`.
+- **No `prompt` for interact**: Unlike the Node.js, Python, and Rust SDKs, the Elixir SDK only accepts `code` for interact, not natural-language `prompt`.
+- **No deprecated aliases**: The auto-generated SDK has no deprecated function aliases.
+
+## Source Of Truth
+
+- `firecrawl/apps/elixir-sdk/lib/firecrawl.ex`
+- `firecrawl/apps/elixir-sdk/mix.exs`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/java.mdx
+++ b/agent-quickstart/java.mdx
@@ -1,0 +1,259 @@
+---
+title: "Java Agent Quickstart"
+description: "Canonical Firecrawl Java quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Java Agent Quickstart
+
+Canonical quickstart for external agents integrating Firecrawl with Java. Generated from SDK source (`com.firecrawl:firecrawl-java`) and the Firecrawl OpenAPI spec.
+
+## Install
+
+**Gradle (Kotlin DSL):**
+
+```kotlin
+implementation("com.firecrawl:firecrawl-java:1.17.0")
+```
+
+**Maven:**
+
+```xml
+<dependency>
+  <groupId>com.firecrawl</groupId>
+  <artifactId>firecrawl-java</artifactId>
+  <version>1.17.0</version>
+</dependency>
+```
+
+Requires Java 11+. Runtime dependencies: OkHttp, Jackson.
+
+## Authenticate
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+
+// Builder pattern with explicit key
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey("fc-your-api-key")
+    .build();
+
+// Read from FIRECRAWL_API_KEY env var or firecrawl.apiKey system property
+FirecrawlClient client = FirecrawlClient.fromEnv();
+
+// Self-hosted with custom URL
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey("fc-your-api-key")
+    .apiUrl("http://localhost:3000")
+    .build();
+```
+
+Builder options:
+
+| Option | Type | Default |
+|---|---|---|
+| `apiKey` | `String` | `FIRECRAWL_API_KEY` env var or `firecrawl.apiKey` system property |
+| `apiUrl` | `String` | `FIRECRAWL_API_URL` env var or `https://api.firecrawl.dev` |
+| `timeoutMs` | `int` | `300000` (5 minutes) |
+| `maxRetries` | `int` | `3` |
+| `backoffFactor` | `double` | `0.5` |
+| `asyncExecutor` | `Executor` | `ForkJoinPool.commonPool()` |
+| `httpClient` | `OkHttpClient` | — (bypasses `timeoutMs` if set) |
+
+## When To Use What
+
+- **`search`**: Start with a query and discover relevant URLs and content from the web.
+- **`scrape`**: You already have a URL and want page content as markdown, HTML, structured JSON, or other formats.
+- **`interact`**: The page needs post-scrape browser interaction — clicks, form fills, or code execution.
+
+## Search
+
+### Why use it
+
+Search takes a natural-language query and returns web, news, or image results with optional scraping of each result page. Use it for discovery when you don't have a specific URL.
+
+### Preferred SDK method
+
+```java
+client.search(query)
+client.search(query, options)
+```
+
+Async variant: `client.searchAsync(query, options)` returns `CompletableFuture<SearchData>`.
+
+### Example
+
+```java
+import com.firecrawl.models.SearchOptions;
+import com.firecrawl.models.SearchData;
+
+SearchData results = client.search("latest AI research papers",
+    SearchOptions.builder()
+        .limit(5)
+        .scrapeOptions(ScrapeOptions.builder()
+            .formats(List.of("markdown"))
+            .build())
+        .build());
+
+for (Map<String, Object> result : results.getWeb()) {
+    System.out.println(result.get("title") + " " + result.get("url"));
+}
+```
+
+### Parameters
+
+`SearchOptions` uses a builder pattern. All fields are optional.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `String` | The search query. Required, passed as the first argument to `search()` |
+| `sources` | `List<Object>` | Sources to search: `"web"`, `"news"`, `"images"`. Default: `["web"]` |
+| `categories` | `List<Object>` | Filter results: `"github"`, `"research"`, `"pdf"` |
+| `includeDomains` | `List<String>` | Restrict results to these domains. Cannot combine with `excludeDomains` |
+| `excludeDomains` | `List<String>` | Exclude results from these domains. Cannot combine with `includeDomains` |
+| `limit` | `Integer` | Maximum results per source type. Default: `10` |
+| `tbs` | `String` | Time-based search filter (e.g. `"qdr:d"` for past day, `"qdr:w"` for past week) |
+| `location` | `String` | Geographic location for results |
+| `ignoreInvalidURLs` | `Boolean` | Exclude URLs invalid for other Firecrawl endpoints. Default: `false` |
+| `timeout` | `Integer` | Timeout in milliseconds. Default: `60000` |
+| `highlights` | `Boolean` | Generate query-relevant highlights. Default: `true` |
+| `scrapeOptions` | `ScrapeOptions` | Options applied when scraping each result page |
+| `integration` | `String` | Integration identifier for telemetry |
+
+## Scrape
+
+### Why use it
+
+Scrape extracts content from a known URL in your choice of formats — markdown, HTML, structured JSON, screenshots, and more. Use it when you have the URL and need the page content.
+
+### Preferred SDK method
+
+```java
+client.scrape(url)
+client.scrape(url, options)
+```
+
+Async variant: `client.scrapeAsync(url, options)` returns `CompletableFuture<Document>`.
+
+### Example
+
+```java
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.Document;
+
+Document doc = client.scrape("https://example.com",
+    ScrapeOptions.builder()
+        .formats(List.of("markdown", "links"))
+        .onlyMainContent(true)
+        .build());
+
+System.out.println(doc.getMarkdown());
+System.out.println(doc.getLinks());
+```
+
+### Parameters
+
+`ScrapeOptions` uses a builder pattern with `toBuilder()` for copy-and-modify. All fields are optional.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `String` | The URL to scrape. Required, passed as the first argument to `scrape()` |
+| `formats` | `List<Object>` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"screenshot"`, `"json"`, `"audio"`, `"video"`. Also accepts typed config objects (`JsonFormat`, `QuestionFormat`, `HighlightsFormat`). Default: `["markdown"]` |
+| `onlyMainContent` | `Boolean` | Exclude headers, navs, and footers. Default: `true` |
+| `includeTags` | `List<String>` | HTML tags to include |
+| `excludeTags` | `List<String>` | HTML tags to exclude |
+| `headers` | `Map<String, String>` | Custom HTTP headers |
+| `timeout` | `Integer` | Timeout in milliseconds. Min: `1000`, max: `300000`. Default: `60000` |
+| `waitFor` | `Integer` | Delay in ms before fetching. Default: `0` |
+| `mobile` | `Boolean` | Emulate mobile device. Default: `false` |
+| `parsers` | `List<Object>` | File parser control (e.g. `"pdf"` or `PdfParser` objects) |
+| `actions` | `List<Map<String, Object>>` | Pre-scrape browser actions |
+| `location` | `LocationConfig` | Geolocation settings: `country`, `languages` |
+| `skipTlsVerification` | `Boolean` | Skip TLS certificate verification. Default: `true` |
+| `removeBase64Images` | `Boolean` | Strip base64 images from markdown. Default: `true` |
+| `blockAds` | `Boolean` | Block ads and cookie popups. Default: `true` |
+| `proxy` | `String` | Proxy type: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. Default: `"auto"` |
+| `maxAge` | `Long` | Cache max age in ms. Default: `172800000` (2 days) |
+| `storeInCache` | `Boolean` | Store result in Firecrawl cache. Default: `true` |
+| `lockdown` | `Boolean` | Cache-only mode, never makes outbound requests. Default: `false` |
+| `redactPII` | `Boolean` | Redact personally identifiable information. Default: `false` |
+| `auditMetadata` | `AuditMetadata` | SIEM logging user attribution |
+| `integration` | `String` | Integration identifier |
+
+## Interact
+
+### Why use it
+
+Interact runs code in the browser session of a scrape job. Use it after scraping a page when you need to click buttons, fill forms, navigate, or perform post-load browser actions.
+
+### Preferred SDK method
+
+```java
+client.interact(jobId, code)
+client.interact(jobId, code, language, timeout)
+client.interact(jobId, code, language, timeout, origin)
+```
+
+To end the session:
+
+```java
+client.stopInteractiveBrowser(jobId)
+```
+
+Async variants: `interactAsync(...)` and `stopInteractiveBrowserAsync(...)` return `CompletableFuture`.
+
+### Example
+
+```java
+import com.firecrawl.models.BrowserExecuteResponse;
+
+// Scrape a page with actions to keep the browser session alive
+Document doc = client.scrape("https://example.com/app",
+    ScrapeOptions.builder()
+        .formats(List.of("markdown"))
+        .actions(List.of(Map.of("type", "wait", "milliseconds", 2000)))
+        .build());
+
+String jobId = (String) doc.getMetadata().get("jobId");
+
+// Execute code in the browser session
+BrowserExecuteResponse result = client.interact(jobId,
+    "document.querySelector('button.submit').click()",
+    "node",
+    30);
+
+System.out.println(result.getResult());
+
+// Stop the session when done
+client.stopInteractiveBrowser(jobId);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `jobId` | `String` | The scrape job ID. Required |
+| `code` | `String` | Code to execute in the browser sandbox. Required |
+| `language` | `String` | Language of the code: `"python"`, `"node"`, `"bash"`. Default: `"node"` |
+| `timeout` | `Integer` | Execution timeout in seconds. Min: `1`, max: `300`. Default: `30` |
+| `origin` | `String` | Origin label for telemetry |
+
+**Note:** The Java SDK does not support the `prompt` parameter for interact. Use `code` to execute browser commands directly.
+
+## Notes
+
+- **Builder pattern**: All option classes use builders (`ScrapeOptions.builder()...build()`). `ScrapeOptions` also supports `toBuilder()` for copy-and-modify.
+- **`formats` and `sources` accept `List<Object>`**: You can pass plain strings (`"markdown"`) or typed config objects (`JsonFormat`, `QuestionFormat`) in the same list.
+- **camelCase parameters**: Java uses camelCase naming (e.g. `onlyMainContent`, `skipTlsVerification`), matching the API wire format.
+- **Async variants**: Every sync method has an async counterpart returning `CompletableFuture`, executed on the configured `asyncExecutor`.
+- **No `prompt` for interact**: Unlike the Node.js, Python, and Rust SDKs, the Java SDK only accepts `code` for interact, not natural-language `prompt`.
+- **Deprecated aliases** (migration notes only):
+  - `scrapeExecute()` → use `interact()`
+  - `deleteScrapeBrowser()` → use `stopInteractiveBrowser()`
+
+## Source Of Truth
+
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/ScrapeOptions.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/SearchOptions.java`
+- `firecrawl/apps/java-sdk/build.gradle.kts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/node.mdx
+++ b/agent-quickstart/node.mdx
@@ -1,0 +1,224 @@
+---
+title: "Node.js Agent Quickstart"
+description: "Canonical Firecrawl Node.js quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Node.js Agent Quickstart
+
+Canonical quickstart for external agents integrating Firecrawl with Node.js/TypeScript. Generated from SDK source (`@mendable/firecrawl-js`) and the Firecrawl OpenAPI spec.
+
+## Install
+
+```bash
+npm install @mendable/firecrawl-js
+```
+
+## Authenticate
+
+```typescript
+import Firecrawl from "@mendable/firecrawl-js";
+
+// Pass an API key directly
+const client = new Firecrawl("fc-your-api-key");
+
+// Or read from FIRECRAWL_API_KEY environment variable
+const client = new Firecrawl();
+
+// For self-hosted instances
+const client = new Firecrawl({
+  apiKey: "fc-your-api-key",
+  apiUrl: "http://localhost:3000",
+});
+```
+
+Constructor options when passing an object:
+
+| Option | Type | Default |
+|---|---|---|
+| `apiKey` | `string \| null` | `process.env.FIRECRAWL_API_KEY` |
+| `apiUrl` | `string \| null` | `process.env.FIRECRAWL_API_URL` or `https://api.firecrawl.dev` |
+| `timeoutMs` | `number` | — |
+| `maxRetries` | `number` | — |
+| `backoffFactor` | `number` | — |
+
+## When To Use What
+
+- **`search`**: Start with a query and discover relevant URLs and content from the web.
+- **`scrape`**: You already have a URL and want page content as markdown, HTML, structured JSON, or other formats.
+- **`interact`**: The page needs post-scrape browser interaction — clicks, form fills, code execution, or natural-language browser commands.
+
+## Search
+
+### Why use it
+
+Search takes a natural-language query and returns web, news, or image results with optional scraping of each result page. Use it for discovery when you don't have a specific URL.
+
+### Preferred SDK method
+
+```typescript
+client.search(query, options?)
+```
+
+### Example
+
+```typescript
+const results = await client.search("latest AI research papers", {
+  limit: 5,
+  scrapeOptions: { formats: ["markdown"] },
+});
+
+for (const result of results.web ?? []) {
+  console.log(result.title, result.url);
+}
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `string` | The search query. Required, passed as the first argument |
+| `sources` | `("web" \| "news" \| "images")[]` | Sources to search. Default: `["web"]` |
+| `categories` | `("github" \| "research" \| "pdf" \| "developer")[]` | Filter results by category |
+| `includeDomains` | `string[]` | Restrict results to these domains. Cannot combine with `excludeDomains` |
+| `excludeDomains` | `string[]` | Exclude results from these domains. Cannot combine with `includeDomains` |
+| `limit` | `number` | Maximum results per source type. Default: `10` |
+| `tbs` | `string` | Time-based search filter (e.g. `"qdr:d"` for past day, `"qdr:w"` for past week) |
+| `location` | `string` | Geographic location for results (e.g. `"San Francisco,California,United States"`) |
+| `ignoreInvalidURLs` | `boolean` | Exclude URLs invalid for other Firecrawl endpoints. Default: `false` |
+| `timeout` | `number` | Timeout in milliseconds. Default: `60000` |
+| `highlights` | `boolean` | Generate query-relevant highlights. Default: `true` |
+| `scrapeOptions` | `ScrapeOptions` | Options applied when scraping each result page |
+| `enterprise` | `("default" \| "anon" \| "zdr")[]` | Enterprise zero-data-retention options |
+| `threatProtection` | `ThreatProtectionOptions` | Per-request threat protection override |
+| `integration` | `string` | Integration identifier for telemetry |
+| `origin` | `string` | Origin label for telemetry |
+
+## Scrape
+
+### Why use it
+
+Scrape extracts content from a known URL in your choice of formats — markdown, HTML, structured JSON, screenshots, and more. Use it when you have the URL and need the page content.
+
+### Preferred SDK method
+
+```typescript
+client.scrape(url, options?)
+```
+
+### Example
+
+```typescript
+const doc = await client.scrape("https://example.com", {
+  formats: ["markdown", "links"],
+  onlyMainContent: true,
+});
+
+console.log(doc.markdown);
+console.log(doc.links);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `string` | The URL to scrape. Required, passed as the first argument |
+| `formats` | `FormatOption[]` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`. Also accepts typed objects for `"json"`, `"screenshot"`, `"question"`, `"highlights"`, `"changeTracking"`, `"attributes"`. Default: `["markdown"]` |
+| `onlyMainContent` | `boolean` | Exclude headers, navs, and footers. Default: `true` |
+| `includeTags` | `string[]` | HTML tags to include |
+| `excludeTags` | `string[]` | HTML tags to exclude |
+| `headers` | `Record<string, string>` | Custom HTTP headers (cookies, user-agent, etc.) |
+| `timeout` | `number` | Timeout in milliseconds. Min: `1000`, max: `300000`. Default: `60000` |
+| `waitFor` | `number` | Delay in ms before fetching, on top of smart wait. Default: `0` |
+| `mobile` | `boolean` | Emulate mobile device. Default: `false` |
+| `parsers` | `(string \| PDFParser)[]` | File parser control (e.g. PDF mode settings). Default: `["pdf"]` |
+| `actions` | `ActionOption[]` | Pre-scrape browser actions: `wait`, `click`, `write`, `press`, `scroll`, `screenshot`, `scrape`, `executeJavascript`, `pdf` |
+| `location` | `{ country?: string, languages?: string[] }` | Geolocation and language settings. Default country: `"US"` |
+| `skipTlsVerification` | `boolean` | Skip TLS certificate verification. Default: `true` |
+| `removeBase64Images` | `boolean` | Strip base64 images from markdown. Default: `true` |
+| `fastMode` | `boolean` | Enable fast mode for quicker results |
+| `blockAds` | `boolean` | Block ads and cookie popups. Default: `true` |
+| `proxy` | `"basic" \| "stealth" \| "enhanced" \| "auto"` | Proxy type. Default: `"auto"` |
+| `maxAge` | `number` | Cache max age in ms. Returns cached version if younger. Default: `172800000` (2 days) |
+| `minAge` | `number` | Cache-only mode. Returns cached data or error |
+| `storeInCache` | `boolean` | Store result in Firecrawl cache. Default: `true` |
+| `lockdown` | `boolean` | Cache-only mode, never makes outbound requests. Default: `false` |
+| `redactPII` | `boolean \| RedactPIIOptions` | Redact personally identifiable information. Default: `false` |
+| `threatProtection` | `ThreatProtectionOptions` | Per-request threat protection override |
+| `auditMetadata` | `{ username: string }` | SIEM logging user attribution |
+| `profile` | `{ name: string, saveChanges?: boolean }` | Persistent browser storage across scrape/interact sessions |
+| `integration` | `string` | Integration identifier |
+| `origin` | `string` | Origin label for telemetry |
+
+## Interact
+
+### Why use it
+
+Interact runs code or natural-language commands in the browser session of a scrape job. Use it after scraping a page when you need to click buttons, fill forms, navigate, or perform any post-load browser action.
+
+### Preferred SDK method
+
+```typescript
+client.interact(jobId, options)
+```
+
+To end the session:
+
+```typescript
+client.stopInteraction(jobId)
+```
+
+### Example
+
+```typescript
+// Scrape a page (actions keep the browser session alive)
+const doc = await client.scrape("https://example.com/app", {
+  formats: ["markdown"],
+  actions: [{ type: "wait", milliseconds: 2000 }],
+});
+const jobId = doc.metadata.jobId;
+
+// Execute code in the browser session
+const result = await client.interact(jobId, {
+  code: "document.querySelector('button.submit').click()",
+  language: "node",
+  timeout: 30,
+});
+console.log(result.output);
+
+// Or use a natural-language prompt
+const result2 = await client.interact(jobId, {
+  prompt: "Click the login button and fill in the email field with test@example.com",
+});
+
+// Stop the session when done
+await client.stopInteraction(jobId);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `jobId` | `string` | The scrape job ID. Required, passed as the first argument |
+| `code` | `string` | Code to execute in the browser sandbox. At least one of `code` or `prompt` is required |
+| `prompt` | `string` | Natural-language browser instruction. At least one of `code` or `prompt` is required |
+| `language` | `"python" \| "node" \| "bash"` | Language of the code. Default: `"node"` |
+| `timeout` | `number` | Execution timeout in seconds. Min: `1`, max: `300`. Default: `30` |
+| `origin` | `string` | Origin label for telemetry |
+
+## Notes
+
+- **Keyless mode**: Scrape, search, and interact work without an API key (rate-limited per IP). Other methods require authentication.
+- **`autoResume` on scrape**: SDK-only parameter (not sent to API). When a large document outlives the request window, the SDK auto-retries up to 5 times over 20 minutes. Set `false` to surface the timeout immediately.
+- **Zod schema inference**: When `formats` includes `{ type: "json", schema: SomeZodType }`, the return type's `.json` field is inferred as `z.infer<typeof SomeZodType>`.
+- **`SearchData` shape**: Results are accessed via `.web`, `.news`, `.images`. There is no `.data` property — accessing it throws a descriptive error.
+- **Deprecated aliases** (migration notes only):
+  - `scrapeUrl()` → use `scrape()`
+  - `scrapeExecute()` → use `interact()`
+  - `stopInteractiveBrowser()` / `deleteScrapeBrowser()` → use `stopInteraction()`
+
+## Source Of Truth
+
+- `firecrawl/apps/js-sdk/firecrawl/src/index.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/python.mdx
+++ b/agent-quickstart/python.mdx
@@ -1,0 +1,229 @@
+---
+title: "Python Agent Quickstart"
+description: "Canonical Firecrawl Python quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Python Agent Quickstart
+
+Canonical quickstart for external agents integrating Firecrawl with Python. Generated from SDK source (`firecrawl-py`) and the Firecrawl OpenAPI spec.
+
+## Install
+
+```bash
+pip install firecrawl-py
+```
+
+## Authenticate
+
+```python
+from firecrawl import Firecrawl
+
+# Pass an API key directly
+client = Firecrawl(api_key="fc-your-api-key")
+
+# Or read from FIRECRAWL_API_KEY environment variable
+client = Firecrawl()
+
+# For self-hosted instances
+client = Firecrawl(
+    api_key="fc-your-api-key",
+    api_url="http://localhost:3000",
+)
+```
+
+Constructor parameters:
+
+| Parameter | Type | Default |
+|---|---|---|
+| `api_key` | `str \| None` | `os.getenv("FIRECRAWL_API_KEY")` |
+| `api_url` | `str` | `"https://api.firecrawl.dev"` |
+| `timeout` | `float \| None` | — |
+| `max_retries` | `int` | `3` |
+| `backoff_factor` | `float` | `0.5` |
+
+An async client is also available: `from firecrawl import AsyncFirecrawl`.
+
+## When To Use What
+
+- **`search`**: Start with a query and discover relevant URLs and content from the web.
+- **`scrape`**: You already have a URL and want page content as markdown, HTML, structured JSON, or other formats.
+- **`interact`**: The page needs post-scrape browser interaction — clicks, form fills, code execution, or natural-language browser commands.
+
+## Search
+
+### Why use it
+
+Search takes a natural-language query and returns web, news, or image results with optional scraping of each result page. Use it for discovery when you don't have a specific URL.
+
+### Preferred SDK method
+
+```python
+client.search(query, **options)
+```
+
+### Example
+
+```python
+results = client.search(
+    "latest AI research papers",
+    limit=5,
+    scrape_options={"formats": ["markdown"]},
+)
+
+for result in results.web or []:
+    print(result.title, result.url)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `str` | The search query. Required, passed as the first argument |
+| `sources` | `list[str \| Source]` | Sources to search: `"web"`, `"news"`, `"images"`. Default: `["web"]` |
+| `categories` | `list[str \| Category]` | Filter results by category: `"github"`, `"research"`, `"pdf"`, `"developer"` |
+| `include_domains` | `list[str]` | Restrict results to these domains. Cannot combine with `exclude_domains` |
+| `exclude_domains` | `list[str]` | Exclude results from these domains. Cannot combine with `include_domains` |
+| `limit` | `int` | Maximum results per source type. Default: `10` |
+| `tbs` | `str` | Time-based search filter (e.g. `"qdr:d"` for past day, `"qdr:w"` for past week) |
+| `location` | `str` | Geographic location for results (e.g. `"San Francisco,California,United States"`) |
+| `ignore_invalid_urls` | `bool` | Exclude URLs invalid for other Firecrawl endpoints. Default: `False` |
+| `timeout` | `int` | Timeout in milliseconds. Default: `60000` |
+| `highlights` | `bool` | Generate query-relevant highlights. Default: `True` |
+| `scrape_options` | `ScrapeOptions \| dict` | Options applied when scraping each result page |
+| `enterprise` | `list[str]` | Enterprise zero-data-retention options: `"anon"`, `"zdr"` |
+| `threat_protection` | `ThreatProtectionOptions` | Per-request threat protection override |
+| `integration` | `str` | Integration identifier for telemetry |
+
+## Scrape
+
+### Why use it
+
+Scrape extracts content from a known URL in your choice of formats — markdown, HTML, structured JSON, screenshots, and more. Use it when you have the URL and need the page content.
+
+### Preferred SDK method
+
+```python
+client.scrape(url, **options)
+```
+
+### Example
+
+```python
+doc = client.scrape(
+    "https://example.com",
+    formats=["markdown", "links"],
+    only_main_content=True,
+)
+
+print(doc.markdown)
+print(doc.links)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `str` | The URL to scrape. Required, passed as the first argument |
+| `formats` | `list[FormatOption]` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`. Also accepts typed objects for `"json"`, `"screenshot"`, `"question"`, `"highlights"`, `"changeTracking"`, `"attributes"`. Default: `["markdown"]` |
+| `only_main_content` | `bool` | Exclude headers, navs, and footers. Default: `True` |
+| `include_tags` | `list[str]` | HTML tags to include |
+| `exclude_tags` | `list[str]` | HTML tags to exclude |
+| `headers` | `dict[str, str]` | Custom HTTP headers (cookies, user-agent, etc.) |
+| `timeout` | `int` | Timeout in milliseconds. Min: `1000`, max: `300000`. Default: `60000` |
+| `wait_for` | `int` | Delay in ms before fetching, on top of smart wait. Default: `0` |
+| `mobile` | `bool` | Emulate mobile device. Default: `False` |
+| `parsers` | `list[str \| PDFParser]` | File parser control (e.g. PDF mode settings). Default: `["pdf"]` |
+| `actions` | `list[Action]` | Pre-scrape browser actions: `WaitAction`, `ClickAction`, `WriteAction`, `PressAction`, `ScrollAction`, `ScreenshotAction`, `ScrapeAction`, `ExecuteJavascriptAction`, `PDFAction` |
+| `location` | `Location` | Geolocation settings with `country` and `languages` fields. Default country: `"US"` |
+| `skip_tls_verification` | `bool` | Skip TLS certificate verification. Default: `True` |
+| `remove_base64_images` | `bool` | Strip base64 images from markdown. Default: `True` |
+| `fast_mode` | `bool` | Enable fast mode for quicker results |
+| `block_ads` | `bool` | Block ads and cookie popups. Default: `True` |
+| `proxy` | `str` | Proxy type: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. Default: `"auto"` |
+| `max_age` | `int` | Cache max age in ms. Returns cached version if younger. Default: `172800000` (2 days) |
+| `store_in_cache` | `bool` | Store result in Firecrawl cache. Default: `True` |
+| `lockdown` | `bool` | Cache-only mode, never makes outbound requests. Default: `False` |
+| `threat_protection` | `ThreatProtectionOptions` | Per-request threat protection override |
+| `audit_metadata` | `AuditMetadata` | SIEM logging user attribution (requires `username` field) |
+| `profile` | `dict` | Persistent browser storage across sessions. Keys: `name` (required), `save_changes` (optional) |
+| `redact_pii` | `bool` | Redact personally identifiable information. Default: `False` |
+| `integration` | `str` | Integration identifier |
+
+## Interact
+
+### Why use it
+
+Interact runs code or natural-language commands in the browser session of a scrape job. Use it after scraping a page when you need to click buttons, fill forms, navigate, or perform any post-load browser action.
+
+### Preferred SDK method
+
+```python
+client.interact(job_id, code=None, **options)
+```
+
+To end the session:
+
+```python
+client.stop_interaction(job_id)
+```
+
+### Example
+
+```python
+# Scrape a page (actions keep the browser session alive)
+doc = client.scrape(
+    "https://example.com/app",
+    formats=["markdown"],
+    actions=[{"type": "wait", "milliseconds": 2000}],
+)
+job_id = doc.metadata.get("jobId")
+
+# Execute code in the browser session
+result = client.interact(
+    job_id,
+    code="document.querySelector('button.submit').click()",
+    language="node",
+    timeout=30,
+)
+print(result.output)
+
+# Or use a natural-language prompt
+result2 = client.interact(
+    job_id,
+    prompt="Click the login button and fill in the email field with test@example.com",
+)
+
+# Stop the session when done
+client.stop_interaction(job_id)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `str` | The scrape job ID. Required, passed as the first argument |
+| `code` | `str` | Code to execute in the browser sandbox. At least one of `code` or `prompt` is required |
+| `prompt` | `str` | Natural-language browser instruction. At least one of `code` or `prompt` is required |
+| `language` | `"python" \| "node" \| "bash"` | Language of the code. Default: `"node"` |
+| `timeout` | `int` | Execution timeout in seconds. Min: `1`, max: `300`. Default: `30` |
+| `origin` | `str` | Origin label for telemetry |
+
+## Notes
+
+- **Keyless mode**: Scrape, search, and interact work without an API key (rate-limited per IP). Other methods require authentication.
+- **snake_case parameters**: All parameters use Python snake_case naming. The SDK handles conversion to camelCase for the API (e.g. `only_main_content` → `onlyMainContent`).
+- **`search().location` vs `scrape().location`**: In search, `location` is a plain `str`. In scrape, `location` is a `Location` object with `country` and `languages` fields.
+- **`SearchData` shape**: Results are accessed via `.web`, `.news`, `.images`. There is no `.data` attribute — accessing it raises an `AttributeError` with guidance.
+- **Async client**: `AsyncFirecrawl` provides identical methods as async coroutines.
+- **Deprecated aliases** (migration notes only):
+  - `scrape_url()` → use `scrape()`
+  - `scrape_execute()` → use `interact()`
+  - `delete_scrape_browser()` / `stop_interactive_browser()` → use `stop_interaction()`
+  - `FirecrawlApp` → use `Firecrawl`
+
+## Source Of Truth
+
+- `firecrawl/apps/python-sdk/firecrawl/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/rust.mdx
+++ b/agent-quickstart/rust.mdx
@@ -1,0 +1,254 @@
+---
+title: "Rust Agent Quickstart"
+description: "Canonical Firecrawl Rust quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Rust Agent Quickstart
+
+Canonical quickstart for external agents integrating Firecrawl with Rust. Generated from SDK source (`firecrawl` crate) and the Firecrawl OpenAPI spec.
+
+## Install
+
+```bash
+cargo add firecrawl
+```
+
+Requires the `tokio` async runtime. All SDK methods are `async fn` returning `Result<T, FirecrawlError>`.
+
+## Authenticate
+
+```rust
+use firecrawl::v2::Client;
+
+// Cloud (API key required for most endpoints)
+let client = Client::new("fc-your-api-key")?;
+
+// Self-hosted (key optional)
+let client = Client::new_selfhosted("http://localhost:3000", Some("fc-your-api-key"))?;
+
+// Keyless (rate-limited per IP, works for scrape/search/interact)
+let client = Client::new_selfhosted("http://localhost:3000", None::<&str>)?;
+```
+
+## When To Use What
+
+- **`search`**: Start with a query and discover relevant URLs and content from the web.
+- **`scrape`**: You already have a URL and want page content as markdown, HTML, structured JSON, or other formats.
+- **`interact`**: The page needs post-scrape browser interaction — clicks, form fills, code execution, or natural-language browser commands.
+
+## Search
+
+### Why use it
+
+Search takes a natural-language query and returns web, news, or image results with optional scraping of each result page. Use it for discovery when you don't have a specific URL.
+
+### Preferred SDK method
+
+```rust
+client.search(query, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::v2::{Client, SearchOptions};
+
+let client = Client::new("fc-your-api-key")?;
+
+let response = client.search("latest AI research papers", SearchOptions {
+    limit: Some(5),
+    scrape_options: Some(ScrapeOptions {
+        formats: Some(vec![Format::Markdown]),
+        ..Default::default()
+    }),
+    ..Default::default()
+}).await?;
+
+if let Some(web_results) = response.data.web {
+    for result in web_results {
+        println!("{:?}", result);
+    }
+}
+```
+
+### Parameters
+
+All fields on `SearchOptions` are `Option<T>` and the struct derives `Default`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `impl AsRef<str>` | The search query. Required, passed as the first argument |
+| `limit` | `Option<u32>` | Maximum results per source type. Default: `10` |
+| `sources` | `Option<Vec<SearchSource>>` | Sources to search: `Web`, `News`, `Images`. Default: `[Web]` |
+| `categories` | `Option<Vec<SearchCategory>>` | Filter results: `Github`, `Research`, `Pdf` |
+| `include_domains` | `Option<Vec<String>>` | Restrict results to these domains. Cannot combine with `exclude_domains` |
+| `exclude_domains` | `Option<Vec<String>>` | Exclude results from these domains. Cannot combine with `include_domains` |
+| `tbs` | `Option<String>` | Time-based search filter (e.g. `"qdr:d"` for past day) |
+| `location` | `Option<String>` | Geographic location for results |
+| `ignore_invalid_urls` | `Option<bool>` | Exclude URLs invalid for other Firecrawl endpoints. Default: `false` |
+| `timeout` | `Option<u32>` | Timeout in milliseconds. Default: `60000` |
+| `highlights` | `Option<bool>` | Generate query-relevant highlights. Default: `true` |
+| `scrape_options` | `Option<ScrapeOptions>` | Options applied when scraping each result page |
+| `integration` | `Option<String>` | Integration identifier for telemetry |
+| `origin` | `Option<String>` | Origin label for telemetry. Auto-set to `"rust-sdk@{version}"` |
+
+## Scrape
+
+### Why use it
+
+Scrape extracts content from a known URL in your choice of formats — markdown, HTML, structured JSON, screenshots, and more. Use it when you have the URL and need the page content.
+
+### Preferred SDK method
+
+```rust
+client.scrape(url, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::v2::{Client, ScrapeOptions, Format};
+
+let client = Client::new("fc-your-api-key")?;
+
+let doc = client.scrape("https://example.com", ScrapeOptions {
+    formats: Some(vec![Format::Markdown, Format::Links]),
+    only_main_content: Some(true),
+    ..Default::default()
+}).await?;
+
+println!("{}", doc.markdown.unwrap_or_default());
+```
+
+### Parameters
+
+All fields on `ScrapeOptions` are `Option<T>` and the struct derives `Default`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `impl AsRef<str>` | The URL to scrape. Required, passed as the first argument |
+| `formats` | `Option<Vec<Format>>` | Output formats: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `Json`, `ChangeTracking`, `Attributes`, `Branding`, `Product`, `Menu`, `Audio`, `Video`. Also `Question(QuestionFormat)`, `Highlights(HighlightsFormat)`. Default: `[Markdown]` |
+| `only_main_content` | `Option<bool>` | Exclude headers, navs, and footers. Default: `true` |
+| `include_tags` | `Option<Vec<String>>` | HTML tags to include |
+| `exclude_tags` | `Option<Vec<String>>` | HTML tags to exclude |
+| `headers` | `Option<HashMap<String, String>>` | Custom HTTP headers |
+| `timeout` | `Option<u32>` | Timeout in milliseconds. Min: `1000`, max: `300000`. Default: `60000` |
+| `wait_for` | `Option<u32>` | Delay in ms before fetching. Default: `0` |
+| `mobile` | `Option<bool>` | Emulate mobile device. Default: `false` |
+| `parsers` | `Option<Vec<ParserConfig>>` | File parser control (e.g. PDF mode) |
+| `actions` | `Option<Vec<Action>>` | Pre-scrape browser actions: `Wait`, `Click`, `Write`, `Press`, `Scroll`, `Screenshot`, `Scrape`, `ExecuteJavascript`, `Pdf` |
+| `location` | `Option<LocationConfig>` | Geolocation settings: `country`, `languages` |
+| `skip_tls_verification` | `Option<bool>` | Skip TLS certificate verification. Default: `true` |
+| `remove_base64_images` | `Option<bool>` | Strip base64 images from markdown. Default: `true` |
+| `fast_mode` | `Option<bool>` | Enable fast mode for quicker results |
+| `block_ads` | `Option<bool>` | Block ads and cookie popups. Default: `true` |
+| `proxy` | `Option<ProxyType>` | Proxy type: `Basic`, `Stealth`, `Enhanced`, `Auto`. Default: `Auto` |
+| `max_age` | `Option<u32>` | Cache max age in seconds |
+| `min_age` | `Option<u32>` | Cache-only mode minimum age in seconds |
+| `store_in_cache` | `Option<bool>` | Store result in Firecrawl cache. Default: `true` |
+| `lockdown` | `Option<bool>` | Cache-only mode, never makes outbound requests. Default: `false` |
+| `redact_pii` | `Option<bool>` | Redact personally identifiable information. Default: `false` |
+| `audit_metadata` | `Option<AuditMetadata>` | SIEM logging user attribution |
+| `profile` | `Option<ProfileConfig>` | Persistent browser storage: `name` and `save_changes` |
+| `integration` | `Option<String>` | Integration identifier |
+| `json_options` | `Option<JsonOptions>` | JSON extraction options: `schema`, `system_prompt`, `prompt`, `check_prompt_injection` |
+| `screenshot_options` | `Option<ScreenshotOptions>` | Screenshot format options: `full_page`, `quality`, `viewport` |
+| `change_tracking_options` | `Option<ChangeTrackingOptions>` | Change tracking config: `modes`, `schema`, `prompt`, `tag` |
+| `attribute_selectors` | `Option<Vec<AttributeSelector>>` | Attribute extraction: `selector`, `attribute` |
+| `origin` | `Option<String>` | Origin label. Auto-set to `"rust-sdk@{version}"` |
+
+### Convenience method
+
+```rust
+client.scrape_with_schema(url, schema, prompt).await
+```
+
+Sets `formats: [Json]` and `json_options` with the given JSON schema and optional prompt, returning the parsed JSON directly.
+
+## Interact
+
+### Why use it
+
+Interact runs code or natural-language commands in the browser session of a scrape job. Use it after scraping a page when you need to click buttons, fill forms, navigate, or perform any post-load browser action.
+
+### Preferred SDK method
+
+```rust
+client.interact(job_id, options).await
+```
+
+To end the session:
+
+```rust
+client.stop_interaction(job_id).await
+```
+
+### Example
+
+```rust
+use firecrawl::v2::{Client, ScrapeOptions, ScrapeExecuteOptions, Format, Action};
+
+let client = Client::new("fc-your-api-key")?;
+
+// Scrape a page with actions to keep the browser session alive
+let doc = client.scrape("https://example.com/app", ScrapeOptions {
+    formats: Some(vec![Format::Markdown]),
+    actions: Some(vec![Action::Wait { milliseconds: 2000 }]),
+    ..Default::default()
+}).await?;
+
+let job_id = doc.metadata.as_ref()
+    .and_then(|m| m.get("jobId"))
+    .and_then(|v| v.as_str())
+    .expect("jobId required for interact");
+
+// Execute code in the browser session
+let result = client.interact(job_id, ScrapeExecuteOptions {
+    code: Some("document.querySelector('button.submit').click()".into()),
+    language: Some(ScrapeExecuteLanguage::Node),
+    timeout: Some(30),
+    ..Default::default()
+}).await?;
+println!("{:?}", result.output);
+
+// Or use a natural-language prompt
+let result2 = client.interact(job_id, ScrapeExecuteOptions {
+    prompt: Some("Click the login button".into()),
+    ..Default::default()
+}).await?;
+
+// Stop the session when done
+client.stop_interaction(job_id).await?;
+```
+
+### Parameters
+
+All fields on `ScrapeExecuteOptions` are `Option<T>` and the struct derives `Default`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `impl AsRef<str>` | The scrape job ID. Required, passed as the first argument |
+| `code` | `Option<String>` | Code to execute in the browser sandbox. At least one of `code` or `prompt` is required |
+| `prompt` | `Option<String>` | Natural-language browser instruction. At least one of `code` or `prompt` is required |
+| `language` | `Option<ScrapeExecuteLanguage>` | Language of the code: `Python`, `Node`, `Bash`. Default: `Node` |
+| `timeout` | `Option<u32>` | Execution timeout in seconds. Min: `1`, max: `300` |
+| `origin` | `Option<String>` | Origin label. Auto-set to `"rust-sdk@{version}"` |
+
+## Notes
+
+- **`impl Into<Option<T>>` pattern**: `scrape` and `search` accept `options: impl Into<Option<...>>`, so you can pass `None` directly or the options struct without wrapping in `Some(...)`.
+- **No builder pattern**: Options structs use `#[derive(Default)]` and are constructed with struct literal syntax + `..Default::default()`.
+- **camelCase on the wire**: All structs use `#[serde(rename_all = "camelCase")]`. The exception is `redact_pii` which has an explicit `#[serde(rename = "redactPII")]`.
+- **`Format` enum complexity**: Simple formats like `Markdown` are unit variants. `Question(QuestionFormat)` and `Highlights(HighlightsFormat)` are tuple variants that serialize as objects with a `type` field.
+- **Client-side validation**: `interact` returns `FirecrawlError::Misuse` before making the HTTP call if neither `code` nor `prompt` is provided.
+- **Deprecated aliases** (migration notes only):
+  - `scrape_execute()` → use `interact()`
+  - `stop_interactive_browser()` / `delete_scrape_browser()` → use `stop_interaction()`
+
+## Source Of Truth
+
+- `firecrawl/apps/rust-sdk/src/v2/client.rs`
+- `firecrawl/apps/rust-sdk/src/v2/search.rs`
+- `firecrawl/apps/rust-sdk/src/v2/scrape.rs`
+- `firecrawl/apps/rust-sdk/Cargo.toml`
+- `firecrawl-docs/api-reference/v2-openapi.json`


### PR DESCRIPTION
## Summary

- Adds canonical agent quickstart documents for **Node.js**, **Python**, **Rust**, **Java**, and **Elixir** in `agent-quickstart/`
- Each file covers the `search`, `scrape`, and `interact` endpoints with install instructions, auth patterns, SDK method names, realistic examples, and every confirmed parameter with descriptions
- Generated from SDK source code (all 5 SDK repos) cross-referenced against the OpenAPI spec (`v2-openapi.json`)

## Details

Each quickstart follows a consistent structure:
- Install and authenticate sections
- "When To Use What" decision guide
- Per-endpoint sections with: why to use it, preferred SDK method, working example, and a full parameter table
- Language-specific notes covering naming conventions, deprecated aliases, and SDK quirks
- Source of truth references listing exact files used

Key language-specific differences documented:
- **`prompt` for interact**: Available in Node.js, Python, and Rust SDKs; not available in Java and Elixir (which only support `code`)
- **Elixir function names**: Auto-generated from OpenAPI (e.g. `scrape_and_extract_from_url`, `interact_with_scrape_browser_session`)
- **Java builder pattern** vs Rust struct literals vs Python/Elixir keyword args

## Test plan

- [ ] Verify each `.mdx` file renders correctly in Mintlify
- [ ] Spot-check parameter lists against SDK source for accuracy
- [ ] Confirm no localized files were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9K9pbYorXNqVUcSBFHxWp

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9K9pbYorXNqVUcSBFHxWp)_