### PR TITLE
docs: embed Parse vs Scrape video on the parse and scrape pages

### DIFF
--- a/features/parse.mdx
+++ b/features/parse.mdx
@@ -22,6 +22,7 @@ import ParseJsonNode from "/snippets/v2/parse/json/js.mdx";
 import ParseJsonCURL from "/snippets/v2/parse/json/curl.mdx";
 import ParseGroundingPython from "/snippets/v2/parse/grounding/python.mdx";
 import ParseGroundingNode from "/snippets/v2/parse/grounding/js.mdx";
+import VideoParseVsScrape from "/snippets/shared/video-parse-vs-scrape.mdx";
 
 Parse converts documents into clean, LLM-ready data. Upload a file to
 [`/parse`](/api-reference/endpoint/parse) — or point [`/scrape`](/features/scrape)
@@ -33,6 +34,10 @@ layout blocks, or structured JSON.
 - **Grounded structure**: typed layout blocks with bounding boxes and character-span links into the markdown (PDFs)
 - **Any common format**: PDF, Word, Excel, PowerPoint, OpenDocument, EPUB, CSV, HTML
 - **Zero Data Retention** support
+
+Not sure whether you want Parse or [Scrape](/features/scrape)? This walks through the differences:
+
+<VideoParseVsScrape />
 
 ## Quickstart
 

--- a/features/scrape.mdx
+++ b/features/scrape.mdx
@@ -60,6 +60,7 @@ import ScrapeHighlightsPython from "/snippets/v2/scrape/highlights/python.mdx";
 import ScrapeHighlightsNode from "/snippets/v2/scrape/highlights/js.mdx";
 import ScrapeHighlightsCURL from "/snippets/v2/scrape/highlights/curl.mdx";
 import PlaygroundCTA from "/snippets/shared/playground-cta-scrape.mdx";
+import VideoParseVsScrape from "/snippets/shared/video-parse-vs-scrape.mdx";
 
 Firecrawl converts web pages into markdown, ideal for LLM applications.
 
@@ -70,6 +71,10 @@ Firecrawl converts web pages into markdown, ideal for LLM applications.
 For details, see the [Scrape Endpoint API Reference](https://docs.firecrawl.dev/api-reference/endpoint/scrape).
 
 <PlaygroundCTA />
+
+Scraping a document at a URL, or parsing one from disk? This walks through when to use Scrape and when to use [Parse](/features/parse):
+
+<VideoParseVsScrape />
 
 <Note>If a request fails, see [Errors](/api-reference/errors) for the full catalog of error codes, causes, remedies, and retry guidance.</Note>
 

--- a/snippets/shared/video-parse-vs-scrape.mdx
+++ b/snippets/shared/video-parse-vs-scrape.mdx
@@ -1,0 +1,9 @@
+<iframe
+  src="https://www.youtube.com/embed/119uEEBQRrA"
+  title="Firecrawl Parse vs Scrape Explained in 5 Minutes"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+  loading="lazy"
+  style={{ width: '100%', aspectRatio: '16 / 9', height: 'auto', borderRadius: '0.5rem' }}
+></iframe>


### PR DESCRIPTION
Embeds [**Firecrawl Parse vs Scrape Explained in 5 Minutes**](https://www.youtube.com/watch?v=119uEEBQRrA) (4:21, Firecrawl channel) on the two pages where readers are actively choosing between the two endpoints.

## Why these two pages

The video is a both-ways comparison, not a Parse explainer, so it earns a place on each side:

- **`features/parse.mdx`** — the intro already points at `/scrape` for public document URLs, so the video answers the exact question the reader arrives with.
- **`features/scrape.mdx`** — the video's core warning is that scraping a URL holding a 300-page document costs 300 credits, not one. This page currently has no document or PDF section at all, so the video is the only place that surprise gets addressed.

Shared as a snippet (`snippets/shared/video-parse-vs-scrape.mdx`) so both pages stay in sync, matching the iframe pattern already in `_essentials/images.mdx`.

## Before / after

Both captures use the same viewport and scroll anchor, so the only difference is the embed.

### `features/parse.mdx`

| Before | After |
|---|---|
|<img width="2560" height="2500" alt="before-parse" src="https://github.com/user-attachments/assets/572d84f3-8391-42bd-8d12-4f27211200fc" />|  <img width="2560" height="2500" alt="after-parse" src="https://github.com/user-attachments/assets/493248d2-7ef4-4c79-a6af-9ce5acc9496b" />|

### `features/scrape.mdx`

| Before | After |
|---|---|
|<img width="2560" height="2500" alt="before-scrape" src="https://github.com/user-attachments/assets/44b76c80-773f-4fce-9227-76917b9abf20" /> | <img width="2560" height="2500" alt="after-scrape" src="https://github.com/user-attachments/assets/b75458f1-8f6c-4bc2-9d27-a460356f016d" />|

Verified in `mint dev`: 16:9 aspect ratio holds, `loading="lazy"`, rounded corners match surrounding cards.

## Notes for review

- **The 30MB figure is deliberately not in the docs.** The video says *"let's say under 30 MB"* as an illustration, and also hedges the large-document streaming as *"might not be released yet."* Neither claim is repeated in the prose here.
- **The `FIRECRAWLYT` coupon** in the video description (500 credits) is not surfaced in the docs. Worth a decision from whoever owns that promo if it should be.
- **`features/document-parsing.mdx` overlaps `features/parse.mdx` heavily** (same formats, also documents `/v2/parse`). Not touched here, but it looks like a stale duplicate and probably wants a redirect in a follow-up.
- **Localized copies untouched**, per `CLAUDE.md`. Flagging that the five locale copies of these pages won't show the embed until the translation pipeline picks up the new import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
