### PR TITLE
docs: add agent quickstart pages for all SDK languages

### DIFF
--- a/agent-quickstart/elixir.mdx
+++ b/agent-quickstart/elixir.mdx
@@ -1,0 +1,223 @@
+---
+title: "Elixir Agent Quickstart"
+description: "Canonical Firecrawl Elixir quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Elixir Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating Firecrawl via the Elixir SDK. It is generated from SDK source and the OpenAPI spec.
+
+## Install
+
+Add to your `mix.exs` dependencies:
+
+```elixir
+{:firecrawl, "~> 1.11"}
+```
+
+Then run `mix deps.get`.
+
+## Authenticate
+
+The Elixir SDK has no client struct. Configure the API key globally or pass it per-call.
+
+**Global configuration** (in `config/config.exs`):
+
+```elixir
+config :firecrawl, api_key: "fc-YOUR_API_KEY"
+```
+
+**Per-call override** (via the `opts` keyword list):
+
+```elixir
+Firecrawl.scrape_and_extract_from_url(
+  [url: "https://example.com"],
+  api_key: "fc-YOUR_API_KEY"
+)
+```
+
+A nil/empty key is allowed — scrape, search, and interact fall back to a keyless free tier (rate-limited per IP).
+
+The `opts` keyword list (always the last argument) also accepts:
+
+| Option | Description |
+|---|---|
+| `:api_key` | Override the API key for this request. |
+| `:base_url` | Override the default `https://api.firecrawl.dev/v2` (for self-hosted). |
+
+## When To Use What
+
+- **`search_and_scrape`** — Use when you start with a query and need discovery. Returns web, news, and image results with optional scraping of each result.
+- **`scrape_and_extract_from_url`** — Use when you already have a URL and want page content (markdown, HTML, screenshots, structured JSON, etc.).
+- **`interact_with_scrape_browser_session`** — Use when the page needs clicks, form fills, or post-scrape browser actions. Runs code against an active browser session.
+
+## Search
+
+### Why use it
+
+Search the web with a query and get back structured results. Optionally scrape each result page inline. Useful for discovery, research, and finding relevant URLs before scraping them in detail.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.search_and_scrape(params, opts \\ [])
+```
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.search_and_scrape(
+  query: "firecrawl web scraping API",
+  limit: 5
+)
+
+IO.inspect(response.body)
+```
+
+Bang variant raises on error: `Firecrawl.search_and_scrape!(params, opts)`.
+
+### Parameters
+
+All parameters are passed as a keyword list:
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `query` | `:string` | **yes** | Search query. |
+| `sources` | `{:list, :any}` | no | Which result types: `"web"`, `"news"`, `"images"`. |
+| `categories` | `{:list, :any}` | no | Narrow search: `"github"`, `"research"`, `"pdf"`. |
+| `include_domains` | `{:list, :string}` | no | Only include results from these domains. |
+| `exclude_domains` | `{:list, :string}` | no | Exclude results from these domains. |
+| `limit` | `:integer` | no | Max number of results. |
+| `tbs` | `:string` | no | Google time-based search filter (e.g. `"qdr:d"`). |
+| `location` | `:string` | no | Geo-target location string. |
+| `country` | `:string` | no | Country code for geo-targeting. |
+| `ignore_invalid_urls` | `:boolean` | no | Skip invalid URLs instead of erroring. |
+| `timeout` | `:integer` | no | Timeout in milliseconds. |
+| `highlights` | `:boolean` | no | Generate query-relevant highlights. |
+| `scrape_options` | `:keyword_list` | no | Options applied when scraping each result (same keys as scrape parameters below). |
+| `enterprise` | `{:list, :string}` | no | Enterprise features: `["zdr"]`, `["anon"]`. |
+
+## Scrape
+
+### Why use it
+
+Fetch a single URL and get back structured page data — markdown, HTML, screenshots, extracted JSON, and more. The workhorse endpoint for turning a known URL into usable content.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.scrape_and_extract_from_url(params, opts \\ [])
+```
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown", "html"],
+  only_main_content: true
+)
+
+IO.puts(response.body["data"]["markdown"])
+```
+
+Bang variant: `Firecrawl.scrape_and_extract_from_url!(params, opts)`.
+
+### Parameters
+
+All parameters are passed as a keyword list:
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `url` | `:string` | **yes** | Target URL to scrape. |
+| `formats` | `{:list, :any}` | no | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"json"`, etc. |
+| `headers` | `:any` | no | Custom HTTP headers. |
+| `include_tags` | `{:list, :string}` | no | Only include these HTML tags. |
+| `exclude_tags` | `{:list, :string}` | no | Exclude these HTML tags. |
+| `only_main_content` | `:boolean` | no | Strip boilerplate, return only main content. |
+| `timeout` | `:integer` | no | Server-side timeout in milliseconds. |
+| `wait_for` | `:integer` | no | Wait time in ms before scraping. |
+| `mobile` | `:boolean` | no | Use a mobile user-agent. |
+| `parsers` | `{:list, :any}` | no | Parser configuration (e.g. for PDF files). |
+| `actions` | `{:list, :any}` | no | Browser actions: wait, click, write, press, scroll, scrape, executeJavascript, screenshot, pdf. |
+| `location` | `:keyword_list` | no | Geo-location settings: `[country: "US", languages: ["en"]]`. |
+| `skip_tls_verification` | `:boolean` | no | Skip TLS certificate verification. |
+| `remove_base64_images` | `:boolean` | no | Strip base64-encoded images. |
+| `block_ads` | `:boolean` | no | Block ads during scraping. |
+| `proxy` | `:basic \| :enhanced \| :auto` | no | Proxy tier to use. |
+| `max_age` | `:integer` | no | Max age in ms of cached content. |
+| `min_age` | `:integer` | no | Min cache age in ms. |
+| `store_in_cache` | `:boolean` | no | Store the result in cache. |
+| `lockdown` | `:boolean` | no | Serve cached only. |
+| `redact_pii` | `:boolean` | no | Redact personally identifiable information. |
+| `profile` | `:keyword_list` | no | Browser profile: `[name: "my-profile"]`. |
+| `audit_metadata` | `:keyword_list` | no | Audit metadata: `[username: "user"]`. |
+| `zero_data_retention` | `:boolean` | no | Enable zero data retention. |
+
+## Interact
+
+### Why use it
+
+Run code against an active browser session tied to a scrape job. Use it for clicking buttons, filling forms, navigating multi-step flows, or extracting data that requires browser interaction after the initial scrape.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.interact_with_scrape_browser_session(job_id, params \\ [], opts \\ [])
+```
+
+### Example
+
+```elixir
+# First scrape to get a job ID
+{:ok, scrape_response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown"]
+)
+job_id = scrape_response.body["data"]["metadata"]["jobId"]
+
+# Then interact with the browser session
+{:ok, result} = Firecrawl.interact_with_scrape_browser_session(
+  job_id,
+  code: "document.querySelector('button.load-more').click()",
+  language: :node,
+  timeout: 30
+)
+
+IO.inspect(result.body)
+```
+
+Bang variant: `Firecrawl.interact_with_scrape_browser_session!(job_id, params, opts)`.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `job_id` | `String.t()` | **yes** | Scrape job ID (first positional argument). |
+| `code` | `:string` | **yes** | Code to execute in the browser. |
+| `language` | `:python \| :node \| :bash` | no | Execution language. Defaults to `:node`. |
+| `timeout` | `:integer` | no | Execution timeout in seconds. |
+| `origin` | `:string` | no | Request origin identifier. |
+
+### Stopping a session
+
+```elixir
+Firecrawl.stop_interactive_scrape_browser_session(job_id)
+```
+
+## Notes
+
+- **Auto-generated SDK** — The Elixir SDK is auto-generated from the OpenAPI spec. Every function maps 1:1 to an API operation. The file header says "DO NOT EDIT MANUALLY".
+- **No client struct** — There is no client object to initialize. `Firecrawl` is a module with static functions.
+- **Keyword list parameters** — All `params` must be keyword lists (e.g. `[url: "...", limit: 10]`). NimbleOptions validates at runtime.
+- **Nested params are keyword lists too** — For `scrape_options`, `location`, `audit_metadata`, `profile`, pass keyword lists. The SDK auto-converts `snake_case` keys to `camelCase` when serializing to JSON.
+- **Enum values are atoms** — For constrained params, pass atoms: `proxy: :enhanced`, `language: :node`. They become strings in the JSON body.
+- **No deprecated aliases** — The SDK has no deprecated aliases or renamed functions.
+- **Return shape** — All functions return `{:ok, %Req.Response{}}` or `{:error, exception}`. Bang variants return `Req.Response.t()` directly and raise on error.
+- **Function names are verbose** — The function names (`scrape_and_extract_from_url`, `search_and_scrape`, `interact_with_scrape_browser_session`) are generated from the OpenAPI operation IDs. Do not rename them.
+
+## Source Of Truth
+
+- `firecrawl/apps/elixir-sdk/lib/firecrawl.ex`
+- `firecrawl/apps/elixir-sdk/mix.exs`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/java.mdx
+++ b/agent-quickstart/java.mdx
@@ -1,0 +1,248 @@
+---
+title: "Java Agent Quickstart"
+description: "Canonical Firecrawl Java quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Java Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating Firecrawl via the Java SDK. It is generated from SDK source and the OpenAPI spec.
+
+## Install
+
+Maven:
+
+```xml
+<dependency>
+    <groupId>com.firecrawl</groupId>
+    <artifactId>firecrawl-java</artifactId>
+    <version>1.18.0</version>
+</dependency>
+```
+
+Gradle (Kotlin DSL):
+
+```kotlin
+implementation("com.firecrawl:firecrawl-java:1.18.0")
+```
+
+Requires Java 11+.
+
+## Authenticate
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey("fc-YOUR_API_KEY")
+    .build();
+```
+
+Or read the key from the `FIRECRAWL_API_KEY` environment variable (or `firecrawl.apiKey` system property):
+
+```java
+FirecrawlClient client = FirecrawlClient.fromEnv();
+```
+
+A null/blank API key is allowed — `scrape`, `search`, and `interact` fall back to a keyless free tier (rate-limited per IP).
+
+Builder options:
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `apiKey` | `String` | env/sysprop | API key. Falls back to `FIRECRAWL_API_KEY` env var, then `firecrawl.apiKey` system property. |
+| `apiUrl` | `String` | `"https://api.firecrawl.dev"` | Base URL. Falls back to `FIRECRAWL_API_URL` env var. |
+| `timeoutMs` | `long` | `300000` | HTTP timeout in milliseconds. |
+| `maxRetries` | `int` | `3` | Max automatic retries. |
+| `backoffFactor` | `double` | `0.5` | Exponential backoff factor in seconds. |
+| `asyncExecutor` | `Executor` | `ForkJoinPool.commonPool()` | Executor for async methods. |
+| `httpClient` | `OkHttpClient` | auto-created | Full control over transport. |
+
+## When To Use What
+
+- **`search`** — Use when you start with a query and need discovery. Returns web, news, and image results with optional scraping of each result.
+- **`scrape`** — Use when you already have a URL and want page content (markdown, HTML, screenshots, structured JSON, etc.).
+- **`interact`** — Use when the page needs clicks, form fills, or post-scrape browser actions. Runs code against an active browser session.
+
+## Search
+
+### Why use it
+
+Search the web with a query and get back structured results. Optionally scrape each result page inline. Useful for discovery, research, and finding relevant URLs before scraping them in detail.
+
+### Preferred SDK method
+
+```java
+client.search(query, options)
+```
+
+### Example
+
+```java
+import com.firecrawl.models.SearchOptions;
+import com.firecrawl.models.SearchData;
+
+SearchData results = client.search("firecrawl web scraping API",
+    SearchOptions.builder()
+        .limit(5)
+        .highlights(true)
+        .build()
+);
+
+for (var result : results.getWeb()) {
+    System.out.println(result.get("url") + " " + result.get("title"));
+}
+```
+
+Results are grouped under `.getWeb()`, `.getNews()`, and `.getImages()`. Each element is a `Map<String, Object>`.
+
+### Parameters
+
+`SearchOptions` (built via `SearchOptions.builder()`):
+
+| Builder method | Type | Description |
+|---|---|---|
+| `sources(List<Object>)` | `List<Object>` | Source types: `"web"`, `"news"`, `"images"`. |
+| `categories(List<Object>)` | `List<Object>` | Categories: `"github"`, `"research"`, `"pdf"`. |
+| `includeDomains(List<String>)` | `List<String>` | Only include results from these domains. Cannot combine with `excludeDomains`. |
+| `excludeDomains(List<String>)` | `List<String>` | Exclude results from these domains. Cannot combine with `includeDomains`. |
+| `limit(Integer)` | `Integer` | Max number of results. |
+| `tbs(String)` | `String` | Google time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location(String)` | `String` | Geo-target location string. |
+| `country(String)` | `String` | Country code for geo-targeting (e.g. `"us"`). |
+| `ignoreInvalidURLs(Boolean)` | `Boolean` | Skip invalid URLs instead of erroring. |
+| `timeout(Integer)` | `Integer` | Timeout in milliseconds. |
+| `highlights(Boolean)` | `Boolean` | Generate query-relevant highlights. Defaults to `true`. |
+| `scrapeOptions(ScrapeOptions)` | `ScrapeOptions` | Options applied when scraping each result. |
+| `integration(String)` | `String` | Integration identifier. |
+
+Async variant: `client.searchAsync(query, options)` returns `CompletableFuture<SearchData>`.
+
+## Scrape
+
+### Why use it
+
+Fetch a single URL and get back structured page data — markdown, HTML, screenshots, extracted JSON, and more. The workhorse endpoint for turning a known URL into usable content.
+
+### Preferred SDK method
+
+```java
+client.scrape(url, options)
+```
+
+### Example
+
+```java
+import com.firecrawl.models.ScrapeOptions;
+import com.firecrawl.models.Document;
+import java.util.List;
+
+Document doc = client.scrape("https://example.com",
+    ScrapeOptions.builder()
+        .formats(List.of("markdown", "html"))
+        .onlyMainContent(true)
+        .build()
+);
+
+System.out.println(doc.getMarkdown());
+```
+
+Passing `null` for options uses defaults.
+
+### Parameters
+
+`ScrapeOptions` (built via `ScrapeOptions.builder()`):
+
+| Builder method | Type | Description |
+|---|---|---|
+| `formats(List<Object>)` | `List<Object>` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"json"`, `"audio"`, `"video"`, or format config objects (`JsonFormat`, `QuestionFormat`, etc.). |
+| `headers(Map<String, String>)` | `Map<String, String>` | Custom HTTP headers. |
+| `includeTags(List<String>)` | `List<String>` | Only include these HTML tags. |
+| `excludeTags(List<String>)` | `List<String>` | Exclude these HTML tags. |
+| `onlyMainContent(Boolean)` | `Boolean` | Strip boilerplate, return only main content. |
+| `timeout(Integer)` | `Integer` | Server-side timeout in milliseconds. |
+| `waitFor(Integer)` | `Integer` | Wait time in ms before scraping. |
+| `mobile(Boolean)` | `Boolean` | Scrape as mobile device. |
+| `parsers(List<Object>)` | `List<Object>` | Parser configuration (e.g. `"pdf"` or `PdfParser`). |
+| `actions(List<Map<String, Object>>)` | `List<Map<String, Object>>` | Browser actions to execute before scraping. |
+| `location(LocationConfig)` | `LocationConfig` | Geolocation: `new LocationConfig("US", List.of("en"))`. |
+| `skipTlsVerification(Boolean)` | `Boolean` | Skip TLS certificate verification. |
+| `removeBase64Images(Boolean)` | `Boolean` | Remove base64 images from response. |
+| `blockAds(Boolean)` | `Boolean` | Block advertisements. |
+| `proxy(String)` | `String` | Proxy tier: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. |
+| `maxAge(Long)` | `Long` | Max age in ms of cached content to reuse. |
+| `storeInCache(Boolean)` | `Boolean` | Store result in cache. |
+| `lockdown(Boolean)` | `Boolean` | Serve cached only. |
+| `redactPII(Boolean)` | `Boolean` | Redact personally identifiable information. |
+| `auditMetadata(AuditMetadata)` | `AuditMetadata` | Audit metadata: `new AuditMetadata("username")`. |
+| `integration(String)` | `String` | Integration identifier. |
+
+Async variant: `client.scrapeAsync(url, options)` returns `CompletableFuture<Document>`.
+
+## Interact
+
+### Why use it
+
+Run code against an active browser session tied to a scrape job. Use it for clicking buttons, filling forms, navigating multi-step flows, or extracting data that requires browser interaction after the initial scrape.
+
+### Preferred SDK method
+
+```java
+client.interact(jobId, code)
+client.interact(jobId, code, language, timeout)
+client.interact(jobId, code, language, timeout, origin)
+```
+
+### Example
+
+```java
+import com.firecrawl.models.BrowserExecuteResponse;
+
+// First scrape to get a job ID
+Document doc = client.scrape("https://example.com", null);
+String jobId = (String) doc.getMetadata().get("jobId");
+
+// Then interact with the browser session
+BrowserExecuteResponse result = client.interact(
+    jobId,
+    "document.querySelector('button.load-more').click()"
+);
+
+System.out.println(result.getStdout());
+```
+
+### Parameters
+
+The method uses positional overloads (not a builder):
+
+| Parameter | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `jobId` | `String` | yes | — | Scrape job ID from a previous scrape. |
+| `code` | `String` | yes | — | Code to execute in the browser. |
+| `language` | `String` | no | `"node"` | `"python"`, `"node"`, or `"bash"`. |
+| `timeout` | `Integer` | no | `null` (server default 30) | Execution timeout in seconds (1–300). |
+| `origin` | `String` | no | `null` | Request origin identifier. |
+
+Async variants: `client.interactAsync(jobId, code)` and overloads return `CompletableFuture<BrowserExecuteResponse>`.
+
+### Stopping a session
+
+```java
+client.stopInteractiveBrowser(jobId);
+```
+
+## Notes
+
+- **Builder pattern** — All options use `ScrapeOptions.builder()...build()` and `SearchOptions.builder()...build()`. Options objects are immutable after construction. `ScrapeOptions` also has `toBuilder()` for copying and modifying.
+- **Interact uses overloads** — The `interact` method has three overloads (2-arg, 4-arg, 5-arg) instead of a builder.
+- **Null options are safe** — Passing `null` for the options parameter on `scrape` and `search` is explicitly handled.
+- **`SearchData` uses loose maps** — `getWeb()`, `getNews()`, `getImages()` return `List<Map<String, Object>>`. Individual result items are not strongly typed.
+- **Deprecated aliases** — `scrapeExecute()` maps to `interact()`. `deleteScrapeBrowser()` maps to `stopInteractiveBrowser()`. Always use the preferred names.
+- **Async methods** — All main methods have `*Async` variants returning `CompletableFuture`, running on the configured executor (default `ForkJoinPool.commonPool()`).
+
+## Source Of Truth
+
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/ScrapeOptions.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/SearchOptions.java`
+- `firecrawl/apps/java-sdk/build.gradle.kts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/node.mdx
+++ b/agent-quickstart/node.mdx
@@ -1,0 +1,212 @@
+---
+title: "Node Agent Quickstart"
+description: "Canonical Firecrawl Node.js/TypeScript quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Node Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating Firecrawl via the Node.js/TypeScript SDK. It is generated from SDK source and the OpenAPI spec.
+
+## Install
+
+```bash
+npm install @mendable/firecrawl-js
+```
+
+Requires Node >= 22.0.0.
+
+## Authenticate
+
+```ts
+import Firecrawl from "@mendable/firecrawl-js";
+
+const firecrawl = new Firecrawl({ apiKey: "fc-YOUR_API_KEY" });
+```
+
+You can also pass a plain string: `new Firecrawl("fc-YOUR_API_KEY")`.
+
+The API key can be omitted — `scrape`, `search`, and `interact` work on a keyless free tier (rate-limited per IP). All other methods require a key.
+
+Constructor options:
+
+| Option | Type | Description |
+|---|---|---|
+| `apiKey` | `string \| null` | API key. Falls back to `FIRECRAWL_API_KEY` env var. |
+| `apiUrl` | `string \| null` | Base URL. Falls back to `FIRECRAWL_API_URL` env var, then `https://api.firecrawl.dev`. |
+| `timeoutMs` | `number` | Per-request timeout in milliseconds. |
+| `maxRetries` | `number` | Max automatic retries for transient failures. |
+| `backoffFactor` | `number` | Exponential backoff factor for retries. |
+
+## When To Use What
+
+- **`search`** — Use when you start with a query and need discovery. Returns web, news, and image results with optional scraping of each result.
+- **`scrape`** — Use when you already have a URL and want page content (markdown, HTML, screenshots, structured JSON, etc.).
+- **`interact`** — Use when the page needs clicks, form fills, or post-scrape browser actions. Runs code or a prompt against an active browser session.
+
+## Search
+
+### Why use it
+
+Search the web with a query and get back structured results. Optionally scrape each result page inline. Useful for discovery, research, and finding relevant URLs before scraping them in detail.
+
+### Preferred SDK method
+
+```ts
+firecrawl.search(query, options?)
+```
+
+### Example
+
+```ts
+const results = await firecrawl.search("firecrawl web scraping API", {
+  limit: 5,
+  scrapeOptions: {
+    formats: ["markdown"],
+  },
+});
+
+for (const result of results.web ?? []) {
+  console.log(result.url, result.title);
+}
+```
+
+Results are grouped under `.web`, `.news`, and `.images` — there is no `.data` property.
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `string` | **(required)** Search query. |
+| `sources` | `Array<"web" \| "news" \| "images">` | Which result types to include. |
+| `categories` | `Array<"github" \| "research" \| "pdf" \| "developer">` | Narrow web search by category. |
+| `includeDomains` | `string[]` | Only include results from these domains. Cannot combine with `excludeDomains`. |
+| `excludeDomains` | `string[]` | Exclude results from these domains. Cannot combine with `includeDomains`. |
+| `limit` | `number` | Max number of results. |
+| `tbs` | `string` | Google time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `string` | Geo-target location string. |
+| `country` | `string` | ISO 3166-1 alpha-2 country code. |
+| `ignoreInvalidURLs` | `boolean` | Skip URLs that fail validation instead of erroring. |
+| `timeout` | `number` | Server-side timeout in milliseconds. |
+| `highlights` | `boolean` | Generate query-relevant highlights in results. Defaults to `true`. |
+| `scrapeOptions` | `ScrapeOptions` | Options applied when scraping each result (same shape as scrape parameters below). |
+| `enterprise` | `Array<"default" \| "anon" \| "zdr">` | Enterprise features: anonymized search, zero data retention. |
+| `threatProtection` | `ThreatProtectionOptions` | Enterprise threat protection settings. |
+| `integration` | `string` | Integration identifier. |
+| `origin` | `string` | Request origin identifier. |
+
+## Scrape
+
+### Why use it
+
+Fetch a single URL and get back structured page data — markdown, HTML, screenshots, extracted JSON, and more. The workhorse endpoint for turning a known URL into usable content.
+
+### Preferred SDK method
+
+```ts
+firecrawl.scrape(url, options?)
+```
+
+### Example
+
+```ts
+const doc = await firecrawl.scrape("https://example.com", {
+  formats: ["markdown", "html"],
+  onlyMainContent: true,
+});
+
+console.log(doc.markdown);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `string` | **(required)** Target URL to scrape. |
+| `formats` | `FormatOption[]` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`. Also structured formats like `{ type: "json", schema: yourSchema }`. |
+| `headers` | `Record<string, string>` | Custom HTTP headers sent with the scrape request. |
+| `includeTags` | `string[]` | Only include these HTML tags in the output. |
+| `excludeTags` | `string[]` | Exclude these HTML tags from the output. |
+| `onlyMainContent` | `boolean` | Strip boilerplate (nav, footer, sidebar) and return only main content. |
+| `timeout` | `number` | Server-side timeout in milliseconds. |
+| `waitFor` | `number` | Wait this many milliseconds for the page to load before scraping. |
+| `mobile` | `boolean` | Use a mobile user-agent. |
+| `parsers` | `Array<string \| PDFParser>` | Parser configuration (e.g. for PDF files). |
+| `actions` | `ActionOption[]` | Browser actions to perform before scraping: wait, click, write, press, scroll, scrape, executeJavascript, screenshot, pdf. |
+| `location` | `{ country?: string; languages?: string[] }` | Geo-location settings for the request. |
+| `skipTlsVerification` | `boolean` | Skip TLS certificate verification. |
+| `removeBase64Images` | `boolean` | Strip base64-encoded images from the output. |
+| `fastMode` | `boolean` | Enable fast scraping mode. |
+| `blockAds` | `boolean` | Block ads during scraping. |
+| `proxy` | `"basic" \| "stealth" \| "enhanced" \| "auto"` | Proxy tier to use. |
+| `maxAge` | `number` | Max age in ms of cached content to reuse. `0` to bypass cache. |
+| `storeInCache` | `boolean` | Store the result in cache. |
+| `lockdown` | `boolean` | Enable lockdown mode. |
+| `redactPII` | `boolean \| RedactPIIOptions` | Redact personally identifiable information. |
+| `threatProtection` | `ThreatProtectionOptions` | Enterprise threat protection settings. |
+| `auditMetadata` | `{ username: string }` | Audit metadata for tracking. |
+| `profile` | `{ name: string; saveChanges?: boolean }` | Browser profile to use. |
+| `integration` | `string` | Integration identifier. |
+| `autoResume` | `boolean` | SDK-only. Auto-retry when a large document outlives the request window. Defaults to `true`. |
+
+## Interact
+
+### Why use it
+
+Run code or a natural-language prompt against an active browser session tied to a scrape job. Use it for clicking buttons, filling forms, navigating multi-step flows, or extracting data that requires browser interaction after the initial scrape.
+
+### Preferred SDK method
+
+```ts
+firecrawl.interact(jobId, args)
+```
+
+### Example
+
+```ts
+// First, scrape with actions to get a persistent browser session
+const doc = await firecrawl.scrape("https://example.com", {
+  formats: ["markdown"],
+});
+const jobId = doc.metadata?.jobId;
+
+// Then interact with the browser session
+const result = await firecrawl.interact(jobId, {
+  code: "document.querySelector('button.load-more').click()",
+  language: "node",
+  timeout: 30,
+});
+
+console.log(result.output);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `jobId` | `string` | **(required)** Scrape job ID from a previous scrape. |
+| `code` | `string` | Code to execute in the browser. At least one of `code` or `prompt` is required. |
+| `prompt` | `string` | Natural-language prompt to execute. At least one of `code` or `prompt` is required. |
+| `language` | `"python" \| "node" \| "bash"` | Language for code execution. Defaults to `"node"`. |
+| `timeout` | `number` | Execution timeout in seconds (1–300). |
+| `origin` | `string` | Request origin identifier. |
+
+### Stopping a session
+
+```ts
+await firecrawl.stopInteraction(jobId);
+```
+
+## Notes
+
+- **camelCase naming** — All parameter names use camelCase (e.g. `onlyMainContent`, `includeTags`).
+- **Deprecated aliases** — `scrapeUrl()` maps to `scrape()`. `scrapeExecute()` maps to `interact()`. `stopInteractiveBrowser()` and `deleteScrapeBrowser()` map to `stopInteraction()`. Always use the preferred names.
+- **Zod schema support** — The `json` format accepts a Zod schema in `schema` which is auto-converted to JSON Schema before sending.
+- **Auto-resume** — By default, `scrape()` transparently retries when a large document outlives the request window (max 5 retries / 20 min). Set `autoResume: false` to disable.
+- **Search result shape** — Results are on `.web`, `.news`, `.images`. Accessing `.data` throws a helpful error.
+
+## Source Of Truth
+
+- `firecrawl/apps/js-sdk/firecrawl/src/index.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/python.mdx
+++ b/agent-quickstart/python.mdx
@@ -1,0 +1,206 @@
+---
+title: "Python Agent Quickstart"
+description: "Canonical Firecrawl Python quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Python Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating Firecrawl via the Python SDK. It is generated from SDK source and the OpenAPI spec.
+
+## Install
+
+```bash
+pip install firecrawl-py
+```
+
+## Authenticate
+
+```python
+from firecrawl import Firecrawl
+
+firecrawl = Firecrawl(api_key="fc-YOUR_API_KEY")
+```
+
+The API key can be omitted — `scrape`, `search`, and `interact` work on a keyless free tier (rate-limited per IP). All other methods require a key. The key also falls back to the `FIRECRAWL_API_KEY` environment variable.
+
+Constructor parameters:
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `api_key` | `str` | `None` | API key. Falls back to `FIRECRAWL_API_KEY` env var. |
+| `api_url` | `str` | `"https://api.firecrawl.dev"` | Base URL for the API. |
+| `timeout` | `float` | `None` | Default request timeout in seconds. |
+| `max_retries` | `int` | `3` | Max automatic retries for transient failures. |
+| `backoff_factor` | `float` | `0.5` | Exponential backoff factor for retries. |
+
+An async client is also available: `from firecrawl import AsyncFirecrawl`.
+
+## When To Use What
+
+- **`search`** — Use when you start with a query and need discovery. Returns web, news, and image results with optional scraping of each result.
+- **`scrape`** — Use when you already have a URL and want page content (markdown, HTML, screenshots, structured JSON, etc.).
+- **`interact`** — Use when the page needs clicks, form fills, or post-scrape browser actions. Runs code or a prompt against an active browser session.
+
+## Search
+
+### Why use it
+
+Search the web with a query and get back structured results. Optionally scrape each result page inline. Useful for discovery, research, and finding relevant URLs before scraping them in detail.
+
+### Preferred SDK method
+
+```python
+firecrawl.search(query, **options)
+```
+
+### Example
+
+```python
+results = firecrawl.search(
+    "firecrawl web scraping API",
+    limit=5,
+    scrape_options={"formats": ["markdown"]},
+)
+
+for result in results.web or []:
+    print(result.url, result.title)
+```
+
+Results are grouped under `.web`, `.news`, and `.images` — there is no `.data` attribute.
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `str` | **(required)** Search query. |
+| `sources` | `list[str]` | Which result types to include: `"web"`, `"news"`, `"images"`. |
+| `categories` | `list[str]` | Narrow web search by category: `"github"`, `"research"`, `"pdf"`, `"developer"`. |
+| `include_domains` | `list[str]` | Only include results from these domains. Cannot combine with `exclude_domains`. |
+| `exclude_domains` | `list[str]` | Exclude results from these domains. Cannot combine with `include_domains`. |
+| `limit` | `int` | Max number of results. Default `5`. |
+| `tbs` | `str` | Google time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `str` | Geo-target location string. Note: this is a plain string, not a `Location` object. |
+| `country` | `str` | ISO 3166-1 alpha-2 country code. |
+| `ignore_invalid_urls` | `bool` | Skip URLs that fail validation instead of erroring. |
+| `timeout` | `int` | Server-side timeout in milliseconds. Default `300000`. |
+| `highlights` | `bool` | Generate query-relevant highlights in results. Default `True`. |
+| `scrape_options` | `ScrapeOptions` | Options applied when scraping each result (same shape as scrape parameters below). |
+| `enterprise` | `list[str]` | Enterprise features: e.g. `["zdr"]`, `["anon"]`. |
+| `threat_protection` | `ThreatProtectionOptions` | Enterprise threat protection settings. |
+| `integration` | `str` | Integration identifier. |
+
+## Scrape
+
+### Why use it
+
+Fetch a single URL and get back structured page data — markdown, HTML, screenshots, extracted JSON, and more. The workhorse endpoint for turning a known URL into usable content.
+
+### Preferred SDK method
+
+```python
+firecrawl.scrape(url, **options)
+```
+
+### Example
+
+```python
+doc = firecrawl.scrape(
+    "https://example.com",
+    formats=["markdown", "html"],
+    only_main_content=True,
+)
+
+print(doc.markdown)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `str` | **(required)** Target URL to scrape. |
+| `formats` | `list[str]` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`. |
+| `headers` | `dict[str, str]` | Custom HTTP headers sent with the scrape request. |
+| `include_tags` | `list[str]` | Only include these HTML tags in the output. |
+| `exclude_tags` | `list[str]` | Exclude these HTML tags from the output. |
+| `only_main_content` | `bool` | Strip boilerplate (nav, footer, sidebar) and return only main content. |
+| `timeout` | `int` | Server-side timeout in milliseconds. |
+| `wait_for` | `int` | Wait this many milliseconds for the page to load before scraping. |
+| `mobile` | `bool` | Use a mobile user-agent. |
+| `parsers` | `list` | Parser configuration (e.g. for PDF files). |
+| `actions` | `list` | Browser actions to perform before scraping: wait, click, write, press, scroll, scrape, executeJavascript, screenshot, pdf. |
+| `location` | `Location` | Geo-location settings: `Location(country="US", languages=["en"])`. Note: this is a `Location` object, not a plain string (unlike search). |
+| `skip_tls_verification` | `bool` | Skip TLS certificate verification. |
+| `remove_base64_images` | `bool` | Strip base64-encoded images from the output. |
+| `fast_mode` | `bool` | Enable fast scraping mode. |
+| `block_ads` | `bool` | Block ads during scraping. |
+| `proxy` | `str` | Proxy tier: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. |
+| `max_age` | `int` | Max age in ms of cached content to reuse. |
+| `store_in_cache` | `bool` | Store the result in cache. |
+| `lockdown` | `bool` | Enable lockdown mode (serve cached only). |
+| `threat_protection` | `ThreatProtectionOptions` | Enterprise threat protection settings. |
+| `profile` | `dict` | Browser profile to use. |
+| `audit_metadata` | `AuditMetadata` | Audit metadata for tracking. |
+| `integration` | `str` | Integration identifier. |
+| `auto_resume` | `bool` | SDK auto-retry when a large document outlives the request window. |
+
+## Interact
+
+### Why use it
+
+Run code or a natural-language prompt against an active browser session tied to a scrape job. Use it for clicking buttons, filling forms, navigating multi-step flows, or extracting data that requires browser interaction after the initial scrape.
+
+### Preferred SDK method
+
+```python
+firecrawl.interact(job_id, code=None, *, prompt=None, language="node", timeout=None, origin=None)
+```
+
+### Example
+
+```python
+# First, scrape to get a job ID with a persistent browser session
+doc = firecrawl.scrape("https://example.com", formats=["markdown"])
+job_id = doc.metadata.get("jobId")
+
+# Then interact with the browser session
+result = firecrawl.interact(
+    job_id,
+    code="document.querySelector('button.load-more').click()",
+    language="node",
+    timeout=30,
+)
+
+print(result.output)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `str` | **(required)** Scrape job ID from a previous scrape. |
+| `code` | `str` | Code to execute in the browser. At least one of `code` or `prompt` is required. |
+| `prompt` | `str` | Natural-language prompt to execute. At least one of `code` or `prompt` is required. |
+| `language` | `str` | Language for code execution: `"python"`, `"node"`, `"bash"`. Default `"node"`. |
+| `timeout` | `int` | Execution timeout in seconds (1–300). |
+| `origin` | `str` | Request origin identifier. |
+
+### Stopping a session
+
+```python
+firecrawl.stop_interaction(job_id)
+```
+
+## Notes
+
+- **snake_case naming** — All parameter names use snake_case (e.g. `only_main_content`, `include_tags`). The SDK handles conversion to camelCase for the API.
+- **Deprecated aliases** — `scrape_url()` maps to `scrape()`. `scrape_execute()` maps to `interact()`. `stop_interactive_browser()` and `delete_scrape_browser()` map to `stop_interaction()`. Always use the preferred names.
+- **Legacy class names** — `FirecrawlApp` and `AsyncFirecrawlApp` are exported as aliases for `Firecrawl` and `AsyncFirecrawl`. Use the new names.
+- **`location` type differs between scrape and search** — In `scrape()`, `location` is a `Location` object with `country` and `languages` fields. In `search()`, `location` is a plain string.
+- **Search result shape** — Results are on `.web`, `.news`, `.images`. Accessing `.data` raises an `AttributeError` with guidance.
+
+## Source Of Truth
+
+- `firecrawl/apps/python-sdk/firecrawl/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/rust.mdx
+++ b/agent-quickstart/rust.mdx
@@ -1,0 +1,266 @@
+---
+title: "Rust Agent Quickstart"
+description: "Canonical Firecrawl Rust quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Rust Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating Firecrawl via the Rust SDK. It is generated from SDK source and the OpenAPI spec.
+
+## Install
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+firecrawl = "2"
+tokio = { version = "1", features = ["full"] }
+```
+
+## Authenticate
+
+```rust
+use firecrawl::Client;
+
+let client = Client::new("fc-YOUR_API_KEY")?;
+```
+
+For self-hosted instances:
+
+```rust
+let client = Client::new_selfhosted("http://localhost:3000", Some("fc-YOUR_API_KEY"))?;
+```
+
+An empty or omitted API key is allowed — `scrape`, `search`, and `interact` fall back to a keyless free tier (rate-limited per IP).
+
+## When To Use What
+
+- **`search`** — Use when you start with a query and need discovery. Returns web, news, and image results with optional scraping of each result.
+- **`scrape`** — Use when you already have a URL and want page content (markdown, HTML, screenshots, structured JSON, etc.).
+- **`interact`** — Use when the page needs clicks, form fills, or post-scrape browser actions. Runs code or a prompt against an active browser session.
+
+## Search
+
+### Why use it
+
+Search the web with a query and get back structured results. Optionally scrape each result page inline. Useful for discovery, research, and finding relevant URLs before scraping them in detail.
+
+### Preferred SDK method
+
+```rust
+client.search(query, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, SearchOptions};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::new("fc-YOUR_API_KEY")?;
+
+    let response = client.search("firecrawl web scraping API", SearchOptions {
+        limit: Some(5),
+        ..Default::default()
+    }).await?;
+
+    if let Some(web_results) = response.data.web {
+        for result in web_results {
+            println!("{:?}", result);
+        }
+    }
+
+    Ok(())
+}
+```
+
+Results are grouped under `.data.web`, `.data.news`, and `.data.images`.
+
+### Parameters
+
+`SearchOptions` fields (all `Option`, derives `Default`):
+
+| Field | Type | Description |
+|---|---|---|
+| `limit` | `Option<u32>` | Max number of results. Default 5, max 20. |
+| `sources` | `Option<Vec<SearchSource>>` | Which result types: `Web`, `News`, `Images`. |
+| `categories` | `Option<Vec<SearchCategory>>` | Narrow search: `Github`, `Research`, `Pdf`. |
+| `include_domains` | `Option<Vec<String>>` | Only include results from these domains. |
+| `exclude_domains` | `Option<Vec<String>>` | Exclude results from these domains. |
+| `tbs` | `Option<String>` | Google time-based search filter (e.g. `"qdr:d"`). |
+| `location` | `Option<String>` | Geo-target location string. |
+| `country` | `Option<String>` | Country code (e.g. `"us"`). |
+| `ignore_invalid_urls` | `Option<bool>` | Skip invalid URLs instead of erroring. |
+| `timeout` | `Option<u32>` | Timeout in milliseconds. |
+| `highlights` | `Option<bool>` | Generate query-relevant highlights. Defaults to `true`. |
+| `scrape_options` | `Option<ScrapeOptions>` | Options applied when scraping each result. |
+| `integration` | `Option<String>` | Integration identifier. |
+| `origin` | `Option<String>` | Auto-set by SDK if `None`. |
+
+### Convenience method
+
+```rust
+client.search_and_scrape(query, limit).await
+```
+
+Searches and scrapes all results, returning `Vec<Document>`.
+
+## Scrape
+
+### Why use it
+
+Fetch a single URL and get back structured page data — markdown, HTML, screenshots, extracted JSON, and more. The workhorse endpoint for turning a known URL into usable content.
+
+### Preferred SDK method
+
+```rust
+client.scrape(url, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, Format};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::new("fc-YOUR_API_KEY")?;
+
+    let doc = client.scrape("https://example.com", ScrapeOptions {
+        formats: Some(vec![Format::Markdown, Format::Html]),
+        only_main_content: Some(true),
+        ..Default::default()
+    }).await?;
+
+    if let Some(markdown) = doc.markdown {
+        println!("{}", markdown);
+    }
+
+    Ok(())
+}
+```
+
+Pass `None` instead of `ScrapeOptions` to use all defaults.
+
+### Parameters
+
+`ScrapeOptions` fields (all `Option`, derives `Default`):
+
+| Field | Type | Description |
+|---|---|---|
+| `formats` | `Option<Vec<Format>>` | Output formats: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `ChangeTracking`, `Json`, `Attributes`, `Branding`, `Product`, `Menu`, `Audio`, `Video`. Also `Question(QuestionFormat)` and `Highlights(HighlightsFormat)`. |
+| `headers` | `Option<HashMap<String, String>>` | Custom HTTP headers. |
+| `include_tags` | `Option<Vec<String>>` | Only include these HTML tags. |
+| `exclude_tags` | `Option<Vec<String>>` | Exclude these HTML tags. |
+| `only_main_content` | `Option<bool>` | Strip boilerplate, return only main content. |
+| `timeout` | `Option<u32>` | Server-side timeout in milliseconds. |
+| `wait_for` | `Option<u32>` | Wait time in ms for page load. |
+| `mobile` | `Option<bool>` | Emulate mobile device. |
+| `parsers` | `Option<Vec<ParserConfig>>` | Parser configuration (e.g. PDF). |
+| `actions` | `Option<Vec<Action>>` | Browser actions: `Wait`, `Click`, `Write`, `Press`, `Scroll`, `Scrape`, `ExecuteJavascript`, `Screenshot`, `Pdf`. |
+| `location` | `Option<LocationConfig>` | Geo-location: `LocationConfig { country, languages }`. |
+| `skip_tls_verification` | `Option<bool>` | Skip TLS certificate verification. |
+| `remove_base64_images` | `Option<bool>` | Strip base64-encoded images. |
+| `fast_mode` | `Option<bool>` | Enable fast scraping mode. |
+| `block_ads` | `Option<bool>` | Block ads during scraping. |
+| `proxy` | `Option<ProxyType>` | Proxy tier: `Basic`, `Stealth`, `Enhanced`, `Auto`. |
+| `max_age` | `Option<u32>` | Max cache age in seconds. |
+| `min_age` | `Option<u32>` | Min cache age in seconds. |
+| `store_in_cache` | `Option<bool>` | Store the result in cache. |
+| `lockdown` | `Option<bool>` | Serve cached only, no outbound requests. |
+| `redact_pii` | `Option<bool>` | Redact personally identifiable information. |
+| `audit_metadata` | `Option<AuditMetadata>` | SIEM logging attribution. |
+| `profile` | `Option<ProfileConfig>` | Browser profile: `ProfileConfig { name, save_changes }`. |
+| `integration` | `Option<String>` | Integration identifier. |
+| `json_options` | `Option<JsonOptions>` | JSON extraction config: `schema`, `system_prompt`, `prompt`, `check_prompt_injection`. |
+| `screenshot_options` | `Option<ScreenshotOptions>` | Screenshot config: `full_page`, `quality`, `viewport`. |
+| `change_tracking_options` | `Option<ChangeTrackingOptions>` | Change tracking config. |
+| `attribute_selectors` | `Option<Vec<AttributeSelector>>` | Attribute extraction selectors. |
+| `origin` | `Option<String>` | Auto-set by SDK if `None`. |
+
+### Convenience method
+
+```rust
+client.scrape_with_schema(url, schema_json, prompt).await
+```
+
+Scrapes with JSON extraction using a JSON Schema value.
+
+## Interact
+
+### Why use it
+
+Run code or a natural-language prompt against an active browser session tied to a scrape job. Use it for clicking buttons, filling forms, navigating multi-step flows, or extracting data that requires browser interaction after the initial scrape.
+
+### Preferred SDK method
+
+```rust
+client.interact(job_id, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeExecuteOptions, ScrapeExecuteLanguage};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::new("fc-YOUR_API_KEY")?;
+
+    // First scrape to get a job ID
+    let doc = client.scrape("https://example.com", None).await?;
+    let job_id = doc.metadata.as_ref()
+        .and_then(|m| m.additional.get("jobId"))
+        .and_then(|v| v.as_str())
+        .expect("no job ID");
+
+    // Then interact with the browser session
+    let result = client.interact(job_id, ScrapeExecuteOptions {
+        code: Some("document.querySelector('button').click()".into()),
+        language: Some(ScrapeExecuteLanguage::Node),
+        timeout: Some(30),
+        ..Default::default()
+    }).await?;
+
+    println!("{:?}", result.output);
+
+    Ok(())
+}
+```
+
+### Parameters
+
+`ScrapeExecuteOptions` fields (all `Option`, derives `Default`):
+
+| Field | Type | Description |
+|---|---|---|
+| `code` | `Option<String>` | Code to execute. At least one of `code` or `prompt` is required. |
+| `prompt` | `Option<String>` | Natural-language prompt. At least one of `code` or `prompt` is required. |
+| `language` | `Option<ScrapeExecuteLanguage>` | Execution language: `Python`, `Node`, `Bash`. Defaults to `Node`. |
+| `timeout` | `Option<u32>` | Execution timeout in seconds. |
+| `origin` | `Option<String>` | Auto-set by SDK if `None`. |
+
+### Stopping a session
+
+```rust
+client.stop_interaction(job_id).await?;
+```
+
+## Notes
+
+- **Async only** — All methods are `async` and require a tokio runtime (`#[tokio::main]`).
+- **`Option` wrapping** — All options structs use `Option<T>` for every field and derive `Default`. Use struct update syntax: `ScrapeOptions { formats: Some(vec![...]), ..Default::default() }`.
+- **No builder pattern** — Options are plain structs with public fields, not builders.
+- **`impl Into<Option<...>>`** — `scrape()` and `search()` accept `impl Into<Option<ScrapeOptions/SearchOptions>>`, so you can pass `None` directly or pass the struct without wrapping in `Some()`.
+- **`impl AsRef<str>`** — URL, query, and job_id parameters accept `impl AsRef<str>`, so `&str`, `String`, etc. all work.
+- **snake_case fields** — Rust fields use `snake_case` (e.g. `only_main_content`). The SDK handles serde `camelCase` conversion for the API wire format.
+- **Deprecated aliases** — `scrape_execute()` maps to `interact()`. `stop_interactive_browser()` and `delete_scrape_browser()` map to `stop_interaction()`. Always use the preferred names.
+
+## Source Of Truth
+
+- `firecrawl/apps/rust-sdk/src/v2/client.rs`
+- `firecrawl/apps/rust-sdk/src/v2/search.rs`
+- `firecrawl/apps/rust-sdk/src/v2/scrape.rs`
+- `firecrawl/apps/rust-sdk/Cargo.toml`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs.json
+++ b/docs.json
@@ -133,6 +133,16 @@
                       },
                       "sdks/cli",
                       "ai-onboarding",
+                      {
+                        "group": "Agent Quickstarts",
+                        "pages": [
+                          "agent-quickstart/node",
+                          "agent-quickstart/python",
+                          "agent-quickstart/rust",
+                          "agent-quickstart/java",
+                          "agent-quickstart/elixir"
+                        ]
+                      },
                       "advanced-scraping-guide",
                       {
                         "group": "Plans and Billing",


### PR DESCRIPTION
## Summary

- Adds canonical agent quickstart documents for **Node.js/TypeScript**, **Python**, **Rust**, **Java**, and **Elixir** in `agent-quickstart/`
- Each file covers the three core agent endpoints: `search`, `scrape`, and `interact`
- Every file includes: install command, auth pattern, when-to-use-what guide, preferred SDK method names, working examples, and a complete parameter table sourced from SDK code and the v2 OpenAPI spec
- Adds the "Agent Quickstarts" navigation group to `docs.json` under "Get Started", after "Build with AI"

## What's in each quickstart

| Section | Content |
|---|---|
| Install | Exact package/crate install command |
| Authenticate | Minimal auth example with constructor options |
| When To Use What | Short decision guide for search vs scrape vs interact |
| Search | Method name, example, full parameter table |
| Scrape | Method name, example, full parameter table |
| Interact | Method name, example, full parameter table |
| Notes | Language-specific caveats, deprecated aliases, naming conventions |
| Source Of Truth | Exact source files used |

## Sources

All content generated from:
1. SDK source code in `firecrawl/` (primary authority)
2. OpenAPI spec at `api-reference/v2-openapi.json` (HTTP contract confirmation)
3. Existing docs used only as secondary reference

## Test plan

- [ ] Verify each `.mdx` file renders correctly in Mintlify
- [ ] Confirm navigation group appears in sidebar under "Get Started"
- [ ] Spot-check parameter tables against SDK source for accuracy
- [ ] Verify code examples are syntactically correct

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KQbRkbaQpspDht18232eu

---
_Generated by [Claude Code](https://claude.ai/code/session_015KQbRkbaQpspDht18232eu)_