### PR TITLE
Document the free plan scope in billing.mdx

### DIFF
--- a/billing.mdx
+++ b/billing.mdx
@@ -91,8 +91,8 @@ New accounts start on the free plan. It costs nothing and does not need a card. 
 
 - **1,000 credits per month.** The allotment resets at the start of each monthly cycle. Unused free credits do not roll over.
 - **2 concurrent browsers**, with the same 50,000 maximum queued jobs as the paid self-serve plans.
-- **Rate limits of 10 requests per minute** on `/scrape`, `/map` and `/search`, and **2 requests per minute** on `/crawl`, `/agent` and `/interact`. Batch scrape shares the crawl limit and extract shares the agent limit. See [Rate Limits](/rate-limits) for the full table.
-- **Every API endpoint.** No endpoint is restricted by plan. Credit costs are the same on every plan, so the [credit costs per endpoint](#credit-costs-per-endpoint) table above applies unchanged.
+- **Rate limits of 10 requests per minute** on `/scrape`, `/map` and `/search`, and **2 requests per minute** on `/crawl`, `/agent` and `/interact`. Batch scrape shares the scrape limit and extract shares the agent limit. See [Rate Limits](/rate-limits) for the full table.
+- **Every core product endpoint.** Scrape, crawl, map, search, extract, batch scrape, interact and monitor all work on the free plan. Some team administration and enterprise features are enabled per team rather than by plan, including threat protection, SIEM logging and zero data retention search. Credit costs are the same on every plan, so the [credit costs per endpoint](#credit-costs-per-endpoint) table above applies unchanged.
 
 The free plan does not include pay-as-you-go, so requests return an HTTP 402 once the monthly allotment runs out. See [Running Out of Credits](#running-out-of-credits). It also does not include credit rollover, a Data Processing Agreement, or Slack support. Support is community support.
 

--- a/billing.mdx
+++ b/billing.mdx
@@ -85,6 +85,19 @@ For needs beyond Scale, Firecrawl offers **Enterprise** plans with custom credit
 
 All paid plans are available with **monthly** or **yearly** billing. Yearly billing offers a discount compared to paying month-to-month. For current pricing on each plan, visit the [pricing page](https://www.firecrawl.dev/pricing).
 
+### Free plan
+
+New accounts start on the free plan. It costs nothing and does not need a card. Here is what it includes:
+
+- **1,000 credits per month.** The allotment resets at the start of each monthly cycle. Unused free credits do not roll over.
+- **2 concurrent browsers**, with the same 50,000 maximum queued jobs as the paid self-serve plans.
+- **Rate limits of 10 requests per minute** on `/scrape`, `/map` and `/search`, and **2 requests per minute** on `/crawl`, `/agent` and `/interact`. Batch scrape shares the crawl limit and extract shares the agent limit. See [Rate Limits](/rate-limits) for the full table.
+- **Every API endpoint.** No endpoint is restricted by plan. Credit costs are the same on every plan, so the [credit costs per endpoint](#credit-costs-per-endpoint) table above applies unchanged.
+
+The free plan does not include pay-as-you-go, so requests return an HTTP 402 once the monthly allotment runs out. See [Running Out of Credits](#running-out-of-credits). It also does not include credit rollover, a Data Processing Agreement, or Slack support. Support is community support.
+
+Scrape, Search and Interact also work with no API key at all, through the keyless free tier, which is capped per IP address per day rather than by a credit allotment. See [Keyless (no API key)](/rate-limits#keyless-no-api-key).
+
 ### Billing cycle
 
 - **Monthly plans**: Credits reset on your monthly renewal date


### PR DESCRIPTION
## Summary

Adds a "Free plan" subsection to the Plans section of `billing.mdx`. It states what the free tier includes: the monthly credit allotment and its reset, concurrency and queue ceiling, per-endpoint rate limits, that no endpoint is restricted by plan, what the free plan does not include, and that Scrape, Search and Interact also work with no API key.

One file, thirteen added lines, nothing removed.

## Why

`billing.mdx` had a "Paid plans" heading with no free counterpart. The only mention of the free plan on the page was one sentence saying pay-as-you-go does not work on it. A reader who wanted to know what the free tier gives them had to assemble it from `rate-limits.mdx` (concurrency and rate limit tables), `partner-credits.mdx` ("standard Free Plan limits"), the SDK and CLI pages (keyless), and the pricing page. No owned page put it in one place, and the page a user reaches for plan and credit questions did not state it at all.

Evidence:

- DI-2026-09-05-WEEKLY, Astra edition, finding OB-03, "Publish cost per usable outcome, not another headline price ladder". Its recommended action asks to "Extend the existing billing surface with an effective-dated operation table, monthly/annual plan distinctions, free-tier scope, rollover and failure treatment."
- DI-2026-09-04-WEEKLY, finding OB-03, whose title records that "no owned page states a managed-vs-self-host crossover or a licence scope", and whose trace quotes show answers falling back to a free self-hosted baseline whenever cost enters the frame. Example: `trace:disc-weekly-2026-W36-category-rerun-daily-2026-09-04/vis_category_v2_web_enabled/opencode_opus5/p106`, "SPAs, auth, crawling → Firecrawl if you'll pay, Crawl4AI if you won't."

Neither finding contains a quote that literally reads "no owned page states the free-tier scope". The gap was confirmed directly against the repository and the live pricing page rather than taken from a quote.

## Changes

`billing.mdx`, one new `### Free plan` subsection between "Paid plans" and "Billing cycle":

- 1,000 credits per month, reset monthly, no rollover.
- 2 concurrent browsers, 50,000 maximum queued jobs.
- 10 requests per minute on `/scrape`, `/map` and `/search`; 2 per minute on `/crawl`, `/agent` and `/interact`. Batch scrape shares the crawl limit, extract shares the agent limit.
- Every API endpoint is available. Credit costs are the same on every plan.
- No pay-as-you-go, so an exhausted allotment returns HTTP 402. No credit rollover, no Data Processing Agreement, no Slack support. Community support.
- Keyless Scrape, Search and Interact, capped per IP address per day, linked to `/rate-limits#keyless-no-api-key`.

Every figure is read from code or from an owned surface:

| Fact | Source |
| --- | --- |
| 1,000 credits, monthly reset | firecrawl-web `components/app/(home)/sections/pricing-section/credit-options.ts:13-14` (`FREE_PLAN_CREDITS = 1000`) and `autumn.config.ts:26-43` (`included: 1000, reset: { interval: "month" }`) |
| No cost, no card | firecrawl-web `Pricing.tsx:953-978` (`price: { monthly: 0, yearly: 0 }`); live pricing page, "No cost, no card, no hassle" |
| 2 concurrent browsers | `autumn.config.ts:31-34`, `lib/billing/tier-concurrency.ts:11-12`, and the fallback at firecrawl `apps/api/src/lib/concurrency-limit.ts:24-38` |
| 50,000 queued jobs, no rollover, no pay-as-you-go, no DPA, no Slack support, community support | firecrawl-web `plan-comparison-data.ts:157,246,267,287,318,352` |
| Rate limits | firecrawl `apps/api/src/services/rate-limiter.ts:53-63`. Free carries no `rate_limits` item in `autumn.config.ts`, and a missing multiplier falls back to 1 (`services/autumn/autumn.service.ts:935-939`), so free gets the base table verbatim |
| No plan-based endpoint gating | firecrawl `apps/api/src/routes/v2.ts`, where access is gated by `checkCreditsMiddleware`, not by plan. No plan allowlist exists in `apps/api` |
| Keyless scope | firecrawl `apps/api/src/lib/keyless.ts:11-16`, "scrape, search, and interact can be used without an API key from the official MCP server, CLI, or SDKs" |

Two things were deliberately left out. The keyless daily request and credit caps are environment configuration with no code default (`apps/api/src/config.ts:103-104`), so the page links to `/rate-limits` instead of naming numbers. No effective date and no change-notice sentence were added, because neither has been set by anyone.

Only the English `billing.mdx` is touched. Locales are left to the translation pass.

## Verification

Mintlify CLI 4.2.773 under Node 22.23.2. Baseline is a detached worktree at `origin/main` `73103de7`, the branch base. No `git stash` was used.

| Check | Baseline | Branch | Result |
| --- | --- | --- | --- |
| `mintlify broken-links` | 208 broken links in 95 files, exit 1 | 208 in 95 files, exit 1 | `diff` of the normalized outputs is empty |
| `mintlify validate` | 18 warnings, all "Could not find file /snippets/..." | same 18 | `diff` of the normalized outputs is empty |

Both commands exit non-zero on a clean `origin/main` too, so exit status is not the signal here. The diff against baseline is. All pre-existing broken links sit under the locale directories.

Anchors used by the new text resolve to headings that already exist: `#credit-costs-per-endpoint` and `#running-out-of-credits` in this file, `#keyless-no-api-key` in `rate-limits.mdx`.

Overlap with the other open `billing.mdx` PRs was checked. This hunk starts at old line 85. #1370 edits line 41 and lines 47 to 53. #1378 edits lines 54 to 56. #1364 does not touch `billing.mdx`. No overlap, so this rebases cleanly whatever the merge order.

## One thing for the owner

The free plan card in firecrawl-web says "1 /crawl per min" (`Pricing.tsx:972-977`), while the rate limiter (`rate-limiter.ts:53-63`), the pricing comparison matrix (`plan-comparison-data.ts:182`) and `rate-limits.mdx` all say 2 per minute. This page follows the code and says 2. The card copy is a separate fix in a separate repo.

## Added 2026-09-07

An external review of this PR found two wrong claims in the free plan section. Both are corrected in commit `ea24078c`, verified against `firecrawl` core `origin/main`.

1. The rate limit line said "Batch scrape shares the crawl limit." It now says "Batch scrape shares the scrape limit." The submit route uses `RateLimiterMode.Scrape`, not `Crawl`, in both API versions: `apps/api/src/routes/v2.ts:261-263` and `apps/api/src/routes/v1.ts:69-71`.

2. The endpoint line said "Every API endpoint. No endpoint is restricted by plan." That is too broad. It now names the core product endpoints that are open on the free plan (scrape, crawl, map, search, extract, batch scrape, interact and monitor, all registered in `apps/api/src/routes/v2.ts` with no plan or flag check) and says that some team administration and enterprise features are enabled per team rather than by plan. The three gates verified are threat protection (`apps/api/src/controllers/v2/team-threat-protection.ts:38-45`), SIEM logging (`apps/api/src/controllers/v2/team-siem-logging.ts:25-32`) and zero data retention search (`apps/api/src/controllers/v2/search.ts:174-183`). No gate that was not read in the code is named.

`mintlify broken-links` on Node 22 still reports 208 broken links in 95 files on this branch, matching a detached worktree at base `73103de7`. No link in `billing.mdx` is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SL5chNkWnr4Gy6uuB8PeKS

