### PR TITLE
Add agent quickstart docs for all 5 SDK languages

### DIFF
--- a/agent-quickstart/elixir.mdx
+++ b/agent-quickstart/elixir.mdx
@@ -1,0 +1,189 @@
+---
+title: "Elixir Agent Quickstart"
+description: "Canonical Firecrawl Elixir quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Elixir Agent Quickstart
+
+Canonical quickstart for external agents. Generated from the `firecrawl` Elixir SDK source and the v2 OpenAPI spec. Function names are generated from the OpenAPI spec.
+
+## Install
+
+Add to `mix.exs`:
+
+```elixir
+defp deps do
+  [
+    {:firecrawl, "~> 1.11"}
+  ]
+end
+```
+
+## Authenticate
+
+```elixir
+# config/runtime.exs
+config :firecrawl, api_key: System.get_env("FIRECRAWL_API_KEY")
+
+# Or pass api_key per call:
+{:ok, res} = Firecrawl.search_and_scrape(
+  [query: "firecrawl webhooks"],
+  api_key: "fc-your-api-key"
+)
+```
+
+## When To Use What
+
+- **`search`**: use when you start with a query and need discovery. Supports `site:` filtering.
+- **`scrape`**: use when you already have a URL and want page content.
+- **`interact`**: use when the page needs code execution in a browser session after a scrape.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+`Firecrawl.search_and_scrape(params \\ [], opts \\ [])`
+
+### Example
+
+```elixir
+{:ok, res} = Firecrawl.search_and_scrape(
+  query: "site:docs.firecrawl.dev webhook retries"
+)
+
+# Results are in res.body["data"]["web"], ["news"], ["images"]
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | string | **Required.** Search query. Use `site:example.com` to limit to a domain. |
+| `sources` | list | Sources to search: `:web`, `:news`, `:images`, or `%{type: "web"}` maps. |
+| `categories` | list | Filter by category: `:developer`, `:research`, `:pdf`, or typed maps. |
+| `limit` | integer | Cap the number of results. |
+| `tbs` | string | Time-based filter (e.g. `"qdr:d"` for past day). |
+| `location` | string | Localized results (e.g. `"San Francisco,California,United States"`). |
+| `country` | string | ISO country code for geo-targeting (e.g. `"US"`). |
+| `include_domains` | list of strings | Whitelist domains. |
+| `exclude_domains` | list of strings | Blacklist domains. |
+| `ignore_invalid_urls` | boolean | Drop URLs that cannot be scraped. |
+| `highlights` | boolean | Generate query-relevant highlights. Default: `true`. |
+| `timeout` | integer | Request timeout in milliseconds. |
+| `scrape_options` | keyword list | Scrape each search result. Accepts the same fields as scrape params. |
+
+## Scrape
+
+### Why use it
+
+Get structured content from a URL in one or more formats.
+
+### Preferred SDK method
+
+`Firecrawl.scrape_and_extract_from_url(params \\ [], opts \\ [])`
+
+### Example
+
+```elixir
+{:ok, res} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com/pricing",
+  formats: [
+    "markdown",
+    %{type: "json", prompt: "Extract plan names and prices."}
+  ],
+  only_main_content: true
+)
+
+# res.body["data"]["markdown"]
+# res.body["data"]["json"]
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | string | **Required.** Page URL to scrape. |
+| `formats` | list | Output formats. Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"branding"`, `"audio"`, `"video"`. Maps: `%{type: "json", prompt: ...}`, `%{type: "screenshot", fullPage: true}`, `%{type: "changeTracking", modes: ["git-diff"]}`. |
+| `headers` | map | Custom HTTP headers. |
+| `include_tags` | list of strings | Include only these HTML tags. |
+| `exclude_tags` | list of strings | Exclude these HTML tags. |
+| `only_main_content` | boolean | Strip nav, footer, and boilerplate. |
+| `timeout` | integer | Timeout in milliseconds. Min: 1000, max: 300000. |
+| `wait_for` | integer | Wait for page render (milliseconds). |
+| `mobile` | boolean | Use a mobile viewport. |
+| `parsers` | list | File parsing controls. E.g. `%{type: "pdf", mode: "auto", maxPages: 5}`. |
+| `actions` | list of maps | Pre-scrape actions: `wait`, `click`, `write`, `press`, `scroll`, `scrape`, `executeJavascript`, `pdf`. |
+| `location` | keyword list | Geo/language targeting: `[country: "US", languages: ["en-US"]]`. |
+| `skip_tls_verification` | boolean | Skip TLS verification. |
+| `remove_base64_images` | boolean | Drop base64 images from markdown. |
+| `block_ads` | boolean | Block ads and cookie popups. |
+| `proxy` | atom or string | Proxy control: `:basic`, `:enhanced`, `:auto`. |
+| `max_age` | integer | Accept cached data up to this age (milliseconds). |
+| `min_age` | integer | Accept cached data only if at least this old (milliseconds). |
+| `store_in_cache` | boolean | Cache the result on Firecrawl's side. |
+| `profile` | keyword list | Persistent browser profile: `[name: "my-session", save_changes: true]`. |
+| `zero_data_retention` | boolean | Enable zero data retention for this scrape. |
+
+## Interact
+
+### Why use it
+
+Execute code in the browser session tied to a scrape job. The Elixir SDK exposes code-based interactions only (no `prompt` parameter). `code` is required.
+
+### Preferred SDK method
+
+`Firecrawl.interact_with_scrape_browser_session(job_id, params \\ [], opts \\ [])`
+
+### Example
+
+```elixir
+{:ok, scrape_res} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown"]
+)
+
+job_id = get_in(scrape_res.body, ["data", "metadata", "scrapeId"])
+
+{:ok, res} = Firecrawl.interact_with_scrape_browser_session(
+  job_id,
+  code: "console.log(await page.title());",
+  language: :node,
+  timeout: 60
+)
+
+# res.body["stdout"]
+
+# End the session when done
+{:ok, _} = Firecrawl.stop_interactive_scrape_browser_session(job_id)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | string | **Required.** Scrape job ID from scrape response metadata. |
+| `code` | string | **Required.** Code to run in the browser session. |
+| `language` | atom or string | Runtime: `:python`, `:node`, `:bash`. |
+| `timeout` | integer | Execution timeout in seconds. |
+
+**Stop session:** `Firecrawl.stop_interactive_scrape_browser_session(job_id)` ends the browser session.
+
+## Notes
+
+- **OpenAPI-generated:** Function names and parameter keys are generated from the spec. Do not rename them.
+- **Bang variants:** Every function has a `!` variant (e.g. `scrape_and_extract_from_url!`) that raises on error instead of returning `{:error, _}`.
+- **NimbleOptions validation:** Unknown keys cause `NimbleOptions.ValidationError` before any HTTP call — provides typo detection.
+- **snake_case keys:** All Elixir params use `snake_case`; the SDK auto-converts to `camelCase` JSON.
+- **Atoms and strings:** Enum params like `proxy` accept both atoms (`:auto`) and strings (`"auto"`).
+- **Code-only interact:** The Elixir SDK does not support `prompt` on interact — use `code` only.
+- **No client struct:** There is no `Firecrawl.Client` — configure globally via `config :firecrawl` or per-call via the `opts` keyword list.
+
+## Source Of Truth
+
+- `firecrawl/apps/elixir-sdk/mix.exs`
+- `firecrawl/apps/elixir-sdk/lib/firecrawl.ex`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/java.mdx
+++ b/agent-quickstart/java.mdx
@@ -1,0 +1,211 @@
+---
+title: "Java Agent Quickstart"
+description: "Canonical Firecrawl Java quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Java Agent Quickstart
+
+Canonical quickstart for external agents. Generated from the `firecrawl-java` SDK source and the v2 OpenAPI spec.
+
+## Install
+
+Maven:
+
+```xml
+<dependency>
+  <groupId>com.firecrawl</groupId>
+  <artifactId>firecrawl-java</artifactId>
+  <version>1.17.0</version>
+</dependency>
+```
+
+Gradle:
+
+```gradle
+implementation("com.firecrawl:firecrawl-java:1.17.0")
+```
+
+## Authenticate
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey(System.getenv("FIRECRAWL_API_KEY"))
+    .build();
+
+// Or from environment (reads FIRECRAWL_API_KEY env var / firecrawl.apiKey system property):
+// FirecrawlClient client = FirecrawlClient.fromEnv();
+```
+
+## When To Use What
+
+- **`search`**: use when you start with a query and need discovery. Supports `site:` filtering.
+- **`scrape`**: use when you already have a URL and want page content.
+- **`interact`**: use when the page needs code execution in a browser session after a scrape.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+`client.search(query)` or `client.search(query, options)` → `SearchData`
+
+### Example
+
+```java
+import com.firecrawl.models.SearchData;
+import com.firecrawl.models.SearchOptions;
+import java.util.List;
+import java.util.Map;
+
+SearchData results = client.search("site:docs.firecrawl.dev webhook retries");
+
+// Results are bucketed: getWeb(), getNews(), getImages()
+List<Map<String, Object>> web = results.getWeb();
+if (web != null) {
+    for (Map<String, Object> item : web) {
+        System.out.println(item.get("url") + " - " + item.get("title"));
+    }
+}
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | String | Search query. Use `site:example.com` to limit to a domain. |
+| `options.sources` | List | Sources to search: `"web"`, `"news"`, `"images"`, or typed maps. |
+| `options.categories` | List | Filter by category: `"github"`, `"research"`, `"pdf"`, or typed maps. |
+| `options.limit` | Integer | Cap the number of results. |
+| `options.tbs` | String | Time-based filter (e.g. `"qdr:d"` for past day). |
+| `options.location` | String | Localized results. |
+| `options.includeDomains` | List\<String\> | Whitelist domains. |
+| `options.excludeDomains` | List\<String\> | Blacklist domains. |
+| `options.ignoreInvalidURLs` | Boolean | Drop URLs that cannot be scraped. |
+| `options.highlights` | Boolean | Generate query-relevant highlights. Default: `true`. |
+| `options.timeout` | Integer | Request timeout in milliseconds. |
+| `options.scrapeOptions` | ScrapeOptions | Scrape each search result. Accepts the same fields as `scrape` options. |
+
+## Scrape
+
+### Why use it
+
+Get structured content from a URL in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url)` or `client.scrape(url, options)` → `Document`
+
+### Example
+
+```java
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.JsonFormat;
+import com.firecrawl.models.Document;
+
+Document doc = client.scrape("https://example.com/pricing",
+    ScrapeOptions.builder()
+        .formats(List.of(
+            "markdown",
+            JsonFormat.builder()
+                .prompt("Extract plan names and prices.")
+                .build()
+        ))
+        .onlyMainContent(true)
+        .build()
+);
+
+System.out.println(doc.getMarkdown());
+System.out.println(doc.getJson());
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | String | Page URL to scrape. |
+| `options.formats` | List | Output formats. Strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"attributes"`, `"branding"`, `"audio"`, `"video"`. Objects: `JsonFormat`, `QuestionFormat`, `HighlightsFormat`. |
+| `options.headers` | Map | Custom HTTP headers. |
+| `options.includeTags` | List\<String\> | Include only these HTML tags. |
+| `options.excludeTags` | List\<String\> | Exclude these HTML tags. |
+| `options.onlyMainContent` | Boolean | Strip nav, footer, and boilerplate. |
+| `options.timeout` | Integer | Timeout in milliseconds. |
+| `options.waitFor` | Integer | Wait for page render (milliseconds). |
+| `options.mobile` | Boolean | Use a mobile viewport. |
+| `options.parsers` | List | File parsing: `"pdf"` or `PdfParser.builder().mode("auto").maxPages(5).build()`. |
+| `options.actions` | List\<Map\> | Pre-scrape actions: `wait`, `click`, `write`, `press`, `scroll`, `scrape`, `executeJavascript`, `pdf`. |
+| `options.location` | LocationConfig | Geo/language targeting: `.country("US").languages(List.of("en-US"))`. |
+| `options.skipTlsVerification` | Boolean | Skip TLS verification. |
+| `options.removeBase64Images` | Boolean | Drop base64 images from markdown. |
+| `options.blockAds` | Boolean | Block ads and cookie popups. |
+| `options.proxy` | String | Proxy control: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`, or custom URL. |
+| `options.maxAge` | Long | Accept cached data up to this age (milliseconds). |
+| `options.storeInCache` | Boolean | Cache the result on Firecrawl's side. |
+
+## Interact
+
+### Why use it
+
+Execute code in the browser session tied to a scrape job. The Java SDK exposes code-based interactions only (no `prompt` parameter).
+
+### Preferred SDK method
+
+- `client.interact(jobId, code)` — defaults to language `"node"`
+- `client.interact(jobId, code, language, timeout)` — `timeout` in seconds (1–300)
+
+### Example
+
+```java
+import com.firecrawl.models.BrowserExecuteResponse;
+import com.firecrawl.models.Document;
+
+Document doc = client.scrape("https://example.com",
+    ScrapeOptions.builder().formats(List.of("markdown")).build()
+);
+String jobId = (String) doc.getMetadata().get("scrapeId");
+
+// Execute code in the browser session
+BrowserExecuteResponse result = client.interact(
+    jobId,
+    "console.log(await page.title());",
+    "node",
+    60
+);
+
+System.out.println(result.getStdout());
+
+// End the session when done
+client.stopInteractiveBrowser(jobId);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `jobId` | String | Scrape job ID from `document.getMetadata().get("scrapeId")`. |
+| `code` | String | Code to run in the browser session (Playwright `page` in Node runtime). |
+| `language` | String | Runtime: `"python"`, `"node"`, `"bash"`. Default: `"node"`. |
+| `timeout` | Integer | Execution timeout in seconds (1–300). `null` uses API default (30s). |
+
+**Stop session:** `client.stopInteractiveBrowser(jobId)` ends the browser session.
+
+## Notes
+
+- **Builder pattern:** `ScrapeOptions`, `SearchOptions`, `JsonFormat`, `LocationConfig` etc. all use `Foo.builder()...build()`.
+- **Untyped search results:** `SearchData.getWeb()`, `.getNews()`, `.getImages()` return `List<Map<String, Object>>`.
+- **Code-only interact:** The Java SDK does not support `prompt` on `interact` — use `code` only.
+- **Async variants:** All methods have `*Async` counterparts returning `CompletableFuture<T>`.
+- **Deprecated aliases:** `scrapeExecute` → `interact`; `deleteScrapeBrowser` → `stopInteractiveBrowser`.
+- Java 11+ required.
+
+## Source Of Truth
+
+- `firecrawl/apps/java-sdk/build.gradle.kts`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/ScrapeOptions.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/SearchOptions.java`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/node.mdx
+++ b/agent-quickstart/node.mdx
@@ -1,0 +1,181 @@
+---
+title: "Node.js Agent Quickstart"
+description: "Canonical Firecrawl Node.js quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Node.js Agent Quickstart
+
+Canonical quickstart for external agents. Generated from the `firecrawl` JS SDK source and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+
+## Install
+
+```bash
+npm install firecrawl
+```
+
+## Authenticate
+
+```ts
+import { Firecrawl } from "firecrawl";
+
+const client = new Firecrawl({
+  apiKey: process.env.FIRECRAWL_API_KEY,
+});
+```
+
+## When To Use What
+
+- **`search`**: use when you start with a query and need discovery. Supports `site:` filtering.
+- **`scrape`**: use when you already have a URL and want page content.
+- **`interact`**: use when the page needs clicks, forms, or post-scrape browser actions. Requires a `scrapeId` from a prior scrape.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+`client.search(query, options?)` → `Promise<SearchData>`
+
+### Example
+
+```ts
+const results = await client.search("site:docs.firecrawl.dev webhook retries");
+
+// Results are bucketed by source, NOT under .data
+for (const item of results.web ?? []) {
+  console.log(item.url, item.title);
+}
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | string | Search query. Use `site:example.com` to limit to a domain. |
+| `options.sources` | array | Sources to search: `"web"`, `"news"`, `"images"`, or typed objects like `{ type: "web" }`. |
+| `options.categories` | array | Filter by category: `"developer"`, `"research"`, `"pdf"`, or typed objects. |
+| `options.limit` | number | Cap the number of results. |
+| `options.tbs` | string | Time-based filter (e.g. `"qdr:d"` for past day, `"qdr:w"` for past week). |
+| `options.location` | string | Localized results (e.g. `"San Francisco,California,United States"`). |
+| `options.ignoreInvalidURLs` | boolean | Drop URLs that cannot be scraped. |
+| `options.timeout` | number | Request timeout in milliseconds. |
+| `options.includeDomains` | string[] | Whitelist domains (mutually exclusive with `excludeDomains`). |
+| `options.excludeDomains` | string[] | Blacklist domains (mutually exclusive with `includeDomains`). |
+| `options.highlights` | boolean | Generate query-relevant highlights. Default: `true` server-side. |
+| `options.scrapeOptions` | ScrapeOptions | Scrape each search result. Accepts the same fields as `scrape` options. |
+
+## Scrape
+
+### Why use it
+
+Get structured content from a URL in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, options?)` → `Promise<Document>`
+
+### Example
+
+```ts
+const doc = await client.scrape("https://example.com/pricing", {
+  formats: [
+    "markdown",
+    { type: "json", prompt: "Extract plan names and prices." }
+  ],
+  onlyMainContent: true,
+});
+
+console.log(doc.markdown);
+console.log(doc.json);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | string | Page URL to scrape. |
+| `options.formats` | array | Output formats. Plain strings: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"audio"`, `"video"`. Object forms: `{ type: "json", prompt?, schema? }`, `{ type: "question", question }`, `{ type: "highlights", query }`, `{ type: "screenshot", fullPage?, quality?, viewport? }`, `{ type: "changeTracking", modes, schema?, prompt?, tag? }`, `{ type: "attributes", selectors }`. Note: `"json"` as a plain string is rejected by the SDK — use the object form. |
+| `options.headers` | Record | Custom HTTP headers. |
+| `options.includeTags` | string[] | Include only these HTML tags. |
+| `options.excludeTags` | string[] | Exclude these HTML tags. |
+| `options.onlyMainContent` | boolean | Strip nav, footer, and boilerplate. |
+| `options.timeout` | number | Timeout in milliseconds. |
+| `options.waitFor` | number | Wait for page render (milliseconds). |
+| `options.mobile` | boolean | Use a mobile viewport. |
+| `options.parsers` | array | File parsing controls. E.g. `"pdf"` or `{ type: "pdf", mode: "auto", maxPages: 5 }`. |
+| `options.actions` | array | Pre-scrape browser actions: `wait`, `click`, `write`, `press`, `scroll`, `scrape`, `screenshot`, `executeJavascript`, `pdf`. |
+| `options.location` | object | Geo/language targeting: `{ country: "US", languages: ["en-US"] }`. |
+| `options.skipTlsVerification` | boolean | Skip TLS verification. |
+| `options.removeBase64Images` | boolean | Drop base64 images from markdown. |
+| `options.fastMode` | boolean | Faster scrapes with reduced fidelity. |
+| `options.blockAds` | boolean | Block ads and cookie popups. |
+| `options.proxy` | string | Proxy control: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`, or a custom URL. |
+| `options.maxAge` | number | Accept cached data up to this age (milliseconds). |
+| `options.minAge` | number | Accept cached data only if at least this old (milliseconds). |
+| `options.storeInCache` | boolean | Cache the result on Firecrawl's side. |
+| `options.profile` | object | Persistent browser profile: `{ name: "my-session", saveChanges: true }`. |
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job. Use for clicks, form fills, or code execution after a scrape. Requires at least one of `code` or `prompt`.
+
+### Preferred SDK method
+
+`client.interact(jobId, args)` → `Promise<ScrapeExecuteResponse>`
+
+### Example
+
+```ts
+const doc = await client.scrape("https://example.com", { formats: ["markdown"] });
+const jobId = doc.metadata?.scrapeId;
+if (!jobId) throw new Error("Missing scrapeId");
+
+// Natural language interaction
+const result = await client.interact(jobId, {
+  prompt: "Click the pricing tab and summarize the plans.",
+});
+
+// Or code-based interaction
+const codeResult = await client.interact(jobId, {
+  code: "console.log(await page.title());",
+  language: "node",
+  timeout: 60,
+});
+
+// End the session when done
+await client.stopInteraction(jobId);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `jobId` | string | Scrape job ID from `document.metadata.scrapeId`. |
+| `args.code` | string | Code to run in the browser session (Playwright `page` in Node runtime). |
+| `args.prompt` | string | Natural-language instruction for the browser agent. |
+| `args.language` | string | Runtime: `"python"`, `"node"`, `"bash"`. Default: `"node"`. |
+| `args.timeout` | number | Execution timeout in seconds. |
+
+At least one of `code` or `prompt` must be non-empty.
+
+**Stop session:** `client.stopInteraction(jobId)` ends the browser session.
+
+## Notes
+
+- **Return shape:** `search()` returns `{ web, news, images }`, not `{ data: [...] }`.
+- **Deprecated aliases:** `scrapeExecute` → `interact`; `stopInteractiveBrowser` / `deleteScrapeBrowser` → `stopInteraction`.
+- The default `Firecrawl` export is the v2 client; v1 remains under `client.v1`.
+- Zod schemas passed to `formats` (for `json` or `changeTracking`) are auto-converted to JSON Schema.
+- Package requires **Node.js >= 22**.
+
+## Source Of Truth
+
+- `firecrawl/apps/js-sdk/firecrawl/src/index.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/python.mdx
+++ b/agent-quickstart/python.mdx
@@ -1,0 +1,179 @@
+---
+title: "Python Agent Quickstart"
+description: "Canonical Firecrawl Python quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Python Agent Quickstart
+
+Canonical quickstart for external agents. Generated from the `firecrawl-py` SDK source and the v2 OpenAPI spec. Method names, parameters, and return types match the v2 client.
+
+## Install
+
+```bash
+pip install firecrawl-py
+```
+
+## Authenticate
+
+```python
+import os
+from firecrawl import Firecrawl
+
+client = Firecrawl(api_key=os.environ.get("FIRECRAWL_API_KEY"))
+```
+
+## When To Use What
+
+- **`search`**: use when you start with a query and need discovery. Supports `site:` filtering.
+- **`scrape`**: use when you already have a URL and want page content.
+- **`interact`**: use when the page needs clicks, forms, or post-scrape browser actions. Requires a `scrape_id` from a prior scrape.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+`client.search(query, **options)` → `SearchData`
+
+### Example
+
+```python
+results = client.search("site:docs.firecrawl.dev webhook retries")
+
+# Results are bucketed by source, NOT under .data
+for item in results.web or []:
+    print(getattr(item, "url", None), getattr(item, "title", None))
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | str | Search query. Use `site:example.com` to limit to a domain. |
+| `sources` | list | Sources to search: `"web"`, `"news"`, `"images"`, or `Source(type=...)` objects. |
+| `categories` | list | Filter by category: `"developer"`, `"research"`, `"pdf"`, or `Category(type=...)` objects. |
+| `limit` | int | Cap the number of results. Default: `5`. |
+| `tbs` | str | Time-based filter (e.g. `"qdr:d"` for past day, `"qdr:w"` for past week). |
+| `location` | str | Localized results (e.g. `"San Francisco,California,United States"`). |
+| `include_domains` | list[str] | Whitelist domains (mutually exclusive with `exclude_domains`). |
+| `exclude_domains` | list[str] | Blacklist domains (mutually exclusive with `include_domains`). |
+| `ignore_invalid_urls` | bool | Drop URLs that cannot be scraped. |
+| `highlights` | bool | Generate query-relevant highlights. Default: `True` server-side. |
+| `timeout` | int | Request timeout in milliseconds. Default: `300000`. |
+| `scrape_options` | ScrapeOptions | Scrape each search result. Accepts the same fields as `scrape` options. |
+
+## Scrape
+
+### Why use it
+
+Get structured content from a URL in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, **options)` → `Document`
+
+### Example
+
+```python
+doc = client.scrape(
+    "https://example.com/pricing",
+    formats=[
+        "markdown",
+        {"type": "json", "prompt": "Extract plan names and prices."},
+    ],
+    only_main_content=True,
+)
+
+print(doc.markdown)
+print(doc.json)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | str | Page URL to scrape. |
+| `formats` | list | Output formats. Plain strings: `"markdown"`, `"html"`, `"rawHtml"` (or `"raw_html"`), `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"` (or `"change_tracking"`), `"attributes"`, `"branding"`, `"audio"`, `"video"`. Object forms: `{"type": "json", "prompt": ..., "schema": ...}`, `{"type": "question", "question": ...}`, `{"type": "highlights", "query": ...}`, `{"type": "screenshot", "full_page": ..., "quality": ..., "viewport": ...}`, `{"type": "changeTracking", "modes": [...], "tag": ...}`, `{"type": "attributes", "selectors": [...]}`. Note: `"json"` as a plain string is rejected — use the object form. |
+| `headers` | dict | Custom HTTP headers. |
+| `include_tags` | list[str] | Include only these HTML tags. |
+| `exclude_tags` | list[str] | Exclude these HTML tags. |
+| `only_main_content` | bool | Strip nav, footer, and boilerplate. |
+| `timeout` | int | Timeout in milliseconds. |
+| `wait_for` | int | Wait for page render (milliseconds). |
+| `mobile` | bool | Use a mobile viewport. |
+| `parsers` | list | File parsing controls. E.g. `"pdf"` or `{"type": "pdf", "mode": "auto", "max_pages": 5}`. |
+| `actions` | list | Pre-scrape browser actions: `wait`, `click`, `write`, `press`, `scroll`, `scrape`, `screenshot`, `executeJavascript`, `pdf`. |
+| `location` | dict | Geo/language targeting: `{"country": "US", "languages": ["en-US"]}`. |
+| `skip_tls_verification` | bool | Skip TLS verification. |
+| `remove_base64_images` | bool | Drop base64 images from markdown. |
+| `fast_mode` | bool | Faster scrapes with reduced fidelity. |
+| `block_ads` | bool | Block ads and cookie popups. |
+| `proxy` | str | Proxy control: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. |
+| `max_age` | int | Accept cached data up to this age (milliseconds). |
+| `store_in_cache` | bool | Cache the result on Firecrawl's side. |
+| `profile` | dict | Persistent browser profile: `{"name": "my-session", "save_changes": True}`. |
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job. Use for clicks, form fills, or code execution after a scrape. Requires at least one of `code` or `prompt`. `prompt` is keyword-only.
+
+### Preferred SDK method
+
+`client.interact(job_id, code=None, *, prompt=None, language="node", timeout=None)`
+
+### Example
+
+```python
+doc = client.scrape("https://example.com", formats=["markdown"])
+job_id = doc.metadata.scrape_id if doc.metadata else None
+if not job_id:
+    raise RuntimeError("Missing scrape_id from scrape response")
+
+# Natural language interaction
+result = client.interact(job_id, prompt="Click the pricing tab and summarize the plans.")
+
+# Or code-based interaction
+result = client.interact(
+    job_id,
+    code="print(await page.title())",
+    language="python",
+    timeout=60,
+)
+
+# End the session when done
+client.stop_interaction(job_id)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | str | Scrape job ID from `document.metadata.scrape_id`. |
+| `code` | str | Code to run in the browser session (positional or keyword). |
+| `prompt` | str | Natural-language instruction for the browser agent (keyword-only). |
+| `language` | str | Runtime: `"python"`, `"node"`, `"bash"`. Default: `"node"`. |
+| `timeout` | int | Execution timeout in seconds. |
+
+At least one of `code` or `prompt` must be non-empty.
+
+**Stop session:** `client.stop_interaction(job_id)` ends the browser session.
+
+## Notes
+
+- **Return shape:** `search()` returns a `SearchData` with `.web`, `.news`, `.images` — not `.data`. Accessing `.data` raises `AttributeError`.
+- **snake_case naming:** All Python parameters use `snake_case` (e.g. `only_main_content`, `include_tags`, `skip_tls_verification`). The SDK handles camelCase conversion.
+- **Deprecated aliases:** `scrape_execute` → `interact`; `stop_interactive_browser` / `delete_scrape_browser` → `stop_interaction`.
+- The top-level `Firecrawl` client exposes v2 methods directly; v1 remains under `client.v1`.
+- Async variant available: `from firecrawl import AsyncFirecrawl`.
+
+## Source Of Truth
+
+- `firecrawl/apps/python-sdk/firecrawl/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/rust.mdx
+++ b/agent-quickstart/rust.mdx
@@ -1,0 +1,224 @@
+---
+title: "Rust Agent Quickstart"
+description: "Canonical Firecrawl Rust quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Rust Agent Quickstart
+
+Canonical quickstart for external agents. Generated from the `firecrawl` Rust crate source and the v2 OpenAPI spec.
+
+## Install
+
+```toml
+# Cargo.toml
+[dependencies]
+firecrawl = "2"
+tokio = { version = "1", features = ["full"] }
+```
+
+## Authenticate
+
+```rust
+use firecrawl::Client;
+
+#[tokio::main]
+async fn main() -> Result<(), firecrawl::FirecrawlError> {
+    let client = Client::new("fc-your-api-key")?;
+    // Self-hosted:
+    // let client = Client::new_selfhosted("http://localhost:3002", Some("fc-your-api-key"))?;
+    Ok(())
+}
+```
+
+## When To Use What
+
+- **`search`**: use when you start with a query and need discovery. Supports `site:` filtering.
+- **`scrape`**: use when you already have a URL and want page content.
+- **`interact`**: use when the page needs clicks, forms, or post-scrape browser actions. Requires a scrape job ID from a prior scrape.
+
+## Search
+
+### Why use it
+
+Discover relevant pages from a query, then pick URLs to scrape or interact with. Constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
+
+### Preferred SDK method
+
+`client.search(query, options)` → `Result<SearchResponse, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{Client, SearchOptions, ScrapeOptions, Format};
+
+let results = client
+    .search("site:docs.firecrawl.dev webhook retries", None)
+    .await?;
+
+// Results are in results.data.web, .news, .images
+if let Some(web) = results.data.web {
+    for item in web {
+        // Each item is SearchResultOrDocument::WebResult or ::Document
+        println!("{:?}", item);
+    }
+}
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `impl AsRef<str>` | Search query. Use `site:example.com` to limit to a domain. |
+| `options.sources` | `Vec<SearchSource>` | Sources to search: `Web`, `News`, `Images`. |
+| `options.categories` | `Vec<SearchCategory>` | Filter by category: `Github`, `Research`, `Pdf`. |
+| `options.limit` | `u32` | Cap the number of results. |
+| `options.tbs` | `String` | Time-based filter (e.g. `"qdr:d"` for past day). |
+| `options.location` | `String` | Localized results. |
+| `options.include_domains` | `Vec<String>` | Whitelist domains. |
+| `options.exclude_domains` | `Vec<String>` | Blacklist domains. |
+| `options.ignore_invalid_urls` | `bool` | Drop URLs that cannot be scraped. |
+| `options.highlights` | `bool` | Generate query-relevant highlights. Default: `true`. |
+| `options.timeout` | `u32` | Request timeout in milliseconds. |
+| `options.scrape_options` | `ScrapeOptions` | Scrape each search result. Accepts the same fields as `scrape` options. |
+
+## Scrape
+
+### Why use it
+
+Get structured content from a URL in one or more formats.
+
+### Preferred SDK method
+
+`client.scrape(url, options)` → `Result<Document, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, Format, JsonOptions};
+
+let doc = client
+    .scrape("https://example.com/pricing", ScrapeOptions {
+        formats: Some(vec![Format::Markdown, Format::Json]),
+        json_options: Some(JsonOptions {
+            prompt: Some("Extract plan names and prices.".to_string()),
+            ..Default::default()
+        }),
+        only_main_content: Some(true),
+        ..Default::default()
+    })
+    .await?;
+
+println!("{:?}", doc.markdown);
+println!("{:?}", doc.json);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `impl AsRef<str>` | Page URL to scrape. |
+| `options.formats` | `Vec<Format>` | Output formats: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `ChangeTracking`, `Json`, `Attributes`, `Branding`, `Product`, `Menu`, `Audio`, `Video`. Struct variants: `Question(QuestionFormat)`, `Highlights(HighlightsFormat)`. |
+| `options.headers` | `HashMap<String, String>` | Custom HTTP headers. |
+| `options.include_tags` | `Vec<String>` | Include only these HTML tags. |
+| `options.exclude_tags` | `Vec<String>` | Exclude these HTML tags. |
+| `options.only_main_content` | `bool` | Strip nav, footer, and boilerplate. |
+| `options.timeout` | `u32` | Timeout in milliseconds. |
+| `options.wait_for` | `u32` | Wait for page render (milliseconds). |
+| `options.mobile` | `bool` | Use a mobile viewport. |
+| `options.parsers` | `Vec<ParserConfig>` | File parsing: `ParserConfig::Simple("pdf".into())` or `ParserConfig::Pdf { .. }`. |
+| `options.actions` | `Vec<Action>` | Pre-scrape actions: `Wait`, `Click`, `Write`, `Press`, `Scroll`, `Scrape`, `Screenshot`, `ExecuteJavascript`, `Pdf`. |
+| `options.location` | `LocationConfig` | Geo/language targeting: `{ country, languages }`. |
+| `options.skip_tls_verification` | `bool` | Skip TLS verification. |
+| `options.remove_base64_images` | `bool` | Drop base64 images from markdown. |
+| `options.fast_mode` | `bool` | Faster scrapes with reduced fidelity. |
+| `options.block_ads` | `bool` | Block ads and cookie popups. |
+| `options.proxy` | `ProxyType` | Proxy control: `Basic`, `Stealth`, `Enhanced`, `Auto`. |
+| `options.max_age` | `u32` | Accept cached data up to this age (milliseconds). |
+| `options.min_age` | `u32` | Accept cached data only if at least this old (milliseconds). |
+| `options.store_in_cache` | `bool` | Cache the result on Firecrawl's side. |
+| `options.profile` | `ProfileConfig` | Persistent browser profile: `{ name, save_changes }`. |
+| `options.json_options` | `JsonOptions` | JSON extraction config: `{ schema, system_prompt, prompt }`. |
+| `options.screenshot_options` | `ScreenshotOptions` | Screenshot config: `{ full_page, quality, viewport }`. |
+| `options.change_tracking_options` | `ChangeTrackingOptions` | Change tracking: `{ modes, schema, prompt, tag }`. |
+| `options.attribute_selectors` | `Vec<AttributeSelector>` | Attribute extraction: `{ selector, attribute }`. |
+
+## Interact
+
+### Why use it
+
+Control the browser session tied to a scrape job. Use for clicks, form fills, or code execution after a scrape. Requires at least one of `code` or `prompt`.
+
+### Preferred SDK method
+
+`client.interact(job_id, options)` → `Result<ScrapeExecuteResponse, FirecrawlError>`
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, Format, ScrapeExecuteOptions, ScrapeExecuteLanguage};
+
+let doc = client
+    .scrape("https://example.com", ScrapeOptions {
+        formats: Some(vec![Format::Markdown]),
+        ..Default::default()
+    })
+    .await?;
+
+let job_id = doc.metadata
+    .as_ref()
+    .and_then(|m| m.get("scrapeId"))
+    .and_then(|v| v.as_str())
+    .expect("Missing scrapeId");
+
+// Natural language interaction
+let result = client
+    .interact(job_id, ScrapeExecuteOptions {
+        prompt: Some("Click the pricing tab and summarize the plans.".to_string()),
+        ..Default::default()
+    })
+    .await?;
+
+// Or code-based interaction
+let result = client
+    .interact(job_id, ScrapeExecuteOptions {
+        code: Some("console.log(await page.title());".to_string()),
+        language: Some(ScrapeExecuteLanguage::Node),
+        timeout: Some(60),
+        ..Default::default()
+    })
+    .await?;
+
+// End the session when done
+client.stop_interaction(job_id).await?;
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `impl AsRef<str>` | Scrape job ID from document metadata. |
+| `options.code` | `Option<String>` | Code to run in the browser session. |
+| `options.prompt` | `Option<String>` | Natural-language instruction for the browser agent. |
+| `options.language` | `ScrapeExecuteLanguage` | Runtime: `Python`, `Node`, `Bash`. Default: `Node`. |
+| `options.timeout` | `u32` | Execution timeout in seconds. |
+
+At least one of `code` or `prompt` must be non-empty (returns `FirecrawlError::Misuse` otherwise).
+
+**Stop session:** `client.stop_interaction(job_id)` ends the browser session.
+
+## Notes
+
+- **Async-only:** All methods are `async` and require a Tokio runtime.
+- **Struct literal construction:** All option structs derive `Default`, so use `ScrapeOptions { formats: Some(vec![Format::Markdown]), ..Default::default() }`.
+- **No builder pattern:** Configuration uses plain structs, not method-chaining.
+- **Deprecated aliases:** `scrape_execute` → `interact`; `stop_interactive_browser` / `delete_scrape_browser` → `stop_interaction`.
+- **Convenience helper:** `search_and_scrape(query, limit)` calls `search` with default `ScrapeOptions` and returns `Vec<Document>`.
+- All types are exported at the crate root: `use firecrawl::Client`.
+
+## Source Of Truth
+
+- `firecrawl/apps/rust-sdk/Cargo.toml`
+- `firecrawl/apps/rust-sdk/src/client.rs`
+- `firecrawl/apps/rust-sdk/src/scrape.rs`
+- `firecrawl/apps/rust-sdk/src/search.rs`
+- `firecrawl-docs/api-reference/v2-openapi.json`


### PR DESCRIPTION
## Summary

- Adds one canonical agent quickstart file per SDK language in `agent-quickstart/`:
  - `node.mdx` — Node.js/TypeScript
  - `python.mdx` — Python
  - `rust.mdx` — Rust
  - `java.mdx` — Java
  - `elixir.mdx` — Elixir
- Each file covers **search**, **scrape**, and **interact** endpoints with:
  - Install and auth instructions
  - Preferred SDK method signatures
  - Realistic working examples
  - Comprehensive parameter tables sourced from SDK code and v2 OpenAPI spec
  - Language-specific notes (naming conventions, deprecated aliases, quirks)
- Designed to be easy to paste into agent context as a canonical reference

## Source of Truth

All content generated from:
1. SDK source code in `firecrawl/` (primary authority)
2. `firecrawl-docs/api-reference/v2-openapi.json` (HTTP contract)
3. Existing `agent-source-of-truth/` files (secondary reference only)

## Test plan

- [ ] Verify each `.mdx` file renders correctly as a Mintlify page
- [ ] Spot-check parameter tables against current SDK source
- [ ] Confirm no localized files were modified

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6aegjf3UXYxfHuq6HP4ba

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6aegjf3UXYxfHuq6HP4ba)_