### PR TITLE
Fix MCP selector icons after snippet compile

### DIFF
--- a/snippets/shared/agent-first-onboarding.jsx
+++ b/snippets/shared/agent-first-onboarding.jsx
@@ -98,7 +98,6 @@ export const McpClientSelector = ({ variant = "agent", showSeeAll = true } = {})
       iconClassName: "fc-client-icon-mono",
       code: cursorConfig,
       codeLabel: "mcp.json",
-      codeClassName: "",
       installUrl: cursorInstallUrl,
       description:
         "Install the hosted MCP server in one click, or copy the configuration below.",
@@ -122,7 +121,6 @@ export const McpClientSelector = ({ variant = "agent", showSeeAll = true } = {})
       iconClassName: "fc-client-icon-mono",
       code: opencodeConfig,
       codeLabel: "opencode.json",
-      codeClassName: "",
       description: isHuman
         ? "Add this remote server configuration to your global or project config. OpenCode opens Firecrawl in your browser on first use."
         : "Add this remote server configuration to your global or project config.",
@@ -234,7 +232,7 @@ export const McpClientSelector = ({ variant = "agent", showSeeAll = true } = {})
     return (
       <button
         type="button"
-        className={`fc-copy-button${copied ? " is-copied" : ""}`}
+        className={copied ? "fc-copy-button is-copied" : "fc-copy-button"}
         onClick={() => copy(id, text, label)}
         aria-label={copied ? `${label} copied` : `Copy ${label}`}
       >
@@ -257,7 +255,7 @@ export const McpClientSelector = ({ variant = "agent", showSeeAll = true } = {})
     </div>
   );
   const codeBlock = ({ client }) => (
-    <div className={`fc-code-block ${client.codeClassName || ""}`.trim()}>
+    <div className="fc-code-block">
       <div className="fc-code-header">
         <span>{client.codeLabel}</span>
         {copyButton({
@@ -323,16 +321,23 @@ export const McpClientSelector = ({ variant = "agent", showSeeAll = true } = {})
               }}
               type="button"
               role="tab"
-              className={`fc-client-tab${selected ? " is-active" : ""}`}
+              className={selected ? "fc-client-tab is-active" : "fc-client-tab"}
               aria-selected={selected}
               aria-controls={`fc-panel-${client.id}`}
               tabIndex={selected ? 0 : -1}
               onClick={() => setActiveId(client.id)}
               onKeyDown={(event) => handleKeyDown(event, index)}
             >
-              <span
-                className={`fc-client-icon ${client.iconClassName}`}
-                style={{ backgroundImage: `url("${client.icon}")` }}
+              <img
+                className={
+                  client.iconClassName === "fc-client-icon-mono"
+                    ? "fc-client-icon fc-client-icon-mono"
+                    : "fc-client-icon"
+                }
+                src={client.icon}
+                alt=""
+                width={26}
+                height={26}
                 aria-hidden="true"
               />
               <span className="fc-client-tab-copy">
@@ -468,7 +473,7 @@ export const AgentSetupButton = () => {
     <div className="fc-agent-prompt not-prose">
       <button
         type="button"
-        className={`fc-agent-prompt-button${copied ? " is-copied" : ""}`}
+        className={copied ? "fc-agent-prompt-button is-copied" : "fc-agent-prompt-button"}
         onClick={copyPrompt}
         aria-label={copied ? "Copied agent setup prompt" : "Setup for agents"}
       >

--- a/snippets/shared/agent-first-onboarding.jsx
+++ b/snippets/shared/agent-first-onboarding.jsx
@@ -93,7 +93,7 @@ export const McpClientSelector = ({ variant = "agent", showSeeAll = true } = {})
     {
       id: "cursor",
       name: "Cursor",
-      detail: "One-click + JSON",
+      detail: "One click",
       icon: "/images/agent-clients/cursor.svg",
       iconClassName: "fc-client-icon-mono",
       code: cursorConfig,

--- a/style.css
+++ b/style.css
@@ -297,7 +297,7 @@ nav ul li:has(a[href="https://github.com/firecrawl/firecrawl"])
     min-width: 0;
     overflow: hidden;
     flex-direction: column;
-    align-items: flex-start;
+    align-items: center;
     gap: 8px;
     padding: 14px 10px;
     border: 0;
@@ -305,7 +305,7 @@ nav ul li:has(a[href="https://github.com/firecrawl/firecrawl"])
     background: transparent;
     color: var(--fc-text);
     cursor: pointer;
-    text-align: left;
+    text-align: center;
     transition: background-color 160ms ease;
 }
 
@@ -336,9 +336,7 @@ nav ul li:has(a[href="https://github.com/firecrawl/firecrawl"])
     width: 26px;
     height: 26px;
     flex: none;
-    background-position: center;
-    background-repeat: no-repeat;
-    background-size: contain;
+    object-fit: contain;
 }
 
 .dark .fc-client-icon-mono {


### PR DESCRIPTION
## Why

Mintlify inlines the MCP client selector per page and strips leading spaces from `className` template fragments. Rebuilt pages then emit glued classes (`fc-client-tabis-active`, `fc-client-iconfc-client-icon-mono`), so the selected-tab layout and two of the four marks fail. For Humans still looked closer to correct only because that page had not been recompiled.

## Summary

- Use complete `className` string literals instead of concatenating a leading space onto a base class.
- Render each mark as a 26×26 `img` so size does not depend on a background-image span matching `.fc-client-icon`.
- Center the mark over its label in each equal-width tab.

## Test plan

- [x] https://docs.firecrawl.dev/mcp-server/keyless — all four tabs show a 26×26 mark; the first tab is not flush to the card edge; the selected tab keeps the heat underline.
- [x] https://docs.firecrawl.dev/mcp-server/oauth — same layout; marks sit over their labels.
- [x] https://docs.firecrawl.dev/introduction — same selector, same classes.
- [x] Dark mode: the two near-black marks invert to light.
- [x] After the preview deploy, the page JS contains `fc-client-tab is-active` / `fc-client-icon fc-client-icon-mono`, not glued class tokens.