### PR TITLE
Update agent source-of-truth docs for all SDKs to latest versions

### DIFF
--- a/agent-source-of-truth/curl.mdx
+++ b/agent-source-of-truth/curl.mdx
@@ -1,14 +1,19 @@
 ---
 title: "Curl Source of Truth"
-description: "Canonical Firecrawl curl source of truth for agents using key endpoints like search, scrape, and interact."
+description: "Canonical Firecrawl curl reference for agents covering search, scrape, interact, ask, and docs-search endpoints."
 ---
 
 Canonical Firecrawl curl source of truth for agents. Aligned with `api-reference/v2-openapi.json` (server base URL `https://api.firecrawl.dev/v2`).
 
 ## Authenticate
 
+Every request requires a Bearer token in the `Authorization` header.
+
 ```bash
-export FIRECRAWL_API_KEY="fc-your-api-key"
+curl -X POST https://api.firecrawl.dev/v2/scrape \
+  -H "Authorization: Bearer fc-YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '...'
 ```
 
 ## When To Use What
@@ -33,7 +38,7 @@ Use search to discover relevant pages from a query, then pick URLs to scrape or 
 
 ```bash
 curl -X POST "https://api.firecrawl.dev/v2/search" \
-  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
+  -H "Authorization: Bearer fc-YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "query": "site:docs.firecrawl.dev webhook retries"
@@ -44,16 +49,19 @@ curl -X POST "https://api.firecrawl.dev/v2/search" \
 
 ```bash
 curl -X POST "https://api.firecrawl.dev/v2/search" \
-  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
+  -H "Authorization: Bearer fc-YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "query": "site:docs.firecrawl.dev crawl webhooks",
     "sources": [{"type": "web"}, {"type": "news"}],
     "categories": [{"type": "research"}],
     "limit": 10,
+    "includeDomains": ["docs.firecrawl.dev"],
     "tbs": "qdr:m",
     "location": "San Francisco,California,United States",
     "country": "US",
+    "safe": true,
+    "highlights": true,
     "ignoreInvalidURLs": true,
     "timeout": 60000,
     "enterprise": ["anon"],
@@ -73,12 +81,24 @@ curl -X POST "https://api.firecrawl.dev/v2/search" \
 
 ### Response
 
-Successful responses include `success`, `data`, optional `warning`, `id`, and `creditsUsed`.
+```json
+{
+  "success": true,
+  "data": {
+    "web": [{ "title": "...", "description": "...", "url": "...", "markdown": "...", "metadata": { "title": "...", "sourceURL": "...", "statusCode": 200 } }],
+    "news": [{ "title": "...", "snippet": "...", "url": "...", "date": "...", "imageUrl": "...", "position": 1 }],
+    "images": [{ "title": "...", "imageUrl": "...", "url": "...", "imageWidth": 800, "imageHeight": 600, "position": 1 }]
+  },
+  "warning": null,
+  "id": "search-job-id",
+  "creditsUsed": 1
+}
+```
 
 - `data.web`, `data.images`, `data.news`: result arrays; which keys appear depends on `sources` (by default only `data.web` is populated).
 - Web and news items include fields such as `title`, `url`, and (when `scrapeOptions` / formats request it) `markdown`, `html`, `rawHtml`, `links`, `screenshot`, `audio`, `video`, and `metadata`.
-- Image items include fields such as `imageUrl`, `url`, and dimensions when available.
-- `warning`: optional human-readable notice.
+- Image items include `title`, `imageUrl`, `url`, `imageWidth`, `imageHeight`, and `position`.
+- `warning`: optional human-readable notice (nullable).
 - `id`: search job id string.
 - `creditsUsed`: integer credits charged for the call.
 
@@ -89,8 +109,12 @@ Successful responses include `success`, `data`, optional `warning`, `id`, and `c
   - Use when: you need a search query.
   - Notes: use `site:example.com` to limit results to a domain.
 
+- `limit`
+  - Type: integer (minimum 1, maximum 100, default 10)
+  - Use when: you want to cap results per source type.
+
 - `sources`
-  - Type: array of typed source objects
+  - Type: array of typed source objects (default `[{"type": "web"}]`)
   - Use when: you want to control which sources are searched.
   - Confirmed object shapes:
     - `{ "type": "web" }` with optional per-source `tbs` and `location`
@@ -98,47 +122,66 @@ Successful responses include `success`, `data`, optional `warning`, `id`, and `c
     - `{ "type": "images" }`
 
 - `categories`
-  - Type: array of typed category objects
+  - Type: array of typed category objects (default `[]`)
   - Use when: you want to filter results by category.
   - Confirmed object shapes:
     - `{ "type": "developer" }`
     - `{ "type": "research" }`
     - `{ "type": "pdf" }`
 
-- `limit`
-  - Type: integer (minimum 1, maximum 100, default 5)
-  - Use when: you want to cap results.
+- `includeDomains`
+  - Type: array of strings (hostnames, no protocol or path)
+  - Use when: you want to restrict results to specific domains.
+  - Notes: cannot be used with `excludeDomains`.
+
+- `excludeDomains`
+  - Type: array of strings (hostnames, no protocol or path)
+  - Use when: you want to exclude results from specific domains.
+  - Notes: cannot be used with `includeDomains`.
 
 - `tbs`
   - Type: string
-  - Use when: you need a time-based filter (for example `qdr:d`, `qdr:w`, `sbd:1,qdr:m`).
+  - Use when: you need a time-based filter.
+  - Values: `qdr:h` (hour), `qdr:d` (day), `qdr:w` (week), `qdr:m` (month), `qdr:y` (year), `cdr:1,cd_min:MM/DD/YYYY,cd_max:MM/DD/YYYY` (custom range), `sbd:1` (sort by date). Combinable, e.g. `sbd:1,qdr:w`.
 
 - `location`
   - Type: string
-  - Use when: you want localized results.
+  - Use when: you want localized results (e.g. `"San Francisco,California,United States"`).
 
 - `country`
   - Type: string (default `"US"`)
-  - Use when: you want ISO 3166-1 alpha-2 targeting (for example `"US"`).
+  - Use when: you want ISO 3166-1 alpha-2 geo-targeting (e.g. `"US"`, `"DE"`).
 
-- `ignoreInvalidURLs`
-  - Type: boolean (default false)
-  - Use when: you want to drop URLs that cannot be scraped by other endpoints.
+- `safe`
+  - Type: boolean
+  - Use when: you want to filter explicit content (SafeSearch). Omit for default (no filter).
 
 - `timeout`
   - Type: integer (milliseconds, default 60000)
-  - Use when: you need a request timeout in milliseconds.
+  - Use when: you need a request timeout.
+
+- `ignoreInvalidURLs`
+  - Type: boolean (default false)
+  - Use when: you want to drop URLs that cannot be scraped by other Firecrawl endpoints.
+
+- `highlights`
+  - Type: boolean (default true)
+  - Use when: you want query-relevant highlights in results. Set false for provider descriptions/snippets without highlighting.
 
 - `enterprise`
-  - Type: array of strings (`"anon"` or `"zdr"` per item)
-  - Use when: you need enterprise search controls.
+  - Type: array of strings (`"anon"` or `"zdr"`)
+  - Use when: you need enterprise zero-data-retention search.
   - Values:
-    - `"zdr"`: end-to-end zero data retention
-    - `"anon"`: anonymized zero data retention
+    - `"zdr"`: end-to-end zero data retention (10 credits / 10 results)
+    - `"anon"`: anonymized zero data retention (2 credits / 10 results)
 
 - `scrapeOptions`
+  - Type: object (full ScrapeOptions, default `{}`)
+  - Use when: you want to scrape each search result (see Scrape parameters for all fields).
+
+- `threatProtection`
   - Type: object
-  - Use when: you want to scrape each search result (see Scrape parameters for fields).
+  - Use when: you need a per-request threat-protection override (enterprise). See `threatProtection` under Scrape parameters.
 
 ## Scrape
 
@@ -154,7 +197,7 @@ Use scrape when you already have a URL and want structured content in one or mor
 
 ```bash
 curl -X POST "https://api.firecrawl.dev/v2/scrape" \
-  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
+  -H "Authorization: Bearer fc-YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "url": "https://docs.firecrawl.dev",
@@ -166,21 +209,29 @@ curl -X POST "https://api.firecrawl.dev/v2/scrape" \
 
 ```bash
 curl -X POST "https://api.firecrawl.dev/v2/scrape" \
-  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
+  -H "Authorization: Bearer fc-YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "url": "https://example.com/pricing",
     "formats": [
       "markdown",
       "links",
-      {"type": "json", "prompt": "Extract plan names and prices."},
+      {"type": "json", "prompt": "Extract plan names and prices.", "checkPromptInjection": true},
       {"type": "screenshot", "fullPage": true, "quality": 80, "viewport": {"width": 1280, "height": 720}},
-      {"type": "changeTracking", "modes": ["git-diff"], "tag": "pricing"}
+      {"type": "changeTracking", "modes": ["git-diff"], "tag": "pricing"},
+      {"type": "question", "question": "What is the enterprise price?"},
+      {"type": "highlights", "query": "pricing plans"}
     ],
     "headers": {"User-Agent": "FirecrawlDocsBot/1.0"},
     "onlyMainContent": true,
+    "onlyCleanContent": false,
+    "includeTags": ["main", "article"],
+    "excludeTags": ["nav", "footer"],
     "waitFor": 1000,
-    "parsers": [{"type": "pdf", "mode": "auto", "maxPages": 5}],
+    "mobile": false,
+    "skipTlsVerification": true,
+    "timeout": 60000,
+    "parsers": [{"type": "pdf", "mode": "auto", "maxPages": 5, "pages": true, "blocks": false, "pageMarkers": false}],
     "actions": [
       {"type": "click", "selector": "#accept"},
       {"type": "wait", "milliseconds": 750},
@@ -193,52 +244,78 @@ curl -X POST "https://api.firecrawl.dev/v2/scrape" \
     "maxAge": 86400000,
     "minAge": 1,
     "storeInCache": true,
+    "lockdown": false,
+    "redactPII": {"mode": "accurate", "entities": ["PERSON", "EMAIL"], "replaceStyle": "tag"},
     "profile": {"name": "docs-session", "saveChanges": true},
+    "threatProtection": {"mode": "normal", "riskScoreThreshold": 75, "failurePolicy": "open"},
+    "auditMetadata": {"username": "agent@example.com"},
     "zeroDataRetention": false
   }'
 ```
 
 ### Response
 
-Successful responses include `success` and `data`. Common `data` fields (depending on `formats` and options):
+```json
+{
+  "success": true,
+  "data": {
+    "markdown": "...",
+    "html": "...",
+    "links": [],
+    "metadata": {
+      "title": "...",
+      "sourceURL": "...",
+      "url": "...",
+      "statusCode": 200,
+      "error": null
+    },
+    "warning": null
+  }
+}
+```
 
-- `markdown`, `summary`, `html`, `rawHtml`, `screenshot`, `audio`, `video`, `links`
-- `actions`: when the request included scrape-time `actions`, contains ordered results such as `screenshots`, `scrapes`, `javascriptReturns`, and `pdfs`
-- `metadata`: page metadata (`title`, `sourceURL`, `url`, `statusCode`, `error`, and other extracted fields)
-- `warning`: optional extraction or formatting notice
-- `changeTracking`: present when the `changeTracking` format is requested
+- `markdown`, `summary`, `html`, `rawHtml`, `screenshot`, `audio`, `video`, `links`: present based on requested `formats`.
+- `actions`: when the request included scrape-time `actions`, contains ordered results such as `screenshots`, `scrapes`, `javascriptReturns`, and `pdfs`.
+- `metadata`: page metadata (`title`, `sourceURL`, `url`, `statusCode`, `error`, and other extracted fields).
+- `warning`: optional extraction or formatting notice.
+- `changeTracking`: present when the `changeTracking` format is requested.
 
 ### Parameters
 
 - `url`
-  - Type: string
+  - Type: string (URI format, required)
   - Use when: you want to scrape a specific page.
 
 - `formats`
-  - Type: array of format strings or format objects
-  - Use when: you want multiple output formats.
-  - Confirmed format strings:
+  - Type: array of format strings or format objects (default `["markdown"]`)
+  - Use when: you want one or more output formats.
+  - Format types:
     - `"markdown"`: markdown content
     - `"html"`: cleaned HTML
     - `"rawHtml"`: raw HTML
+    - `"rawBase64"`: raw base64-encoded file content
     - `"links"`: page links
     - `"images"`: image URLs
-    - `"screenshot"`: screenshot output
+    - `"screenshot"`: screenshot output. Object options: `fullPage` (boolean, default false), `quality` (integer 1-100), `viewport` (object with `width` and `height`)
     - `"summary"`: summary output
-    - `"changeTracking"`: change tracking output
-    - `"json"`: JSON extraction
+    - `"json"`: LLM-based JSON extraction. Object options: `schema` (JSON Schema object), `prompt` (string), `checkPromptInjection` (boolean, default false, +4 credits)
+    - `"changeTracking"`: change tracking. Object options: `modes` (array of `"git-diff"` | `"json"`), `schema` (object), `prompt` (string), `tag` (string, nullable)
     - `"branding"`: branding profile output
-    - `"audio"`: audio extraction
-    - `"video"`: video extraction
-  - Format object fields:
-    - `type`: one of the format strings above
-    - `prompt`, `schema`: JSON extraction options for `type: "json"`
-    - `modes`, `schema`, `prompt`, `tag`: change tracking options for `type: "changeTracking"`
-    - `fullPage`, `quality`, `viewport`: screenshot options for `type: "screenshot"`
+    - `"product"`: product data output
+    - `"menu"`: menu data output
+    - `"audio"`: audio extraction (MP3 from video URLs like YouTube, returns signed URL)
+    - `"video"`: video extraction (returns signed URL)
+    - `"question"`: ask a question about the page. Requires `question` (string, max 10000 chars)
+    - `"highlights"`: find relevant source text. Requires `query` (string, max 10000 chars)
+  - String shorthand: `"markdown"` is equivalent to `{"type": "markdown"}`.
 
-- `headers`
-  - Type: object
-  - Use when: you need custom request headers.
+- `onlyMainContent`
+  - Type: boolean (default true)
+  - Use when: you want to strip nav, footer, and other boilerplate. Deterministic HTML-level filter, no LLM involved.
+
+- `onlyCleanContent`
+  - Type: boolean (default false)
+  - Use when: you want an additional LLM-based pass to remove residual boilerplate (cookie banners, ad blocks, social widgets, breadcrumbs, newsletter signups, comment sections, related-article lists). Can be combined with `onlyMainContent`. Not supported on zero-data-retention requests.
 
 - `includeTags`
   - Type: array of strings
@@ -248,81 +325,114 @@ Successful responses include `success` and `data`. Common `data` fields (dependi
   - Type: array of strings
   - Use when: you want to exclude specific HTML tags.
 
-- `onlyMainContent`
-  - Type: boolean
-  - Use when: you want to strip nav, footer, and other boilerplate.
+- `maxAge`
+  - Type: integer (milliseconds, default 172800000 = 2 days)
+  - Use when: you want cached data up to a maximum age. Enables up to 500% speed improvement.
 
-- `timeout`
-  - Type: number
-  - Use when: you need a timeout in milliseconds.
+- `minAge`
+  - Type: integer (milliseconds)
+  - Use when: you want cache-only lookup without triggering a fresh scrape. Set to `1` to accept any cached data regardless of age. Returns 404 with `SCRAPE_NO_CACHED_DATA` on cache miss.
+
+- `headers`
+  - Type: object
+  - Use when: you need custom HTTP headers (cookies, user-agent, etc.).
 
 - `waitFor`
-  - Type: number
-  - Use when: you need to wait for the page to render (milliseconds).
+  - Type: integer (milliseconds, default 0)
+  - Use when: you need extra delay for page rendering (in addition to Firecrawl's smart wait).
 
 - `mobile`
-  - Type: boolean
-  - Use when: you want a mobile viewport.
+  - Type: boolean (default false)
+  - Use when: you want a mobile viewport. Useful for responsive pages and mobile screenshots.
+
+- `skipTlsVerification`
+  - Type: boolean (default true)
+  - Use when: you need to skip TLS certificate verification.
+
+- `timeout`
+  - Type: integer (milliseconds, default 60000, minimum 1000, maximum 300000)
+  - Use when: you need a request timeout.
 
 - `parsers`
-  - Type: array of objects
+  - Type: array of objects (default `[{"type": "pdf"}]`)
   - Use when: you need file parsing controls.
-  - Confirmed shape: `{ "type": "pdf", "mode": "fast" | "auto" | "ocr", "maxPages": number }` (`type` required; other fields optional with defaults per spec)
+  - PDF parser shape: `{ "type": "pdf", "mode": "fast" | "auto" | "ocr", "maxPages": integer (1-10000), "pages": boolean, "blocks": boolean, "pageMarkers": boolean }`
+    - `mode` (default `"auto"`): `"fast"` text-only, `"auto"` text-first with OCR fallback, `"ocr"` forces OCR on every page.
+    - `maxPages`: cap pages parsed (1 credit per page).
+    - `pages` (default false): include per-page markdown array.
+    - `blocks` (default false): include per-page typed layout blocks with bounding boxes.
+    - `pageMarkers` (default false): insert `<!-- page N -->` markers between pages in the markdown.
+  - Pass an empty array `[]` to return the raw PDF as base64 at a flat 1-credit rate.
 
 - `actions`
   - Type: array of action objects
-  - Use when: you need lightweight pre-scrape actions.
-  - Confirmed action types:
-    - `wait`: `milliseconds` or `selector` required
-    - `screenshot`: `fullPage`, `quality`, `viewport` optional
-    - `click`: `selector` required, `all` optional
-    - `write`: `text` required (click to focus the input first)
-    - `press`: `key` required
-    - `scroll`: `type` required; `direction` (`up` or `down`, default `down`); optional `selector`
-    - `scrape`: no additional fields
-    - `executeJavascript`: `script` required
-    - `pdf`: `format` (A0, A1, A2, A3, A4, A5, A6, Letter, Legal, Tabloid, Ledger), `landscape`, `scale` optional
+  - Use when: you need lightweight pre-scrape browser actions.
+  - Action types:
+    - `wait`: either `milliseconds` (integer, min 1) or `selector` (CSS selector string) required.
+    - `screenshot`: optional `fullPage` (boolean), `quality` (integer 1-100), `viewport` (object with `width`, `height`).
+    - `click`: `selector` required (CSS selector), `all` optional (boolean, default false, clicks all matches).
+    - `write`: `text` required (click to focus the input first).
+    - `press`: `key` required (e.g. `"Enter"`).
+    - `scroll`: `direction` (`"up"` or `"down"`, default `"down"`), optional `selector`.
+    - `scrape`: no additional fields, scrapes current page content.
+    - `executeJavascript`: `script` required (JavaScript string).
+    - `pdf`: optional `format` (A0-A6, Letter, Legal, Tabloid, Ledger; default Letter), `landscape` (boolean, default false), `scale` (number, default 1).
 
 - `location`
-  - Type: object with `country` and `languages`
-  - Use when: you need geo or language-aware scraping.
-
-- `skipTlsVerification`
-  - Type: boolean
-  - Use when: you need to skip TLS verification.
+  - Type: object with `country` (string, default `"US"`) and `languages` (string array)
+  - Use when: you need geo or language-aware scraping. Uses appropriate proxy and emulates language/timezone.
 
 - `removeBase64Images`
-  - Type: boolean
-  - Use when: you want to drop base64 images from markdown output.
+  - Type: boolean (default true)
+  - Use when: you want to drop base64 images from markdown output. Alt text is preserved with a placeholder URL.
 
 - `blockAds`
-  - Type: boolean
+  - Type: boolean (default true)
   - Use when: you want ad and cookie popup blocking.
 
 - `proxy`
-  - Type: string
+  - Type: string (default `"auto"`)
   - Use when: you need proxy control.
-  - Confirmed values: `"basic"`, `"enhanced"`, `"auto"`
-
-- `maxAge`
-  - Type: number
-  - Use when: you want cached data up to a maximum age (milliseconds).
-
-- `minAge`
-  - Type: number
-  - Use when: you want cached data only if it is at least this old (milliseconds).
+  - Values: `"basic"` (fast, sites with none to basic anti-bot), `"enhanced"` (advanced anti-bot, slower but more reliable, same credit cost), `"auto"` (retries with enhanced if basic fails).
 
 - `storeInCache`
-  - Type: boolean
-  - Use when: you want Firecrawl to cache the result.
+  - Type: boolean (default true)
+  - Use when: you want Firecrawl to cache the result. Forced false for sensitive parameters like `actions` or `headers`.
+
+- `lockdown`
+  - Type: boolean (default false)
+  - Use when: you need cache-only mode for compliance/air-gapped environments. Never makes outbound requests. Returns 404 on cache miss. Treated as zero data retention. 5 credits on hit, 1 on miss.
+
+- `redactPII`
+  - Type: boolean or object (default false)
+  - Use when: you want PII redaction on returned markdown.
+  - Pass `true` for defaults, or an object:
+    - `mode`: `"accurate"` (default, model-only precision), `"aggressive"` (model + heuristics for higher recall), `"fast"` (heuristics only, no model)
+    - `entities`: array of `"PERSON"`, `"EMAIL"`, `"PHONE"`, `"LOCATION"`, `"FINANCIAL"`, `"SECRET"` (omit for all)
+    - `replaceStyle`: `"tag"` (default, e.g. `<EMAIL>`), `"mask"` (replaces with `*`), `"remove"` (deletes text)
 
 - `profile`
-  - Type: object with `name` and optional `saveChanges`
-  - Use when: you want a persistent browser profile shared across scrapes and interactions.
+  - Type: object with `name` (string, 1-128 chars, required) and optional `saveChanges` (boolean, default true)
+  - Use when: you want a persistent browser profile (cookies, localStorage, sessions) shared across scrapes and interactions.
+
+- `threatProtection`
+  - Type: object
+  - Use when: you need a per-request threat-protection override (enterprise feature).
+  - Fields:
+    - `mode`: `"off"` or `"normal"` (URL scanning via Google Web Risk, +2 credits per URL scanned)
+    - `riskScoreThreshold`: integer 0-100, score at or above which a URL is blocked (lower = stricter)
+    - `blacklist`: array of domains to always block (plain domains or wildcard globs, max 1000)
+    - `whitelist`: array of domains to always allow (wins over all other rules, max 1000)
+    - `blockedTlds`: array of TLDs to block (lowercase, no leading dot, e.g. `"zip"`, max 1000)
+    - `failurePolicy`: `"open"` (allow on classifier failure) or `"closed"` (block on failure)
+
+- `auditMetadata`
+  - Type: object with `username` (string, max 1024 chars, required)
+  - Use when: you need SIEM-logging user attribution (enterprise feature).
 
 - `zeroDataRetention`
-  - Type: boolean
-  - Use when: you want zero data retention for this scrape.
+  - Type: boolean (default false)
+  - Use when: you want zero data retention for this scrape. Contact help@firecrawl.dev to enable.
 
 ## Interact
 
@@ -338,7 +448,7 @@ Use interact when a page requires browser actions or code execution after a scra
 
 ```bash
 curl -X POST "https://api.firecrawl.dev/v2/scrape/<jobId>/interact" \
-  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
+  -H "Authorization: Bearer fc-YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "code": "console.log(await page.title());"
@@ -349,48 +459,76 @@ curl -X POST "https://api.firecrawl.dev/v2/scrape/<jobId>/interact" \
 
 ```bash
 curl -X POST "https://api.firecrawl.dev/v2/scrape/<jobId>/interact" \
-  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
+  -H "Authorization: Bearer fc-YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "code": "const title = await page.title();\nconst h1 = await page.locator(\"h1\").first().textContent().catch(() => null);\nconsole.log(JSON.stringify({ title, h1 }));",
     "language": "node",
-    "timeout": 120
+    "timeout": 120,
+    "origin": "my-agent"
   }'
 ```
+
+### Response
+
+```json
+{
+  "success": true,
+  "cdpUrl": null,
+  "liveViewUrl": "...",
+  "interactiveLiveViewUrl": "...",
+  "stdout": "...",
+  "result": "...",
+  "stderr": null,
+  "exitCode": 0,
+  "killed": false,
+  "error": null
+}
+```
+
+- `cdpUrl`: raw Chrome DevTools Protocol WebSocket URL for direct Playwright/Puppeteer/CDP connections (nullable).
+- `liveViewUrl`: read-only live view URL for the browser session (nullable).
+- `interactiveLiveViewUrl`: interactive live view URL where viewers can control the browser (nullable).
+- `stdout`: standard output from code execution (nullable).
+- `result`: alias for `stdout` (nullable).
+- `stderr`: standard error output (nullable).
+- `exitCode`: exit code of the executed process (nullable).
+- `killed`: whether the process was killed due to timeout.
+- `error`: error message if the code raised an exception (nullable).
 
 ### Parameters
 
 - `jobId` (path)
-  - Type: string (UUID)
+  - Type: string (UUID, required)
   - Use when: you have the scrape job id for the live browser session.
 
 - `code` (JSON body)
-  - Type: string (required in OpenAPI; min length 1, max length 100000)
+  - Type: string (required, min length 1, max length 100000)
   - Use when: you want to run code in the scrape-bound browser sandbox.
 
 - `language` (JSON body)
-  - Type: string
+  - Type: string (default `"node"`)
   - Use when: you need a specific runtime.
-  - Confirmed values: `"python"`, `"node"`, `"bash"` (default `"node"`)
+  - Values: `"python"`, `"node"`, `"bash"`
 
 - `timeout` (JSON body)
-  - Type: integer (seconds; minimum 1, maximum 300, default 30)
+  - Type: integer (seconds, minimum 1, maximum 300, default 30)
   - Use when: you need an execution timeout.
 
-### Response
+- `origin` (JSON body)
+  - Type: string
+  - Use when: you want a telemetry label for execution tracking.
 
-Successful responses include `success` plus execution fields such as `stdout`, `result` (alias of stdout), `stderr`, `exitCode`, `killed`, and `error` (nullable).
+### Stop session
 
-### DELETE /scrape/{jobId}/interact
-
-### Example
+`DELETE /scrape/{jobId}/interact`
 
 ```bash
 curl -X DELETE "https://api.firecrawl.dev/v2/scrape/<jobId>/interact" \
-  -H "Authorization: Bearer $FIRECRAWL_API_KEY"
+  -H "Authorization: Bearer fc-YOUR_API_KEY"
 ```
 
-No JSON body. A successful response includes `success`.
+No JSON body. Response: `{ "success": true }`.
 
 ## Ask (Agentic Debugging)
 
@@ -398,44 +536,18 @@ No JSON body. A successful response includes `success`.
 
 Use ask when a Firecrawl API call fails or returns unexpected results. The AI support agent diagnoses the issue, proposes fix parameters, and optionally validates the fix against the live API. Typical latency: 15-30 seconds.
 
-### Endpoint
-
-`POST /support/ask`
-
 ### Simple Example
 
 ```bash
 curl -X POST "https://api.firecrawl.dev/v2/support/ask" \
-  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
+  -H "Authorization: Bearer fc-YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "question": "my scrape returned empty markdown for https://example.com"
-  }'
-```
-
-### Complex Example
-
-```bash
-curl -X POST "https://api.firecrawl.dev/v2/support/ask" \
-  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "question": "crawl returned 3 pages but I expected 50",
-    "rationale": "user is on their third failed crawl attempt today",
+    "question": "my scrape returned empty markdown for https://example.com",
+    "rationale": "user is on their third failed scrape attempt today",
     "context": {"userPlan": "standard", "retryCount": 3}
   }'
 ```
-
-### Response
-
-Successful responses include `requestId`, `answer`, `confidence`, `fixParameters`, `validation`, `usage`, and `durationMs`.
-
-- `answer`: 2-4 sentence prose covering the diagnosis and fix.
-- `confidence`: `high`, `medium`, or `low`.
-- `fixParameters`: machine-actionable API parameters to apply the fix (null if no fix applies).
-- `validation.tested`: whether the agent tested the fix against the live API.
-- `validation.result`: `success`, `failure`, or `skipped`.
-- `feedback`: present when the agent gets stuck; null on success.
 
 ### Parameters
 
@@ -455,17 +567,13 @@ Successful responses include `requestId`, `answer`, `confidence`, `fixParameters
 
 ### Why use it
 
-Use docs-search to look up Firecrawl documentation.
+Use docs-search to look up Firecrawl documentation with a docs-grounded AI answer and source citations.
 
-### Endpoint
-
-`POST /support/docs-search`
-
-### Example
+### Simple Example
 
 ```bash
 curl -X POST "https://api.firecrawl.dev/v2/support/docs-search" \
-  -H "Authorization: Bearer $FIRECRAWL_API_KEY" \
+  -H "Authorization: Bearer fc-YOUR_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
     "question": "how do I verify webhook signatures?"
@@ -478,15 +586,6 @@ curl -X POST "https://api.firecrawl.dev/v2/support/docs-search" \
   - Type: string (required, 1-8000 chars)
   - Use when: you need a docs-grounded answer.
 
-## Notes
-
-- Search result rows are nested under `data.web`, `data.images`, or `data.news`, not as a flat `data` array.
-- Use `POST /scrape/{jobId}/interact` for multi-step browser workflows; scrape `actions` are best for small pre-scrape steps.
-- The published OpenAPI schema requires `code` for interact. Some SDKs and clients also accept a `prompt` field for natural-language instructions; that alias is not in `v2-openapi.json`.
-
 ## Source Of Truth
 
 - `firecrawl-docs/api-reference/v2-openapi.json`
-- `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
-- `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
-- `firecrawl/apps/rust-sdk/src/v2/scrape.rs`

--- a/agent-source-of-truth/elixir.mdx
+++ b/agent-source-of-truth/elixir.mdx
@@ -3,25 +3,29 @@ title: "Elixir Source of Truth"
 description: "Canonical Firecrawl Elixir source of truth for agents using key endpoints like search, scrape, and interact."
 ---
 
-Canonical Firecrawl Elixir source of truth for agents. Generated from SDK source and the v2 OpenAPI spec.
+Canonical Firecrawl Elixir source of truth for agents. Generated from SDK source (`:firecrawl` hex package **1.11.0**) and the v2 OpenAPI spec. Function names and parameter keys are auto-generated from the OpenAPI spec via `generate.exs`.
 
 ## Install
 
 Add to `mix.exs`:
 
 ```elixir
-{:firecrawl, "~> 1.0.0"}
+defp deps do
+  [{:firecrawl, "~> 1.11"}]
+end
 ```
 
 ## Authenticate
 
 ```elixir
-# config/runtime.exs or config.exs
-config :firecrawl, api_key: System.get_env("FIRECRAWL_API_KEY")
+# config/config.exs
+config :firecrawl, api_key: "fc-YOUR_API_KEY"
 
-# or pass api_key per call
-{:ok, res} = Firecrawl.search_and_scrape([query: "site:docs.firecrawl.dev webhook retries"], api_key: "fc-your-api-key")
+# or per-request via opts:
+Firecrawl.search_and_scrape([query: "test"], api_key: "fc-YOUR_API_KEY")
 ```
+
+The `opts` keyword list also accepts `:base_url` for self-hosted instances and any `Req` options.
 
 ## When To Use What
 
@@ -37,12 +41,20 @@ Use search to discover relevant pages from a query, then pick URLs to scrape or 
 
 ### Preferred SDK method
 
-`Firecrawl.search_and_scrape(params \\ [], opts \\ [])`
+`Firecrawl.search_and_scrape(params \\ [], opts \\ [])` → `{:ok, Req.Response.t()} | {:error, Exception.t()}`
+
+Bang variant: `Firecrawl.search_and_scrape!(params \\ [], opts \\ [])` → `Req.Response.t()`
 
 ### Simple Example
 
 ```elixir
 {:ok, res} = Firecrawl.search_and_scrape(query: "site:docs.firecrawl.dev webhook retries")
+
+# Access results from the response body
+web_results = res.body["web"] || []
+Enum.each(web_results, fn item ->
+  IO.puts("#{item["url"]} — #{item["title"]}")
+end)
 ```
 
 ### Complex Example
@@ -50,14 +62,17 @@ Use search to discover relevant pages from a query, then pick URLs to scrape or 
 ```elixir
 {:ok, res} = Firecrawl.search_and_scrape(
   query: "site:docs.firecrawl.dev crawl webhooks",
-  sources: [:web, :news],
-  categories: [:research],
+  sources: ["web", "news"],
+  categories: ["research"],
+  include_domains: ["docs.firecrawl.dev"],
+  exclude_domains: ["old.firecrawl.dev"],
   limit: 10,
   tbs: "qdr:m",
   location: "San Francisco,California,United States",
   country: "US",
   ignore_invalid_urls: true,
   timeout: 60000,
+  highlights: true,
   scrape_options: [
     formats: [
       "markdown",
@@ -72,65 +87,95 @@ Use search to discover relevant pages from a query, then pick URLs to scrape or 
 )
 ```
 
+### Return value
+
+Returns `{:ok, Req.Response.t()}`. Parse `res.body` for the JSON response. The body contains optional keys:
+
+- `"web"` — web hits (list of result maps, or full document maps when `scrape_options` hydrates content)
+- `"news"` — news hits
+- `"images"` — image hits
+
+Omitted keys are absent when the API did not return that source.
+
+**Wrong turn to avoid:** `search_and_scrape` does not return `%{"data" => [...]}`. Do not access `res.body["data"]`. Web results are in `res.body["web"]`, news in `res.body["news"]`, images in `res.body["images"]`.
+
 ### Parameters
 
 - `query`
   - Type: string
+  - Required: yes
   - Use when: you need a search query.
   - Notes: use `site:example.com` to limit results to a domain.
 
 - `sources`
-  - Type: list of atoms, strings, or maps
+  - Type: list of any (strings or maps)
+  - JSON key: `sources`
   - Use when: you want to control which sources are searched.
-  - Confirmed values:
-    - `"web"` or `:web`
-    - `"news"` or `:news`
-    - `"images"` or `:images`
-    - `%{type: "web" | "news" | "images"}`
+  - Confirmed values: `"web"`, `"news"`, `"images"`
 
 - `categories`
-  - Type: list of atoms, strings, or maps
+  - Type: list of any (strings or maps)
+  - JSON key: `categories`
   - Use when: you want to filter results by category.
-  - Confirmed values:
-    - `"developer"` or `:developer`
-    - `"research"` or `:research`
-    - `"pdf"` or `:pdf`
-    - `%{type: "developer" | "research" | "pdf"}`
+  - Confirmed values: `"developer"`, `"research"`, `"pdf"`
+
+- `include_domains`
+  - Type: list of strings
+  - JSON key: `includeDomains`
+  - Use when: you want to restrict results to specific domains.
+
+- `exclude_domains`
+  - Type: list of strings
+  - JSON key: `excludeDomains`
+  - Use when: you want to exclude results from specific domains.
 
 - `limit`
   - Type: integer
+  - JSON key: `limit`
   - Use when: you want to cap results.
 
 - `tbs`
   - Type: string
+  - JSON key: `tbs`
   - Use when: you need a time-based filter (for example `qdr:d`, `qdr:w`, `sbd:1,qdr:m`).
 
 - `location`
   - Type: string
+  - JSON key: `location`
   - Use when: you want localized results.
 
 - `country`
   - Type: string
+  - JSON key: `country`
   - Use when: you want ISO 3166-1 alpha-2 targeting (for example `"US"`).
 
 - `ignore_invalid_urls`
   - Type: boolean
+  - JSON key: `ignoreInvalidURLs`
   - Use when: you want to drop URLs that cannot be scraped by other endpoints.
 
 - `timeout`
   - Type: integer
+  - JSON key: `timeout`
   - Use when: you need a request timeout in milliseconds.
+
+- `highlights`
+  - Type: boolean
+  - JSON key: `highlights`
+  - Use when: you want highlighted snippets in results. API default is `true`.
+
+- `scrape_options`
+  - Type: keyword list
+  - JSON key: `scrapeOptions`
+  - Use when: you want to scrape each search result (see Scrape parameters for fields).
 
 - `enterprise`
   - Type: list of strings
+  - JSON key: `enterprise`
   - Use when: you need enterprise search controls.
   - Confirmed values:
     - `"zdr"`: end-to-end zero data retention
     - `"anon"`: anonymized zero data retention
-
-- `scrape_options`
-  - Type: keyword list
-  - Use when: you want to scrape each search result (see Scrape parameters for fields).
 
 ## Scrape
 
@@ -140,7 +185,9 @@ Use scrape when you already have a URL and want structured content in one or mor
 
 ### Preferred SDK method
 
-`Firecrawl.scrape_and_extract_from_url(params \\ [], opts \\ [])`
+`Firecrawl.scrape_and_extract_from_url(params \\ [], opts \\ [])` → `{:ok, Req.Response.t()} | {:error, Exception.t()}`
+
+Bang variant: `Firecrawl.scrape_and_extract_from_url!(params \\ [], opts \\ [])` → `Req.Response.t()`
 
 ### Simple Example
 
@@ -149,6 +196,8 @@ Use scrape when you already have a URL and want structured content in one or mor
   url: "https://docs.firecrawl.dev",
   formats: ["markdown"]
 )
+
+markdown = res.body["data"]["markdown"]
 ```
 
 ### Complex Example
@@ -164,8 +213,12 @@ Use scrape when you already have a URL and want structured content in one or mor
     %{type: "changeTracking", modes: ["git-diff"], tag: "pricing"}
   ],
   headers: %{"User-Agent" => "FirecrawlDocsBot/1.0"},
+  include_tags: ["main", "article"],
+  exclude_tags: ["nav", "footer"],
   only_main_content: true,
+  timeout: 30000,
   wait_for: 1000,
+  mobile: false,
   parsers: [%{type: "pdf", mode: "auto", maxPages: 5}],
   actions: [
     %{type: "click", selector: "#accept"},
@@ -173,12 +226,16 @@ Use scrape when you already have a URL and want structured content in one or mor
     %{type: "scrape"}
   ],
   location: [country: "US", languages: ["en-US"]],
+  skip_tls_verification: false,
   remove_base64_images: true,
   block_ads: true,
   proxy: :auto,
   max_age: 86400000,
   min_age: 1,
   store_in_cache: true,
+  lockdown: false,
+  redact_pii: false,
+  audit_metadata: [username: "agent@example.com"],
   profile: [name: "docs-session", save_changes: true],
   zero_data_retention: false
 )
@@ -188,10 +245,12 @@ Use scrape when you already have a URL and want structured content in one or mor
 
 - `url`
   - Type: string
+  - Required: yes
   - Use when: you want to scrape a specific page.
 
 - `formats`
-  - Type: list of format strings or format maps
+  - Type: list of any (format strings or format maps)
+  - JSON key: `formats`
   - Use when: you want multiple output formats.
   - Confirmed format strings:
     - `"markdown"`: markdown content
@@ -213,42 +272,51 @@ Use scrape when you already have a URL and want structured content in one or mor
     - `fullPage`, `quality`, `viewport`: screenshot options for `type: "screenshot"`
 
 - `headers`
-  - Type: map
+  - Type: any (map)
+  - JSON key: `headers`
   - Use when: you need custom request headers.
 
 - `include_tags`
   - Type: list of strings
+  - JSON key: `includeTags`
   - Use when: you want to include only specific HTML tags.
 
 - `exclude_tags`
   - Type: list of strings
+  - JSON key: `excludeTags`
   - Use when: you want to exclude specific HTML tags.
 
 - `only_main_content`
   - Type: boolean
+  - JSON key: `onlyMainContent`
   - Use when: you want to strip nav, footer, and other boilerplate.
 
 - `timeout`
   - Type: integer
+  - JSON key: `timeout`
   - Use when: you need a timeout in milliseconds.
 
 - `wait_for`
   - Type: integer
+  - JSON key: `waitFor`
   - Use when: you need to wait for the page to render (milliseconds).
 
 - `mobile`
   - Type: boolean
+  - JSON key: `mobile`
   - Use when: you want a mobile viewport.
 
 - `parsers`
-  - Type: list of parser strings or maps
+  - Type: list of any (parser strings or maps)
+  - JSON key: `parsers`
   - Use when: you need file parsing controls.
   - Confirmed values:
     - `"pdf"`
     - `%{type: "pdf", mode: "fast" | "auto" | "ocr", maxPages: integer}`
 
 - `actions`
-  - Type: list of action maps
+  - Type: list of any (action maps)
+  - JSON key: `actions`
   - Use when: you need lightweight pre-scrape actions.
   - Confirmed action types:
     - `wait`: `milliseconds` or `selector` required
@@ -263,43 +331,70 @@ Use scrape when you already have a URL and want structured content in one or mor
 
 - `location`
   - Type: keyword list (for example `country:` and `languages:`)
+  - JSON key: `location`
   - Use when: you need geo or language-aware scraping.
 
 - `skip_tls_verification`
   - Type: boolean
+  - JSON key: `skipTlsVerification`
   - Use when: you need to skip TLS verification.
 
 - `remove_base64_images`
   - Type: boolean
+  - JSON key: `removeBase64Images`
   - Use when: you want to drop base64 images from markdown output.
 
 - `block_ads`
   - Type: boolean
+  - JSON key: `blockAds`
   - Use when: you want ad and cookie popup blocking.
 
 - `proxy`
-  - Type: atom or string
+  - Type: atom
+  - JSON key: `proxy`
   - Use when: you need proxy control.
   - Confirmed values: `:basic`, `:enhanced`, `:auto`
+  - Notes: `:stealth` is NOT in the Elixir SDK's NimbleOptions validation.
 
 - `max_age`
   - Type: integer
+  - JSON key: `maxAge`
   - Use when: you want cached data up to a maximum age (milliseconds).
 
 - `min_age`
   - Type: integer
+  - JSON key: `minAge`
   - Use when: you want cached data only if it is at least this old (milliseconds).
 
 - `store_in_cache`
   - Type: boolean
+  - JSON key: `storeInCache`
   - Use when: you want Firecrawl to cache the result.
 
+- `lockdown`
+  - Type: boolean
+  - JSON key: `lockdown`
+  - Use when: you want to enable lockdown mode for the scrape.
+
+- `redact_pii`
+  - Type: boolean
+  - JSON key: `redactPII`
+  - Use when: you want to redact personally identifiable information from the output.
+
+- `audit_metadata`
+  - Type: keyword list (keys: `username` string, required)
+  - JSON key: `auditMetadata`
+  - Use when: you need to attach audit metadata to the scrape.
+
 - `profile`
-  - Type: keyword list with `name:` and optional `save_changes:` (or `saveChanges:`)
+  - Type: keyword list
+  - JSON key: `profile`
   - Use when: you want a persistent browser profile shared across scrapes and interactions.
+  - Keys: `name` (string), `save_changes` (boolean)
 
 - `zero_data_retention`
   - Type: boolean
+  - JSON key: `zeroDataRetention`
   - Use when: you want zero data retention for this scrape.
 
 ## Interact
@@ -310,17 +405,31 @@ Use interact when a page requires browser actions or code execution after a scra
 
 ### Preferred SDK method
 
-`Firecrawl.interact_with_scrape_browser_session(job_id, params \\ [], opts \\ [])`
+`Firecrawl.interact_with_scrape_browser_session(job_id, params \\ [], opts \\ [])` → `{:ok, Req.Response.t()} | {:error, Exception.t()}`
+
+Bang variant: `Firecrawl.interact_with_scrape_browser_session!(job_id, params, opts)` → `Req.Response.t()`
+
+**Important:** The Elixir SDK interact is code-only based on the NimbleOptions schema. There is no `prompt` parameter — use `code` with a browser automation script instead.
 
 ### Simple Example
 
 ```elixir
+# First scrape to get a job ID
+{:ok, scrape_res} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown"]
+)
+job_id = scrape_res.body["data"]["metadata"]["scrapeId"]
+
+# Then interact with the browser session
 {:ok, res} = Firecrawl.interact_with_scrape_browser_session(
-  "<scrapeJobId>",
+  job_id,
   code: "console.log(await page.title());",
   language: :node,
   timeout: 60
 )
+
+IO.inspect(res.body)
 ```
 
 ### Complex Example
@@ -328,7 +437,17 @@ Use interact when a page requires browser actions or code execution after a scra
 ```elixir
 {:ok, res} = Firecrawl.interact_with_scrape_browser_session(
   "<scrapeJobId>",
-  code: "// Use Playwright page methods here",
+  code: """
+  await page.click('#pricing-tab');
+  await page.waitForSelector('.plan-card');
+  const plans = await page.$$eval('.plan-card', cards =>
+    cards.map(c => ({
+      name: c.querySelector('h3')?.textContent,
+      price: c.querySelector('.price')?.textContent
+    }))
+  );
+  console.log(JSON.stringify(plans));
+  """,
   language: :node,
   timeout: 120
 )
@@ -337,29 +456,50 @@ Use interact when a page requires browser actions or code execution after a scra
 ### Parameters
 
 - `job_id`
-  - Type: string
-  - Use when: you have a scrape job ID.
+  - Type: String.t()
+  - Required: yes (first argument, path parameter)
+  - Use when: you have a scrape job ID from the scrape response metadata.
 
 - `code`
   - Type: string
+  - Required: yes
   - Use when: you want to run code in the browser session.
 
 - `language`
-  - Type: atom or string
+  - Type: atom
+  - JSON key: `language`
   - Use when: you need a specific runtime.
-  - Confirmed values: `:python`, `:node`, `:bash` (or the string equivalents)
+  - Confirmed values: `:python`, `:node`, `:bash`
 
 - `timeout`
   - Type: integer
+  - JSON key: `timeout`
   - Use when: you need an execution timeout in seconds.
 
 - `origin`
   - Type: string
+  - JSON key: `origin`
   - Use when: you want an optional origin label for execution telemetry.
 
-### Stop interactive session
+### Return value
 
-`Firecrawl.stop_interactive_scrape_browser_session(job_id, opts \\ [])` issues `DELETE /scrape/{jobId}/interact` and tears down the browser session for that scrape job. A bang variant `stop_interactive_scrape_browser_session!/2` is also available.
+Returns `{:ok, Req.Response.t()}`. Parse `res.body` for the JSON response. The body may contain:
+
+- `"success"` — boolean
+- `"output"` — string output from the executed code
+- `"stdout"` — standard output
+- `"stderr"` — standard error
+- `"exitCode"` — exit code of the execution
+- `"killed"` — whether the process was killed (timeout)
+- `"error"` — error message if execution failed
+- `"liveViewUrl"` — URL to view the browser session live
+- `"interactiveLiveViewUrl"` — URL to interact with the browser session live
+
+### Stop session
+
+`Firecrawl.stop_interactive_scrape_browser_session(job_id, opts \\ [])` issues `DELETE /scrape/{jobId}/interact` and tears down the browser session for that scrape job.
+
+Bang variant: `Firecrawl.stop_interactive_scrape_browser_session!(job_id, opts \\ [])` → `Req.Response.t()`
 
 ```elixir
 {:ok, res} = Firecrawl.stop_interactive_scrape_browser_session("<scrapeJobId>")
@@ -367,9 +507,15 @@ Use interact when a page requires browser actions or code execution after a scra
 
 ## Notes
 
-- The Elixir client is OpenAPI-shaped; function names and parameter keys are generated from the spec.
-- Each public function has a bang (`!`) variant that raises on error instead of returning `{:error, _}`.
-- This SDK exposes code-based interactions only (no `prompt` parameter on `interact_with_scrape_browser_session`).
+- Auto-generated from the OpenAPI spec via `generate.exs`. Do not rename functions.
+- All public functions have bang (`!`) variants that raise on error instead of returning `{:error, _}`.
+- Params are validated at call time via NimbleOptions.
+- Snake_case Elixir keys are mapped to camelCase JSON keys automatically.
+- SDK version is embedded at compile time and sent as `origin` in every request.
+- Returns raw `Req.Response.t()` — parse `.body` for the JSON response.
+- `:stealth` proxy is NOT in the Elixir SDK's NimbleOptions validation (only `:basic`, `:enhanced`, `:auto`).
+- No `fast_mode` parameter in the Elixir SDK.
+- No `prompt` parameter on `interact_with_scrape_browser_session` — the Elixir SDK is code-only for interact.
 
 ## Source Of Truth
 

--- a/agent-source-of-truth/java.mdx
+++ b/agent-source-of-truth/java.mdx
@@ -3,7 +3,7 @@ title: "Java Source of Truth"
 description: "Canonical Firecrawl Java source of truth for agents using key endpoints like search, scrape, and interact."
 ---
 
-Canonical Firecrawl Java source of truth for agents. Generated from SDK source and the v2 OpenAPI spec.
+Canonical Firecrawl Java source of truth for agents. Generated from SDK source (`com.firecrawl:firecrawl-java` **1.18.0**) and the v2 OpenAPI spec. Method names, parameters, and return types match `FirecrawlClient.java` unless noted.
 
 ## Install
 
@@ -13,25 +13,41 @@ Maven:
 <dependency>
   <groupId>com.firecrawl</groupId>
   <artifactId>firecrawl-java</artifactId>
-  <version>1.2.0</version>
+  <version>1.18.0</version>
 </dependency>
 ```
 
 Gradle:
 
 ```gradle
-implementation("com.firecrawl:firecrawl-java:1.2.0")
+implementation 'com.firecrawl:firecrawl-java:1.18.0'
 ```
+
+Requires Java 11+.
 
 ## Authenticate
 
 ```java
 import com.firecrawl.client.FirecrawlClient;
 
+// Explicit API key
 FirecrawlClient client = FirecrawlClient.builder()
-    .apiKey(System.getenv("FIRECRAWL_API_KEY"))
+    .apiKey("fc-YOUR_API_KEY")
     .build();
+
+// From FIRECRAWL_API_KEY env var or firecrawl.apiKey system property
+FirecrawlClient client = FirecrawlClient.fromEnv();
 ```
+
+### Builder options
+
+- `apiKey(String)` — API key. Falls back to `FIRECRAWL_API_KEY` env var or `firecrawl.apiKey` system property. Can be null/blank for keyless free tier.
+- `apiUrl(String)` — Base URL. Default `"https://api.firecrawl.dev"`.
+- `timeoutMs(int)` — HTTP timeout in milliseconds. Default `300000`.
+- `maxRetries(int)` — Retry count. Default `3`.
+- `backoffFactor(double)` — Exponential backoff factor. Default `0.5`.
+- `asyncExecutor(Executor)` — Executor for async methods. Default `ForkJoinPool.commonPool()`.
+- `httpClient(OkHttpClient)` — Custom OkHttp client instance.
 
 ## When To Use What
 
@@ -47,14 +63,12 @@ FirecrawlClient client = FirecrawlClient.builder()
 
 Use search to discover relevant pages from a query, then pick URLs to scrape or interact with. You can constrain results to a site with `site:`, for example `site:docs.firecrawl.dev crawl webhooks`.
 
-### Preferred SDK methods
+### Preferred SDK method
 
-- `client.search(query)`
-- `client.search(query, options)`
-
-### Return value
-
-`search` returns `SearchData`. Read result buckets with `getWeb()`, `getNews()`, and `getImages()` (each is `List<Map<String, Object>>` and may be null). Do not treat `SearchData` as a directly iterable list of hits.
+- `client.search(String query)` → `SearchData`
+- `client.search(String query, SearchOptions options)` → `SearchData`
+- `client.searchAsync(String query)` → `CompletableFuture<SearchData>`
+- `client.searchAsync(String query, SearchOptions options)` → `CompletableFuture<SearchData>`
 
 ### Simple Example
 
@@ -73,16 +87,20 @@ List<Map<String, Object>> web = results.getWeb();
 import com.firecrawl.models.SearchOptions;
 import com.firecrawl.models.ScrapeOptions;
 import com.firecrawl.models.JsonFormat;
-import com.firecrawl.models.LocationConfig;
 
 SearchOptions options = SearchOptions.builder()
     .sources(List.of("web", "news"))
-    .categories(List.of("research"))
+    .categories(List.of("research", "pdf"))
+    .includeDomains(List.of("docs.firecrawl.dev", "firecrawl.dev"))
+    .excludeDomains(List.of("old.firecrawl.dev"))
     .limit(10)
     .tbs("qdr:m")
     .location("San Francisco,California,United States")
+    .country("US")
     .ignoreInvalidURLs(true)
+    .highlights(true)
     .timeout(60000)
+    .integration("my-agent")
     .scrapeOptions(
         ScrapeOptions.builder()
             .formats(List.of(
@@ -97,7 +115,14 @@ SearchOptions options = SearchOptions.builder()
     .build();
 
 SearchData results = client.search("site:docs.firecrawl.dev crawl webhooks", options);
+List<Map<String, Object>> web = results.getWeb();
+List<Map<String, Object>> news = results.getNews();
+List<Map<String, Object>> images = results.getImages();
 ```
+
+### Return value
+
+`search` returns `SearchData`. Read result buckets with `getWeb()`, `getNews()`, and `getImages()` (each is `List<Map<String, Object>>` and may be null). Do not treat `SearchData` as a directly iterable list of hits.
 
 ### Parameters
 
@@ -107,22 +132,28 @@ SearchData results = client.search("site:docs.firecrawl.dev crawl webhooks", opt
   - Notes: use `site:example.com` to limit results to a domain.
 
 - `options.sources`
-  - Type: List of source strings or maps
+  - Type: List&lt;Object&gt;
   - Use when: you want to control which sources are searched.
   - Confirmed values:
     - `"web"`: web index results
     - `"news"`: news results
     - `"images"`: image results
-    - `{type: "web" | "news" | "images"}`: typed source map form
 
 - `options.categories`
-  - Type: List of category strings or maps
+  - Type: List&lt;Object&gt;
   - Use when: you want to filter results by category.
   - Confirmed values:
-    - `"developer"`: Developer Index results
+    - `"github"`: GitHub-focused results
     - `"research"`: research and academic results
     - `"pdf"`: PDF-focused results
-    - `{type: "developer" | "research" | "pdf"}`: typed category map form
+
+- `options.includeDomains`
+  - Type: List&lt;String&gt;
+  - Use when: you want results only from specific domains.
+
+- `options.excludeDomains`
+  - Type: List&lt;String&gt;
+  - Use when: you want to exclude specific domains from results.
 
 - `options.limit`
   - Type: Integer
@@ -136,6 +167,10 @@ SearchData results = client.search("site:docs.firecrawl.dev crawl webhooks", opt
   - Type: String
   - Use when: you want localized results.
 
+- `options.country`
+  - Type: String
+  - Use when: you want country-specific results.
+
 - `options.ignoreInvalidURLs`
   - Type: Boolean
   - Use when: you want to drop URLs that cannot be scraped by other endpoints.
@@ -143,6 +178,11 @@ SearchData results = client.search("site:docs.firecrawl.dev crawl webhooks", opt
 - `options.timeout`
   - Type: Integer
   - Use when: you need a request timeout in milliseconds.
+
+- `options.highlights`
+  - Type: Boolean
+  - Use when: you want highlighted snippets in results.
+  - Notes: default `true` server-side.
 
 - `options.scrapeOptions`
   - Type: `ScrapeOptions`
@@ -158,22 +198,24 @@ SearchData results = client.search("site:docs.firecrawl.dev crawl webhooks", opt
 
 Use scrape when you already have a URL and want structured content in one or more formats.
 
-### Preferred SDK methods
+### Preferred SDK method
 
-- `client.scrape(url)`
-- `client.scrape(url, options)`
-
-### Return value
-
-`scrape` returns `Document`. Typical getters include `getMarkdown()`, `getHtml()`, `getRawHtml()`, `getJson()`, `getMetadata()`, `getLinks()`, `getAudio()`, `getVideo()`, and additional fields when the corresponding formats are requested.
+- `client.scrape(String url)` → `Document`
+- `client.scrape(String url, ScrapeOptions options)` → `Document`
+- `client.scrapeAsync(String url)` → `CompletableFuture<Document>`
+- `client.scrapeAsync(String url, ScrapeOptions options)` → `CompletableFuture<Document>`
 
 ### Simple Example
 
 ```java
+import com.firecrawl.models.Document;
+import com.firecrawl.models.ScrapeOptions;
+
 Document doc = client.scrape(
     "https://docs.firecrawl.dev",
     ScrapeOptions.builder().formats(List.of("markdown")).build()
 );
+String markdown = doc.getMarkdown();
 ```
 
 ### Complex Example
@@ -181,6 +223,10 @@ Document doc = client.scrape(
 ```java
 import com.firecrawl.models.ScrapeOptions;
 import com.firecrawl.models.JsonFormat;
+import com.firecrawl.models.QuestionFormat;
+import com.firecrawl.models.HighlightsFormat;
+import com.firecrawl.models.LocationConfig;
+import com.firecrawl.models.AuditMetadata;
 
 List<Map<String, Object>> actions = List.of(
     Map.of("type", "click", "selector", "#accept"),
@@ -196,20 +242,41 @@ LocationConfig location = LocationConfig.builder()
 ScrapeOptions options = ScrapeOptions.builder()
     .formats(List.of(
         "markdown",
+        "html",
         "links",
-        JsonFormat.builder().prompt("Extract plan names and prices.").build(),
-        Map.of("type", "screenshot", "fullPage", true, "quality", 80)
+        "screenshot",
+        "audio",
+        "video",
+        JsonFormat.builder()
+            .prompt("Extract plan names and prices.")
+            .schema(Map.of("type", "object", "properties", Map.of(
+                "plans", Map.of("type", "array")
+            )))
+            .checkPromptInjection(true)
+            .build(),
+        QuestionFormat.builder().question("What is the pricing?").build(),
+        HighlightsFormat.builder().query("pricing tiers").build()
     ))
+    .headers(Map.of("User-Agent", "FirecrawlDocsBot/1.0"))
+    .includeTags(List.of("main", "article"))
+    .excludeTags(List.of("nav", "footer"))
     .onlyMainContent(true)
+    .timeout(60000)
     .waitFor(1000)
+    .mobile(false)
     .parsers(List.of(Map.of("type", "pdf", "maxPages", 5)))
     .actions(actions)
     .location(location)
+    .skipTlsVerification(false)
     .removeBase64Images(true)
     .blockAds(true)
     .proxy("auto")
     .maxAge(86400000L)
     .storeInCache(true)
+    .lockdown(false)
+    .redactPII(false)
+    .auditMetadata(AuditMetadata.builder().username("agent-user").build())
+    .integration("my-agent")
     .build();
 
 Document doc = client.scrape("https://example.com/pricing", options);
@@ -222,39 +289,32 @@ Document doc = client.scrape("https://example.com/pricing", options);
   - Use when: you want to scrape a specific page.
 
 - `options.formats`
-  - Type: List of format strings or format maps
+  - Type: List&lt;Object&gt;
   - Use when: you want multiple output formats.
   - Confirmed format strings:
     - `"markdown"`: markdown content
     - `"html"`: cleaned HTML
     - `"rawHtml"`: raw HTML
     - `"links"`: page links
-    - `"images"`: image URLs
     - `"screenshot"`: screenshot output
-    - `"summary"`: summary output
-    - `"changeTracking"`: change tracking output
     - `"json"`: JSON extraction
-    - `"attributes"`: attribute extraction
-    - `"branding"`: branding profile output
     - `"audio"`: audio extraction
     - `"video"`: video extraction
-  - Format object fields:
-    - `type`: one of the format strings above
-    - `prompt`, `schema`: JSON extraction options for `type: "json"`
-    - `modes`, `schema`, `prompt`, `tag`: change tracking options for `type: "changeTracking"`
-    - `fullPage`, `quality`, `viewport`: screenshot options for `type: "screenshot"`
-    - `selectors`: array of `{selector, attribute}` for `type: "attributes"`
+  - Format objects:
+    - `JsonFormat.builder().prompt("...").schema(Map).checkPromptInjection(Boolean).build()`: structured JSON extraction
+    - `QuestionFormat.builder().question("...").build()`: question-answer output
+    - `HighlightsFormat.builder().query("...").build()`: relevant source-text output
 
 - `options.headers`
-  - Type: `Map<String, String>`
+  - Type: Map&lt;String, String&gt;
   - Use when: you need custom request headers.
 
 - `options.includeTags`
-  - Type: `List<String>`
+  - Type: List&lt;String&gt;
   - Use when: you want to include only specific HTML tags.
 
 - `options.excludeTags`
-  - Type: `List<String>`
+  - Type: List&lt;String&gt;
   - Use when: you want to exclude specific HTML tags.
 
 - `options.onlyMainContent`
@@ -274,14 +334,14 @@ Document doc = client.scrape("https://example.com/pricing", options);
   - Use when: you want a mobile viewport.
 
 - `options.parsers`
-  - Type: `List<Object>`
+  - Type: List&lt;Object&gt;
   - Use when: you need file parsing controls.
   - Confirmed values:
     - `"pdf"`
     - `{type: "pdf", maxPages: number}`
 
 - `options.actions`
-  - Type: `List<Map<String, Object>>`
+  - Type: List&lt;Map&lt;String, Object&gt;&gt;
   - Use when: you need lightweight pre-scrape actions.
   - Confirmed action types:
     - `wait`: `milliseconds` or `selector` required
@@ -297,6 +357,7 @@ Document doc = client.scrape("https://example.com/pricing", options);
 - `options.location`
   - Type: `LocationConfig`
   - Use when: you need geo or language-aware scraping.
+  - Fields: `country` (String), `languages` (List&lt;String&gt;)
 
 - `options.skipTlsVerification`
   - Type: Boolean
@@ -313,7 +374,7 @@ Document doc = client.scrape("https://example.com/pricing", options);
 - `options.proxy`
   - Type: String
   - Use when: you need proxy control.
-  - Confirmed values: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`, or a custom proxy URL string
+  - Confirmed values: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`
 
 - `options.maxAge`
   - Type: Long
@@ -323,6 +384,19 @@ Document doc = client.scrape("https://example.com/pricing", options);
   - Type: Boolean
   - Use when: you want Firecrawl to cache the result.
 
+- `options.lockdown`
+  - Type: Boolean
+  - Use when: you want to enable lockdown mode for the scrape.
+
+- `options.redactPII`
+  - Type: Boolean
+  - Use when: you want to redact personally identifiable information from the output.
+
+- `options.auditMetadata`
+  - Type: `AuditMetadata`
+  - Use when: you need to attach audit context to the request.
+  - Fields: `username` (String)
+
 - `options.integration`
   - Type: String
   - Use when: the API expects an integration identifier on the request.
@@ -331,72 +405,70 @@ Document doc = client.scrape("https://example.com/pricing", options);
 
 ### Why use it
 
-Use interact when a page requires browser actions or code execution after a scrape starts.
+Use interact when a page requires browser actions or code execution after a scrape starts. The Java SDK exposes code-based interactions only: there is no `prompt` parameter on `interact` (unlike some other language SDKs).
 
-### Preferred SDK methods
+### Preferred SDK method
 
-- `client.interact(jobId, code)` — uses default language `node` and API default execution timeout
-- `client.interact(jobId, code, language, timeout)` — `timeout` is seconds (1–300), or null to omit and use the API default (30 seconds)
-- `client.interact(jobId, code, language, timeout, origin)` — optional `origin` string is sent only when non-null (request attribution)
+- `client.interact(String jobId, String code)` — uses default language `"node"` and API default execution timeout
+- `client.interact(String jobId, String code, String language, Integer timeout)` — `timeout` is seconds (1-300), or null to use the API default (30 seconds)
+- `client.interact(String jobId, String code, String language, Integer timeout, String origin)` — optional `origin` string for request attribution
+- `client.interactAsync(...)` → `CompletableFuture<BrowserExecuteResponse>`
 
 ### Simple Example
 
 ```java
+import com.firecrawl.models.Document;
+import com.firecrawl.models.ScrapeOptions;
 import com.firecrawl.models.BrowserExecuteResponse;
 
-BrowserExecuteResponse result = client.interact(
-    "<scrapeJobId>",
-    "console.log(await page.title());",
-    "node",
-    60
+Document doc = client.scrape(
+    "https://example.com",
+    ScrapeOptions.builder().formats(List.of("markdown")).build()
 );
+
+BrowserExecuteResponse result = client.interact(
+    doc.getMetadata().get("scrapeId").toString(),
+    "console.log(await page.title());"
+);
+System.out.println(result.getStdout());
 ```
 
 ### Complex Example
 
 ```java
+import com.firecrawl.models.BrowserExecuteResponse;
+
+String jobId = "<scrapeJobId>";
+
+// Execute Python code in the browser session
 BrowserExecuteResponse result = client.interact(
-    "<scrapeJobId>",
-    "// Use Playwright page methods here",
-    "node",
+    jobId,
+    "import asyncio\nprint(await page.title())",
+    "python",
     120
 );
+
+if (result.isSuccess()) {
+    System.out.println("stdout: " + result.getStdout());
+    System.out.println("result: " + result.getResult());
+} else {
+    System.err.println("error: " + result.getError());
+    System.err.println("stderr: " + result.getStderr());
+    System.err.println("exit code: " + result.getExitCode());
+    if (Boolean.TRUE.equals(result.getKilled())) {
+        System.err.println("Execution was killed (timeout)");
+    }
+}
 ```
-
-### Stop interactive browser
-
-End the scrape-bound browser session when finished.
-
-**Preferred SDK method:** `client.stopInteractiveBrowser(jobId)`
-
-```java
-import com.firecrawl.models.BrowserDeleteResponse;
-
-BrowserDeleteResponse stopped = client.stopInteractiveBrowser("<scrapeJobId>");
-```
-
-### Interact response (`BrowserExecuteResponse`)
-
-- `isSuccess()`: boolean
-- `getStdout()`, `getStderr()`, `getResult()`, `getError()`: String (may be null)
-- `getExitCode()`: Integer (may be null)
-- `getKilled()`: Boolean (may be null) — true when execution was stopped due to timeout
-
-### Stop response (`BrowserDeleteResponse`)
-
-- `isSuccess()`: boolean
-- `getSessionDurationMs()`: Long (may be null)
-- `getCreditsBilled()`: Integer (may be null)
-- `getError()`: String (may be null)
 
 ### Parameters
 
 - `jobId`
-  - Type: String
-  - Use when: you have a scrape job ID.
+  - Type: String (required)
+  - Use when: you have a scrape job ID from `document.getMetadata().get("scrapeId")`.
 
 - `code`
-  - Type: String
+  - Type: String (required)
   - Use when: you want to run code in the browser session.
 
 - `language`
@@ -407,26 +479,75 @@ BrowserDeleteResponse stopped = client.stopInteractiveBrowser("<scrapeJobId>");
 
 - `timeout`
   - Type: Integer
-  - Use when: you need an execution timeout in seconds (1–300). Null omits the field and uses the API default.
+  - Use when: you need an execution timeout in seconds (1-300). Null omits the field and uses the API default (30 seconds).
 
 - `origin`
   - Type: String
-  - Use when: you need an optional origin label on the request. Prefer omitting unless your integration requires it.
+  - Use when: you need an optional origin label on the request. SDK auto-injects `"java-sdk@1.18.0"` by default.
+
+### Return value
+
+`interact` returns `BrowserExecuteResponse`:
+
+- `isSuccess()`: boolean
+- `getStdout()`: String (may be null)
+- `getResult()`: String (may be null)
+- `getStderr()`: String (may be null)
+- `getExitCode()`: Integer (may be null)
+- `getKilled()`: Boolean (may be null) -- true when execution was stopped due to timeout
+- `getError()`: String (may be null)
+
+### Stop session
+
+End the scrape-bound browser session when finished.
+
+**Preferred SDK method:** `client.stopInteractiveBrowser(String jobId)` → `BrowserDeleteResponse`
+
+Async: `client.stopInteractiveBrowserAsync(String jobId)` → `CompletableFuture<BrowserDeleteResponse>`
+
+```java
+import com.firecrawl.models.BrowserDeleteResponse;
+
+BrowserDeleteResponse stopped = client.stopInteractiveBrowser(jobId);
+if (stopped.isSuccess()) {
+    System.out.println("Session lasted " + stopped.getSessionDurationMs() + "ms");
+    System.out.println("Credits billed: " + stopped.getCreditsBilled());
+}
+```
+
+`BrowserDeleteResponse` fields:
+
+- `isSuccess()`: boolean
+- `getSessionDurationMs()`: Long (may be null)
+- `getCreditsBilled()`: Integer (may be null)
+- `getError()`: String (may be null)
 
 ## Notes
 
-- Deprecated aliases: `scrapeExecute` → `interact`, `deleteScrapeBrowser` → `stopInteractiveBrowser` (and the corresponding `*Async` helpers).
-- The Java SDK exposes code-based interactions only: there is no `prompt` parameter on `interact` (unlike some other language SDKs).
+- Java 11+ required.
+- Uses builder pattern for all option types (`SearchOptions.builder()`, `ScrapeOptions.builder()`, etc.).
+- OkHttp 4.x + Jackson under the hood.
+- API key can be null/blank for keyless free tier.
+- SDK auto-injects origin `"java-sdk@1.18.0"` on interact requests.
+- Deprecated aliases (still functional, prefer the new names):
+  - `scrapeExecute()` → use `interact()`
+  - `deleteScrapeBrowser()` → use `stopInteractiveBrowser()`
+  - `scrapeExecuteAsync()` → use `interactAsync()`
+  - `deleteScrapeBrowserAsync()` → use `stopInteractiveBrowserAsync()`
+  - `QueryFormat` → use `QuestionFormat` or `HighlightsFormat`
 
 ## Source Of Truth
 
 - `firecrawl/apps/java-sdk/build.gradle.kts`
 - `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
-- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/SearchOptions.java`
 - `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/ScrapeOptions.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/SearchOptions.java`
 - `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/SearchData.java`
 - `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/JsonFormat.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/QuestionFormat.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/HighlightsFormat.java`
 - `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/LocationConfig.java`
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/AuditMetadata.java`
 - `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/Document.java`
 - `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/BrowserExecuteResponse.java`
 - `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/models/BrowserDeleteResponse.java`

--- a/agent-source-of-truth/node.mdx
+++ b/agent-source-of-truth/node.mdx
@@ -3,7 +3,7 @@ title: "Node.js Source of Truth"
 description: "Canonical Firecrawl Node.js source of truth for agents using key endpoints like search, scrape, and interact."
 ---
 
-Canonical Firecrawl Node.js source of truth for agents. Aligned with `firecrawl` **v4.18.2** (`firecrawl/apps/js-sdk/firecrawl`) and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
+Canonical Firecrawl Node.js source of truth for agents. Aligned with `firecrawl` **v4.39.0** (`firecrawl/apps/js-sdk/firecrawl`) and the v2 OpenAPI spec. Method names, parameters, and types match the SDK public API.
 
 ## Install
 
@@ -21,6 +21,8 @@ const client = new Firecrawl({
   // apiUrl: "https://api.firecrawl.dev" // optional; falls back to FIRECRAWL_API_URL or cloud default
 });
 ```
+
+Constructor options: `apiKey` (string, falls back to `FIRECRAWL_API_KEY` env), `apiUrl` (string, default `"https://api.firecrawl.dev"`), `timeoutMs` (number), `maxRetries` (number), `backoffFactor` (number).
 
 ## When To Use What
 
@@ -51,12 +53,17 @@ const results = await client.search("site:docs.firecrawl.dev webhook retries");
 ```ts
 const results = await client.search("site:docs.firecrawl.dev crawl webhooks", {
   sources: ["web", "news"],
-  categories: ["research"],
+  categories: ["research", "github"],
   limit: 10,
   tbs: "qdr:m",
   location: "San Francisco,California,United States",
+  country: "US",
+  includeDomains: ["docs.firecrawl.dev"],
   ignoreInvalidURLs: true,
+  highlights: true,
   timeout: 60000,
+  enterprise: ["default"],
+  threatProtection: { blockedCategories: ["malware"] },
   scrapeOptions: {
     formats: [
       "markdown",
@@ -79,12 +86,12 @@ const results = await client.search("site:docs.firecrawl.dev crawl webhooks", {
 - `news`: news hits
 - `images`: image hits
 
-**Wrong turn to avoid:** `search()` does not return `{ data: [...] }`. Do not access `result.data`. Web results are in `result.web`, news in `result.news`, images in `result.images`.
+**Wrong turn to avoid:** `search()` does not return `{ data: [...] }`. Accessing `.data` throws an error. Web results are in `result.web`, news in `result.news`, images in `result.images`.
 
 ### Parameters
 
 - `query`
-  - Type: string
+  - Type: string (required)
   - Use when: you need a search query.
   - Notes: use `site:example.com` to limit results to a domain.
 
@@ -104,10 +111,21 @@ const results = await client.search("site:docs.firecrawl.dev crawl webhooks", {
   - Type: array of category names or typed category objects
   - Use when: you want to filter results by category.
   - Confirmed values:
+    - `"github"`: GitHub results
     - `"developer"`: Developer Index results
     - `"research"`: research and academic results
     - `"pdf"`: PDF-focused results
-    - `{ type: "developer" | "research" | "pdf" }`: typed category object form
+    - `{ type: "github" | "developer" | "research" | "pdf" }`: typed category object form
+
+- `options.includeDomains`
+  - Type: string[]
+  - Use when: you want results only from specific domains.
+  - Notes: cannot combine with `excludeDomains`.
+
+- `options.excludeDomains`
+  - Type: string[]
+  - Use when: you want to exclude specific domains from results.
+  - Notes: cannot combine with `includeDomains`.
 
 - `options.limit`
   - Type: number
@@ -115,23 +133,51 @@ const results = await client.search("site:docs.firecrawl.dev crawl webhooks", {
 
 - `options.tbs`
   - Type: string
-  - Use when: you need a time-based filter (for example `qdr:d`, `qdr:w`, `sbd:1,qdr:m`).
+  - Use when: you need a time-based filter (for example `"qdr:d"`, `"qdr:w"`, `"sbd:1,qdr:m"`).
 
 - `options.location`
   - Type: string
   - Use when: you want localized results.
 
+- `options.country`
+  - Type: string
+  - Use when: you want results for a specific country.
+  - Notes: ISO 3166-1 alpha-2 code (for example `"US"`, `"GB"`).
+
 - `options.ignoreInvalidURLs`
   - Type: boolean
   - Use when: you want to drop URLs that cannot be scraped by other endpoints.
 
+- `options.highlights`
+  - Type: boolean
+  - Use when: you want highlighted snippets in results.
+  - Notes: defaults to `true` server-side.
+
 - `options.timeout`
   - Type: number
   - Use when: you need a request timeout in milliseconds.
+  - Notes: the SDK adds 5000 ms to the HTTP timeout beyond this value.
 
 - `options.scrapeOptions`
   - Type: `ScrapeOptions`
   - Use when: you want to scrape each search result (see Scrape parameters for fields). The SDK runs the same validation as for `scrape` (for example plain string `"json"` in `formats` is rejected).
+
+- `options.enterprise`
+  - Type: array of enterprise mode strings
+  - Use when: you need enterprise scraping capabilities.
+  - Confirmed values: `"default"`, `"anon"`, `"zdr"`
+
+- `options.threatProtection`
+  - Type: `ThreatProtectionOptions` object
+  - Use when: you want threat-level filtering on results.
+
+- `options.integration`
+  - Type: string
+  - Use when: you are calling through a named integration.
+
+- `options.origin`
+  - Type: string
+  - Use when: you need to tag the request origin.
 
 ## Scrape
 
@@ -158,23 +204,28 @@ const doc = await client.scrape("https://example.com/pricing", {
   formats: [
     "markdown",
     "links",
+    "summary",
     { type: "json", prompt: "Extract plan names and prices." },
     { type: "screenshot", fullPage: true, quality: 80, viewport: { width: 1280, height: 720 } },
     { type: "changeTracking", modes: ["git-diff"], tag: "pricing" },
-    { type: "attributes", selectors: [{ selector: "a", attribute: "href" }] }
+    { type: "attributes", selectors: [{ selector: "a", attribute: "href" }] },
+    { type: "question", question: "What is the enterprise price?" },
+    { type: "highlights", query: "pricing tiers" }
   ],
-  headers: {
-    "User-Agent": "FirecrawlDocsBot/1.0"
-  },
+  headers: { "User-Agent": "FirecrawlDocsBot/1.0" },
   onlyMainContent: true,
+  includeTags: ["main", "article"],
+  excludeTags: ["nav", "footer"],
   waitFor: 1000,
-  parsers: [{ type: "pdf", mode: "auto", maxPages: 5 }],
+  mobile: false,
+  parsers: [{ type: "pdf", mode: "auto", maxPages: 5, pages: "1-3", blocks: true, pageMarkers: true }],
   actions: [
     { type: "click", selector: "#accept" },
     { type: "wait", milliseconds: 750 },
     { type: "scrape" }
   ],
   location: { country: "US", languages: ["en-US"] },
+  skipTlsVerification: false,
   removeBase64Images: true,
   fastMode: true,
   blockAds: true,
@@ -182,14 +233,19 @@ const doc = await client.scrape("https://example.com/pricing", {
   maxAge: 86400000,
   minAge: 1,
   storeInCache: true,
-  profile: { name: "docs-session", saveChanges: true }
+  lockdown: false,
+  redactPII: { mode: "accurate", entities: ["email", "phone"], replaceStyle: "tag" },
+  threatProtection: { blockedCategories: ["malware"] },
+  auditMetadata: { username: "bot-user" },
+  profile: { name: "docs-session", saveChanges: true },
+  autoResume: true
 });
 ```
 
 ### Parameters
 
 - `url`
-  - Type: string
+  - Type: string (required)
   - Use when: you want to scrape a specific page.
 
 - `options.formats`
@@ -206,6 +262,8 @@ const doc = await client.scrape("https://example.com/pricing", {
     - `"changeTracking"`: change tracking output (for options like `modes`, use `{ type: "changeTracking", modes: [...] }` — `modes` is required on that object in typings)
     - `"attributes"`: attribute extraction (use `{ type: "attributes", selectors: [...] }` when passing selectors)
     - `"branding"`: branding profile output
+    - `"product"`: product data extraction
+    - `"menu"`: menu/navigation extraction
     - `"audio"`: audio extraction
     - `"video"`: video extraction
   - Object-only format types (at minimum `type` as shown):
@@ -222,15 +280,15 @@ const doc = await client.scrape("https://example.com/pricing", {
     - `fullPage`, `quality`, `viewport`: screenshot options.
 
 - `options.headers`
-  - Type: record of string to string
+  - Type: Record<string, string>
   - Use when: you need custom request headers.
 
 - `options.includeTags`
-  - Type: array of strings
+  - Type: string[]
   - Use when: you want to include only specific HTML tags.
 
 - `options.excludeTags`
-  - Type: array of strings
+  - Type: string[]
   - Use when: you want to exclude specific HTML tags.
 
 - `options.onlyMainContent`
@@ -250,11 +308,11 @@ const doc = await client.scrape("https://example.com/pricing", {
   - Use when: you want a mobile viewport.
 
 - `options.parsers`
-  - Type: array of parser names or parser objects
+  - Type: array of parser strings or parser objects
   - Use when: you need file parsing controls (for example PDF parsing).
   - Confirmed values:
     - `"pdf"`: enable PDF parsing
-    - `{ type: "pdf", mode?: "fast" | "auto" | "ocr", maxPages?: number }`: PDF parser options
+    - `{ type: "pdf", mode?: "fast" | "auto" | "ocr", maxPages?: number, pages?: string, blocks?: boolean, pageMarkers?: boolean }`: PDF parser options
 
 - `options.actions`
   - Type: array of action objects
@@ -312,9 +370,42 @@ const doc = await client.scrape("https://example.com/pricing", {
   - Type: boolean
   - Use when: you want Firecrawl to cache the result.
 
+- `options.lockdown`
+  - Type: boolean
+  - Use when: you want to serve only cached results and never hit the live page.
+
+- `options.redactPII`
+  - Type: boolean or object
+  - Use when: you need to redact personally identifiable information from output.
+  - As boolean: `true` enables PII redaction with defaults.
+  - As object: `{ mode?: "accurate" | "aggressive" | "fast", entities?: string[], replaceStyle?: "tag" | "mask" | "remove" }`
+
+- `options.threatProtection`
+  - Type: `ThreatProtectionOptions` object
+  - Use when: you want threat-level filtering on the scrape target.
+
+- `options.auditMetadata`
+  - Type: object with `username`
+  - Use when: you need to tag a scrape for audit purposes.
+  - Shape: `{ username: string }`
+
 - `options.profile`
   - Type: object with `name` and optional `saveChanges`
   - Use when: you want a persistent browser profile shared across scrapes and interactions.
+
+- `options.integration`
+  - Type: string
+  - Use when: you are calling through a named integration.
+
+- `options.origin`
+  - Type: string
+  - Use when: you need to tag the request origin.
+
+- `options.autoResume` (SDK-only)
+  - Type: boolean
+  - Default: `true`
+  - Use when: you want to control automatic resume of large-document processing.
+  - Notes: the SDK auto-resumes up to 5 times with a 20-minute total limit. Set `false` to handle resume manually.
 
 ## Interact
 
@@ -351,7 +442,7 @@ const result = await client.interact("<scrapeJobId>", {
 ### Parameters
 
 - `jobId`
-  - Type: string
+  - Type: string (required)
   - Use when: you have a scrape job ID from `document.metadata.scrapeId`.
 
 - `args.code`
@@ -374,19 +465,24 @@ const result = await client.interact("<scrapeJobId>", {
   - Type: number
   - Use when: you need an execution timeout in seconds.
 
-### Return value (`interact`)
+- `args.origin`
+  - Type: string
+  - Use when: you need to tag the request origin.
+
+### Return value
 
 `ScrapeExecuteResponse` matches `BrowserExecuteResponse`. Confirmed fields include:
 
 - `success`: boolean
+- `cdpUrl`: string (Chrome DevTools Protocol URL)
+- `liveViewUrl`: string
+- `interactiveLiveViewUrl`: string
 - `output`: string (aggregated output when present)
 - `stdout`: string
 - `result`: string (alias-style field alongside stdout in typings)
 - `stderr`: string
 - `exitCode`: number
 - `killed`: boolean
-- `liveViewUrl`: string
-- `interactiveLiveViewUrl`: string
 - `error`: string
 
 ### Stop session
@@ -394,142 +490,20 @@ const result = await client.interact("<scrapeJobId>", {
 `client.stopInteraction(jobId)` → `Promise<ScrapeBrowserDeleteResponse>`
 
 - `jobId`: scrape job id (same id used for `interact`).
-- Response fields in typings include `success`, `sessionDurationMs`, `creditsBilled`, `error`.
-
-## Ask (Agentic Debugging)
-
-### Why use it
-
-Use ask when a Firecrawl API call fails or returns unexpected results. The AI support agent diagnoses the issue, proposes fix parameters, and optionally validates the fix against the live API. Typical latency: 15-30 seconds.
-
-### Preferred SDK method
-
-Not yet available in the Node.js SDK. Use `fetch` directly.
-
-### Simple Example
-
-```ts
-const response = await fetch("https://api.firecrawl.dev/v2/support/ask", {
-  method: "POST",
-  headers: {
-    Authorization: `Bearer ${process.env.FIRECRAWL_API_KEY}`,
-    "Content-Type": "application/json",
-  },
-  body: JSON.stringify({
-    question: "my scrape returned empty markdown for https://example.com",
-  }),
-});
-const result = await response.json();
-console.log(result.answer);
-console.log(result.fixParameters);
-```
-
-### Complex Example
-
-```ts
-const response = await fetch("https://api.firecrawl.dev/v2/support/ask", {
-  method: "POST",
-  headers: {
-    Authorization: `Bearer ${process.env.FIRECRAWL_API_KEY}`,
-    "Content-Type": "application/json",
-  },
-  body: JSON.stringify({
-    question: "crawl returned 3 pages but I expected 50",
-    rationale: "user is on their third failed crawl attempt today",
-    context: { userPlan: "standard", retryCount: 3 },
-  }),
-});
-const result = await response.json();
-```
-
-### Agent retry pattern
-
-```ts
-import { Firecrawl } from "firecrawl";
-
-const client = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
-
-const doc = await client.scrape("https://example.com/pricing", {
-  formats: ["markdown"],
-});
-
-if (!doc.markdown || doc.markdown.length < 100) {
-  const diagResponse = await fetch(
-    "https://api.firecrawl.dev/v2/support/ask",
-    {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${process.env.FIRECRAWL_API_KEY}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        question: `scrape returned only ${doc.markdown?.length ?? 0} chars for https://example.com/pricing`,
-      }),
-    }
-  );
-  const diagnosis = await diagResponse.json();
-
-  if (diagnosis.fixParameters) {
-    const retryDoc = await client.scrape("https://example.com/pricing", {
-      formats: ["markdown"],
-      ...diagnosis.fixParameters,
-    });
-  }
-}
-```
-
-### Parameters
-
-- `question`
-  - Type: string (required, 1-8000 chars)
-  - Use when: you need to describe the issue.
-
-- `rationale`
-  - Type: string (1-2000 chars)
-  - Use when: you are an AI agent calling on behalf of a user.
-
-- `context`
-  - Type: object (free-form)
-  - Use when: you want to pass metadata into the debugging prompt.
-
-## Docs Search
-
-### Why use it
-
-Use docs-search to look up Firecrawl documentation.
-
-### Simple Example
-
-```ts
-const response = await fetch(
-  "https://api.firecrawl.dev/v2/support/docs-search",
-  {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${process.env.FIRECRAWL_API_KEY}`,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      question: "how do I verify webhook signatures?",
-    }),
-  }
-);
-const result = await response.json();
-console.log(result.answer);
-```
-
-### Parameters
-
-- `question`
-  - Type: string (required, 1-8000 chars)
-  - Use when: you need a docs-grounded answer.
+- Response fields: `success`, `sessionDurationMs`, `creditsBilled`, `error`.
 
 ## Notes
 
-- Deprecated client aliases: `scrapeExecute` → `interact`; `stopInteractiveBrowser` and `deleteScrapeBrowser` → `stopInteraction`.
+- Deprecated client aliases:
+  - `scrapeExecute(jobId, args)` → use `interact(jobId, args)`
+  - `stopInteractiveBrowser(jobId)` → use `stopInteraction(jobId)`
+  - `deleteScrapeBrowser(jobId)` → use `stopInteraction(jobId)`
+  - `scrapeUrl(url, options?)` → use `scrape(url, options?)`
+  - `QueryFormat` (`{ type: "query" }`) → use `QuestionFormat` (`{ type: "question" }`) or `HighlightsFormat` (`{ type: "highlights" }`)
 - The default `Firecrawl` export is the v2 client; v1 remains under `client.v1`.
 - Zod schemas passed to `formats` (for `json` or `changeTracking`) are converted to JSON Schema by the SDK.
 - The package declares **Node.js >= 22** in `engines`.
+- `search()` does NOT return `{ data: [...] }` — use `.web`, `.news`, `.images`.
 
 ## Source Of Truth
 
@@ -537,7 +511,4 @@ console.log(result.answer);
 - `firecrawl/apps/js-sdk/firecrawl/src/index.ts`
 - `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`
 - `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
-- `firecrawl/apps/js-sdk/firecrawl/src/v2/utils/validation.ts`
-- `firecrawl/apps/js-sdk/firecrawl/src/v2/methods/search.ts`
-- `firecrawl/apps/js-sdk/firecrawl/src/v2/methods/scrape.ts`
 - `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-source-of-truth/python.mdx
+++ b/agent-source-of-truth/python.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Python Source of Truth"
-description: "Canonical Firecrawl Python source of truth for agents using key endpoints like search, scrape, and interact."
+description: "Canonical Firecrawl Python source of truth for agents using key endpoints like search, scrape, interact, ask, and docs-search."
 ---
 
-Canonical Firecrawl Python source of truth for agents. Generated from SDK source (`firecrawl-py` / `firecrawl` **4.22.1**) and the v2 OpenAPI spec. Method names, parameters, and return types match the v2 client in `firecrawl/v2/client.py` unless noted.
+Canonical Firecrawl Python source of truth for agents. Generated from SDK source (`firecrawl-py` / `firecrawl`) and the v2 OpenAPI spec. Method names, parameters, and return types match the v2 client in `firecrawl/v2/client.py` unless noted.
 
 ## Install
 
@@ -11,23 +11,43 @@ Canonical Firecrawl Python source of truth for agents. Generated from SDK source
 pip install firecrawl-py
 ```
 
+Import the sync client, the async client, or their aliases:
+
+```py
+from firecrawl import Firecrawl          # sync client
+from firecrawl import AsyncFirecrawl     # async client
+from firecrawl import FirecrawlApp       # alias for Firecrawl
+from firecrawl import AsyncFirecrawlApp  # alias for AsyncFirecrawl
+```
+
 ## Authenticate
 
 ```py
-import os
 from firecrawl import Firecrawl
 
-client = Firecrawl(api_key=os.environ.get("FIRECRAWL_API_KEY"))
-# client = Firecrawl(api_key="fc-...", api_url="https://api.firecrawl.dev")
+# Explicit API key
+client = Firecrawl(api_key="fc-YOUR_API_KEY")
+
+# Falls back to FIRECRAWL_API_KEY env var
+client = Firecrawl()
+
+# All constructor parameters
+client = Firecrawl(
+    api_key="fc-YOUR_API_KEY",                    # str, falls back to FIRECRAWL_API_KEY env var
+    api_url="https://api.firecrawl.dev",          # str, default "https://api.firecrawl.dev"
+    timeout=30.0,                                  # float, seconds
+    max_retries=3,                                 # int, default 3
+    backoff_factor=0.5,                            # float, default 0.5
+)
 ```
 
 ## When To Use What
 
-- `search`: use when you start with a query and need discovery.
-- `scrape`: use when you already have a URL and want page content.
-- `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
-- `support/ask`: use when a Firecrawl API call fails or returns unexpected results and you need a diagnosis.
-- `support/docs-search`: use when you need to look up Firecrawl documentation.
+- `search` — use when you start with a query and need discovery.
+- `scrape` — use when you already have a URL and want page content.
+- `interact` — use when the page needs clicks, forms, or post-scrape browser actions.
+- `support/ask` — use when a Firecrawl API call fails or returns unexpected results and you need a diagnosis.
+- `support/docs-search` — use when you need to look up Firecrawl documentation.
 
 ## Search
 
@@ -38,18 +58,6 @@ Use search to discover relevant pages from a query, then pick URLs to scrape or 
 ### Preferred SDK method
 
 `client.search(query, **options)` → `SearchData` (`firecrawl.v2.types`)
-
-### Return value
-
-Returns a `SearchData` model with optional lists:
-
-- `web` — web hits (`SearchResultWeb` or full `Document` when `scrape_options` hydrates content)
-- `news` — news hits (`SearchResultNews` or `Document`)
-- `images` — image hits (`SearchResultImages` or `Document`)
-
-Omitted buckets are `None` when the API did not return that key.
-
-**Wrong turn to avoid:** `search()` does not return `{ data: [...] }`. Do not access `result.data`. Web results are in `result.web`, news in `result.news`, images in `result.images`.
 
 ### Simple Example
 
@@ -66,13 +74,20 @@ from firecrawl.v2.types import ScrapeOptions
 
 results = client.search(
     "site:docs.firecrawl.dev crawl webhooks",
-    sources=["web", "news"],
-    categories=["research"],
+    sources=["web", "news", "images"],
+    categories=["github", "research", "pdf", "developer"],
+    include_domains=["docs.firecrawl.dev", "firecrawl.dev"],
+    # exclude_domains=["example.com"],  # mutually exclusive with include_domains
     limit=10,
     tbs="qdr:m",
     location="San Francisco,California,United States",
+    country="US",
     ignore_invalid_urls=True,
     timeout=300000,
+    highlights=True,
+    enterprise=["zdr"],            # ["zdr"] for Zero Data Retention, ["anon"] for anonymized
+    threat_protection={"mode": "safe"},
+    integration="custom-integration",
     scrape_options=ScrapeOptions(
         formats=[
             "markdown",
@@ -92,30 +107,44 @@ results = client.search(
 )
 ```
 
+### Return value
+
+Returns a `SearchData` model with optional lists:
+
+- `web` — web hits (`SearchResultWeb` or full `Document` when `scrape_options` hydrates content)
+- `news` — news hits (`SearchResultNews` or `Document`)
+- `images` — image hits (`SearchResultImages` or `Document`)
+
+Omitted buckets are `None` when the API did not return that key.
+
+**Wrong turn to avoid:** `search()` does not return `{ data: [...] }`. Do not access `result.data` — it raises `AttributeError`. Web results are in `result.web`, news in `result.news`, images in `result.images`.
+
 ### Parameters
 
 - `query`
-  - Type: str
+  - Type: str (required, positional)
   - Use when: you need a search query.
   - Notes: use `site:example.com` to limit results to a domain.
 
 - `sources`
-  - Type: list of source names or `Source` objects
+  - Type: List[SourceOption]
   - Use when: you want to control which sources are searched.
-  - Confirmed values:
-    - `"web"`: web index results
-    - `"news"`: news results
-    - `"images"`: image results
-    - `Source(type="web" | "news" | "images")`: typed source object form
+  - Confirmed values: `"web"`, `"news"`, `"images"`
 
 - `categories`
-  - Type: list of category names or `Category` objects
+  - Type: List[CategoryOption]
   - Use when: you want to filter results by category.
-  - Confirmed values:
-    - `"developer"`: Developer Index results
-    - `"research"`: research and academic results
-    - `"pdf"`: PDF-focused results
-    - `Category(type="developer" | "research" | "pdf")`: typed category object form
+  - Confirmed values: `"github"`, `"research"`, `"pdf"`, `"developer"`
+
+- `include_domains`
+  - Type: List[str]
+  - Use when: you want results only from specific domains.
+  - Notes: mutually exclusive with `exclude_domains`.
+
+- `exclude_domains`
+  - Type: List[str]
+  - Use when: you want to exclude specific domains from results.
+  - Notes: mutually exclusive with `include_domains`.
 
 - `limit`
   - Type: int
@@ -129,6 +158,12 @@ results = client.search(
 - `location`
   - Type: str
   - Use when: you want localized results.
+  - Notes: plain string (not a Location object). Example: `"San Francisco,California,United States"`.
+
+- `country`
+  - Type: str
+  - Use when: you want results localized to a country.
+  - Notes: ISO country code (for example `"US"`, `"GB"`, `"DE"`).
 
 - `ignore_invalid_urls`
   - Type: bool
@@ -139,9 +174,27 @@ results = client.search(
   - Use when: you need a request timeout in milliseconds.
   - Notes: defaults to `300000` in the SDK model.
 
+- `highlights`
+  - Type: bool
+  - Use when: you want highlighted snippets in results.
+  - Notes: defaults to `true` server-side.
+
 - `scrape_options`
   - Type: `ScrapeOptions`
   - Use when: you want to scrape each search result (see Scrape parameters for fields).
+
+- `enterprise`
+  - Type: List[str]
+  - Use when: you need enterprise features.
+  - Confirmed values: `["zdr"]` for Zero Data Retention, `["anon"]` for anonymized.
+
+- `threat_protection`
+  - Type: ThreatProtectionOptions
+  - Use when: you need threat protection on search results.
+
+- `integration`
+  - Type: str
+  - Use when: you want to specify a custom integration identifier.
 
 ## Scrape
 
@@ -157,6 +210,7 @@ Use scrape when you already have a URL and want structured content in one or mor
 
 ```py
 doc = client.scrape("https://docs.firecrawl.dev", formats=["markdown"])
+print(doc.markdown)
 ```
 
 ### Complex Example
@@ -173,8 +227,12 @@ doc = client.scrape(
         {"type": "attributes", "selectors": [{"selector": "a", "attribute": "href"}]},
     ],
     headers={"User-Agent": "FirecrawlDocsBot/1.0"},
+    include_tags=["main", "article"],
+    exclude_tags=["nav", "footer"],
     only_main_content=True,
+    timeout=60000,
     wait_for=1000,
+    mobile=False,
     parsers=[{"type": "pdf", "mode": "auto", "max_pages": 5}],
     actions=[
         {"type": "click", "selector": "#accept"},
@@ -182,24 +240,30 @@ doc = client.scrape(
         {"type": "scrape"},
     ],
     location={"country": "US", "languages": ["en-US"]},
+    skip_tls_verification=False,
     remove_base64_images=True,
     fast_mode=True,
     block_ads=True,
     proxy="auto",
     max_age=86400000,
     store_in_cache=True,
+    lockdown=False,
+    threat_protection={"mode": "safe"},
     profile={"name": "docs-session", "save_changes": True},
+    audit_metadata={"username": "agent-bot"},
+    integration="custom-integration",
+    auto_resume=True,
 )
 ```
 
 ### Parameters
 
 - `url`
-  - Type: str
+  - Type: str (required, positional)
   - Use when: you want to scrape a specific page.
 
 - `formats`
-  - Type: list of format strings or format objects
+  - Type: List[FormatOption]
   - Use when: you want multiple output formats.
   - Confirmed format strings:
     - `"markdown"`: markdown content
@@ -230,15 +294,15 @@ doc = client.scrape(
     - `selectors`: array of `{selector, attribute}` for `type: "attributes"`
 
 - `headers`
-  - Type: dict of str to str
+  - Type: Dict[str, str]
   - Use when: you need custom request headers.
 
 - `include_tags`
-  - Type: list of str
+  - Type: List[str]
   - Use when: you want to include only specific HTML tags.
 
 - `exclude_tags`
-  - Type: list of str
+  - Type: List[str]
   - Use when: you want to exclude specific HTML tags.
 
 - `only_main_content`
@@ -258,29 +322,30 @@ doc = client.scrape(
   - Use when: you want a mobile viewport.
 
 - `parsers`
-  - Type: list of parser names or parser objects
+  - Type: List
   - Use when: you need file parsing controls (for example PDF parsing).
   - Confirmed values:
     - `"pdf"`: enable PDF parsing
     - `{ "type": "pdf", "mode": "fast" | "auto" | "ocr", "max_pages": int }`: PDF parser options
 
 - `actions`
-  - Type: list of action objects
+  - Type: List of action dicts
   - Use when: you need lightweight pre-scrape actions.
   - Confirmed action types:
-    - `wait`: `milliseconds` or `selector` required
-    - `screenshot`: `full_page`, `quality`, `viewport` optional
-    - `click`: `selector` required
-    - `write`: `text` required (click to focus the input first)
-    - `press`: `key` required
-    - `scroll`: `direction` (`up` or `down`) required, `selector` optional
-    - `scrape`: no additional fields
-    - `executeJavascript`: `script` required
-    - `pdf`: `format` (A0, A1, A2, A3, A4, A5, A6, Letter, Legal, Tabloid, Ledger), `landscape`, `scale` optional
+    - `WaitAction`: `{"type": "wait", "milliseconds": int}` or `{"type": "wait", "selector": str}`
+    - `ScreenshotAction`: `{"type": "screenshot", "full_page": bool, "quality": int, "viewport": dict}`
+    - `ClickAction`: `{"type": "click", "selector": str}`
+    - `WriteAction`: `{"type": "write", "text": str}` (click to focus the input first)
+    - `PressAction`: `{"type": "press", "key": str}`
+    - `ScrollAction`: `{"type": "scroll", "direction": "up" | "down", "selector": str}`
+    - `ScrapeAction`: `{"type": "scrape"}`
+    - `ExecuteJavascriptAction`: `{"type": "executeJavascript", "script": str}`
+    - `PDFAction`: `{"type": "pdf", "format": str, "landscape": bool, "scale": float}`
 
 - `location`
-  - Type: dict with `country` and `languages`
+  - Type: Location object `{ "country": str, "languages": List[str] }`
   - Use when: you need geo or language-aware scraping.
+  - Notes: this is a dict/Location object, unlike `location` on `search()` which is a plain string.
 
 - `skip_tls_verification`
   - Type: bool
@@ -307,18 +372,35 @@ doc = client.scrape(
   - Type: int
   - Use when: you want cached data up to a maximum age (milliseconds).
 
-- `min_age`
-  - Type: int
-  - Use when: you want cached data only if it is at least this old (milliseconds).
-  - Notes: only on `ScrapeOptions` passed as `scrape_options` to `client.search`. The `client.scrape` method does not accept `min_age`.
-
 - `store_in_cache`
   - Type: bool
   - Use when: you want Firecrawl to cache the result.
 
+- `lockdown`
+  - Type: bool
+  - Use when: you want lockdown mode for the scrape.
+
+- `threat_protection`
+  - Type: ThreatProtectionOptions
+  - Use when: you need threat protection on the scrape.
+
 - `profile`
-  - Type: dict with `name` and optional `save_changes` or `saveChanges`
+  - Type: dict with `name` (str) and optional `save_changes` (bool)
   - Use when: you want a persistent browser profile shared across scrapes and interactions.
+
+- `audit_metadata`
+  - Type: AuditMetadata `{ "username": str }`
+  - Use when: you want to attach audit metadata to the scrape.
+
+- `integration`
+  - Type: str
+  - Use when: you want to specify a custom integration identifier.
+
+- `auto_resume`
+  - Type: bool
+  - Use when: you want automatic resume behavior for the scrape.
+
+**Note:** `redact_pii` and `min_age` are available on `ScrapeOptions` (used in `search()`'s `scrape_options` parameter) but are not accepted as direct keyword arguments on `client.scrape()`.
 
 ## Interact
 
@@ -328,9 +410,9 @@ Use interact when a page requires browser actions or code execution after a scra
 
 ### Preferred SDK method
 
-`client.interact(job_id, code=None, *, prompt=None, language="node", timeout=None)`
+`client.interact(job_id, code=None, *, prompt=None, language="node", timeout=None, origin=None)` → `BrowserExecuteResponse`
 
-`prompt` is keyword-only: call `client.interact(job_id, prompt="...")` or `client.interact(job_id, code="...")`. At least one of `code` or `prompt` must be non-empty (validated in `firecrawl/v2/methods/scrape.py`).
+`prompt` is keyword-only: call `client.interact(job_id, prompt="...")` or `client.interact(job_id, code="...")`. At least one of `code` or `prompt` must be non-empty.
 
 ### Simple Example
 
@@ -351,25 +433,22 @@ result = client.interact(
     code="print(await page.title())",
     language="python",
     timeout=60,
+    origin="agent-workflow",
 )
 ```
-
-### Stop session
-
-`client.stop_interaction(job_id)` ends the scrape-bound browser session. Returns `BrowserDeleteResponse` (`success`, optional `session_duration_ms`, `credits_billed`, `error`).
 
 ### Parameters
 
 - `job_id`
-  - Type: str
+  - Type: str (required, positional)
   - Use when: you have a scrape job ID from `document.metadata.scrape_id`.
 
 - `code`
-  - Type: str
+  - Type: str (optional, positional)
   - Use when: you want to run code in the browser session (optional if `prompt` is set).
 
 - `prompt`
-  - Type: str
+  - Type: str (keyword-only)
   - Use when: you want the browser agent to follow a natural-language instruction (optional if `code` is set).
 
 - `language`
@@ -380,11 +459,19 @@ result = client.interact(
 
 - `timeout`
   - Type: int
-  - Use when: you need an execution timeout in seconds.
+  - Use when: you need an execution timeout in seconds (1-300).
+
+- `origin`
+  - Type: str
+  - Use when: you want to tag the origin of the interaction.
 
 ### Return value
 
 Returns `BrowserExecuteResponse`: `success`, optional `live_view_url`, `interactive_live_view_url`, `output`, `stdout`, `result`, `stderr`, `exit_code`, `killed`, `error` (API camelCase is normalized to snake_case on the model).
+
+### Stop session
+
+`client.stop_interaction(job_id)` ends the scrape-bound browser session. Returns `BrowserDeleteResponse` (`success`, optional `session_duration_ms`, `credits_billed`, `error`).
 
 ## Ask (Agentic Debugging)
 
@@ -392,14 +479,12 @@ Returns `BrowserExecuteResponse`: `success`, optional `live_view_url`, `interact
 
 Use ask when a Firecrawl API call fails or returns unexpected results. The AI support agent diagnoses the issue, proposes fix parameters, and optionally validates the fix against the live API. Typical latency: 15-30 seconds.
 
-### Preferred SDK method
-
-Not yet available in the Python SDK. Use `requests` or `httpx` directly.
-
 ### Simple Example
 
+Not yet available in the Python SDK. Use `requests` or `httpx` directly:
+
 ```py
-import requests
+import os, requests
 
 response = requests.post(
     "https://api.firecrawl.dev/v2/support/ask",
@@ -412,56 +497,6 @@ response = requests.post(
 result = response.json()
 print(result["answer"])
 print(result["fixParameters"])
-```
-
-### Complex Example
-
-```py
-import requests
-
-response = requests.post(
-    "https://api.firecrawl.dev/v2/support/ask",
-    headers={
-        "Authorization": f"Bearer {os.environ['FIRECRAWL_API_KEY']}",
-        "Content-Type": "application/json",
-    },
-    json={
-        "question": "crawl returned 3 pages but I expected 50",
-        "rationale": "user is on their third failed crawl attempt today",
-        "context": {"userPlan": "standard", "retryCount": 3},
-    },
-)
-result = response.json()
-```
-
-### Agent retry pattern
-
-```py
-from firecrawl import Firecrawl
-import requests, os
-
-client = Firecrawl(api_key=os.environ["FIRECRAWL_API_KEY"])
-
-doc = client.scrape("https://example.com/pricing", formats=["markdown"])
-
-if not doc.markdown or len(doc.markdown) < 100:
-    diagnosis = requests.post(
-        "https://api.firecrawl.dev/v2/support/ask",
-        headers={
-            "Authorization": f"Bearer {os.environ['FIRECRAWL_API_KEY']}",
-            "Content-Type": "application/json",
-        },
-        json={
-            "question": f"scrape returned only {len(doc.markdown or '')} chars for https://example.com/pricing",
-        },
-    ).json()
-
-    if diagnosis.get("fixParameters"):
-        doc = client.scrape(
-            "https://example.com/pricing",
-            formats=["markdown"],
-            **diagnosis["fixParameters"],
-        )
 ```
 
 ### Parameters
@@ -482,18 +517,21 @@ if not doc.markdown or len(doc.markdown) < 100:
 
 ### Why use it
 
-Use docs-search to look up Firecrawl documentation.
+Use docs-search to look up Firecrawl documentation when you need a docs-grounded answer.
 
 ### Simple Example
 
-```py
-import requests
+Not yet available in the Python SDK. Use `requests` or `httpx` directly:
 
-FIRECRAWL_API_KEY = "fc-YOUR_API_KEY"
+```py
+import os, requests
 
 response = requests.post(
     "https://api.firecrawl.dev/v2/support/docs-search",
-    headers={"Authorization": f"Bearer {FIRECRAWL_API_KEY}"},
+    headers={
+        "Authorization": f"Bearer {os.environ['FIRECRAWL_API_KEY']}",
+        "Content-Type": "application/json",
+    },
     json={"question": "how do I verify webhook signatures?"},
 )
 print(response.json()["answer"])
@@ -503,22 +541,25 @@ print(response.json()["answer"])
 
 - `question`
   - Type: str (required, 1-8000 chars)
-  - Use when: you need a docs-grounded answer.
+  - Use when: you need a docs-grounded answer about Firecrawl.
 
 ## Notes
 
-- Deprecated aliases: `scrape_execute` → `interact`; `stop_interactive_browser` and `delete_scrape_browser` → `stop_interaction`.
+- **Async client:** Use `AsyncFirecrawl` (or its alias `AsyncFirecrawlApp`) for async workflows. All methods mirror the sync client.
+- **Deprecated aliases:**
+  - `scrape_execute()` → `interact()`
+  - `delete_scrape_browser()` → `stop_interaction()`
+  - `stop_interactive_browser()` → `stop_interaction()`
+  - `scrape_url()` → `scrape()`
+  - `FirecrawlApp` is an alias for `Firecrawl`
+  - `AsyncFirecrawlApp` is an alias for `AsyncFirecrawl`
 - The top-level `Firecrawl` client exposes v2 methods directly; v1 remains under `client.v1`.
 - The bundled v2 OpenAPI snippet for `POST /v2/scrape/{jobId}/interact` may only document `code`; the Python SDK and server accept either `code` or `prompt` for this endpoint.
+- `redact_pii` and `min_age` exist on `ScrapeOptions` (for `search()`'s `scrape_options`) but are not accepted as direct kwargs on `client.scrape()`.
 
 ## Source Of Truth
 
-- `firecrawl/apps/python-sdk/pyproject.toml`
-- `firecrawl/apps/python-sdk/firecrawl/__init__.py`
 - `firecrawl/apps/python-sdk/firecrawl/client.py`
 - `firecrawl/apps/python-sdk/firecrawl/v2/client.py`
 - `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
-- `firecrawl/apps/python-sdk/firecrawl/v2/methods/search.py`
-- `firecrawl/apps/python-sdk/firecrawl/v2/methods/scrape.py`
-- `firecrawl/apps/python-sdk/firecrawl/v2/utils/validation.py`
 - `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-source-of-truth/rust.mdx
+++ b/agent-source-of-truth/rust.mdx
@@ -3,24 +3,27 @@ title: "Rust Source of Truth"
 description: "Canonical Firecrawl Rust source of truth for agents using key endpoints like search, scrape, and interact."
 ---
 
-Canonical Firecrawl Rust source of truth for agents. Generated from SDK source and the v2 OpenAPI spec.
+Canonical Firecrawl Rust source of truth for agents. Generated from SDK source (`firecrawl` **2.19.0**) and the v2 OpenAPI spec. Method names, parameters, and return types match the v2 client in `apps/rust-sdk/src/v2/client.rs` unless noted.
 
 ## Install
 
-```bash
-cargo add firecrawl
+```toml
+# Cargo.toml
+[dependencies]
+firecrawl = "2.19.0"
+tokio = { version = "1", features = ["full"] }
 ```
 
-Crate: **`firecrawl`** on crates.io. The current SDK version is **2.0.0** (verify the latest release on crates.io before pinning).
+Crate: **`firecrawl`** on crates.io. The current SDK version is **2.19.0**.
 
 ## Authenticate
 
 ```rust
 use firecrawl::Client;
 
-let client = Client::new("fc-your-api-key")?;
-// Self-hosted example:
-// let client = Client::new_selfhosted("http://localhost:3002", Some("fc-your-api-key"))?;
+let client = Client::new("fc-YOUR_API_KEY")?;
+// or for self-hosted:
+let client = Client::new_selfhosted("https://your-instance.com", Some("fc-YOUR_API_KEY"))?;
 ```
 
 ## When To Use What
@@ -28,8 +31,6 @@ let client = Client::new("fc-your-api-key")?;
 - `search`: use when you start with a query and need discovery.
 - `scrape`: use when you already have a URL and want page content.
 - `interact`: use when the page needs clicks, forms, or post-scrape browser actions.
-- `support/ask`: use when a Firecrawl API call fails or returns unexpected results and you need a diagnosis.
-- `support/docs-search`: use when you need to look up Firecrawl documentation.
 
 ## Search
 
@@ -41,49 +42,82 @@ Use search to discover relevant pages from a query, then pick URLs to scrape or 
 
 `client.search(query, options)` → `Result<SearchResponse, FirecrawlError>`
 
+Convenience: `client.search_and_scrape(query, limit)` → `Result<Vec<Document>, FirecrawlError>` — calls `search` with default `ScrapeOptions` and returns `Vec<Document>` built from `SearchResultOrDocument::Document` entries in `data.web`.
+
 ### Simple Example
 
 ```rust
 use firecrawl::Client;
 
-let results = client
-    .search("site:docs.firecrawl.dev webhook retries", None)
-    .await?;
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::new("fc-YOUR_API_KEY")?;
+
+    let results = client
+        .search("site:docs.firecrawl.dev webhook retries", None)
+        .await?;
+
+    if let Some(web) = results.data.web {
+        for item in web {
+            println!("{item:?}");
+        }
+    }
+
+    Ok(())
+}
 ```
 
 ### Complex Example
 
 ```rust
 use firecrawl::{
-    Client, SearchOptions, SearchSource, SearchCategory, ScrapeOptions, Format, JsonOptions,
+    Client, SearchOptions, SearchSource, SearchCategory,
+    ScrapeOptions, Format, JsonOptions,
 };
 
-let options = SearchOptions {
-    sources: Some(vec![SearchSource::Web, SearchSource::News]),
-    categories: Some(vec![SearchCategory::Research]),
-    limit: Some(10),
-    tbs: Some("qdr:m".to_string()),
-    location: Some("San Francisco,California,United States".to_string()),
-    ignore_invalid_urls: Some(true),
-    timeout: Some(60000),
-    scrape_options: Some(ScrapeOptions {
-        formats: Some(vec![Format::Markdown, Format::Links, Format::Json]),
-        json_options: Some(JsonOptions {
-            prompt: Some("Extract title and key endpoints.".to_string()),
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::new("fc-YOUR_API_KEY")?;
+
+    let options = SearchOptions {
+        sources: Some(vec![SearchSource::Web, SearchSource::News]),
+        categories: Some(vec![SearchCategory::Research, SearchCategory::Github]),
+        limit: Some(10),
+        tbs: Some("qdr:m".to_string()),
+        location: Some("San Francisco,California,United States".to_string()),
+        country: Some("US".to_string()),
+        ignore_invalid_urls: Some(true),
+        timeout: Some(60000),
+        highlights: Some(true),
+        include_domains: Some(vec!["docs.firecrawl.dev".to_string()]),
+        exclude_domains: Some(vec!["old.firecrawl.dev".to_string()]),
+        scrape_options: Some(ScrapeOptions {
+            formats: Some(vec![Format::Markdown, Format::Links, Format::Json]),
+            json_options: Some(JsonOptions {
+                prompt: Some("Extract title and key endpoints.".to_string()),
+                ..Default::default()
+            }),
+            only_main_content: Some(true),
             ..Default::default()
         }),
-        only_main_content: Some(true),
         ..Default::default()
-    }),
-    ..Default::default()
-};
+    };
 
-let results = client
-    .search("site:docs.firecrawl.dev crawl webhooks", options)
-    .await?;
+    let results = client
+        .search("site:docs.firecrawl.dev crawl webhooks", options)
+        .await?;
+
+    if let Some(web) = results.data.web {
+        for item in web {
+            println!("{item:?}");
+        }
+    }
+
+    Ok(())
+}
 ```
 
-### Return type
+### Return value
 
 `client.search(...)` returns `Result<SearchResponse, FirecrawlError>`.
 
@@ -92,7 +126,7 @@ let results = client
   - `data: SearchData`
   - `warning: Option<String>`
 - `SearchData`
-  - `web: Option<Vec<SearchResultOrDocument>>` — each item is either `SearchResultOrDocument::WebResult(SearchResultWeb)` (url, title, description, …) or `SearchResultOrDocument::Document(Document)` when the API returned scraped content for that row (detected when markdown, html, rawHtml, or metadata is present).
+  - `web: Option<Vec<SearchResultOrDocument>>` — each item is either `SearchResultOrDocument::WebResult(SearchResultWeb)` (url, title, description, ...) or `SearchResultOrDocument::Document(Document)` when the API returned scraped content for that row (detected when markdown, html, rawHtml, or metadata is present).
   - `news: Option<Vec<SearchResultNews>>`
   - `images: Option<Vec<SearchResultImage>>`
 
@@ -103,44 +137,67 @@ let results = client
   - Use when: you need a search query.
   - Notes: use `site:example.com` to limit results to a domain.
 
+- `options.limit`
+  - Type: `Option<u32>`
+  - Use when: you want to cap results.
+  - Notes: defaults to 5, max 20.
+
 - `options.sources`
-  - Type: `Vec<SearchSource>`
+  - Type: `Option<Vec<SearchSource>>`
   - Use when: you want to control which sources are searched.
   - Confirmed values: `Web`, `News`, `Images`
 
 - `options.categories`
-  - Type: `Vec<SearchCategory>`
+  - Type: `Option<Vec<SearchCategory>>`
   - Use when: you want to filter results by category.
-  - Confirmed values: `Research`, `Pdf`
+  - Confirmed values: `Github`, `Research`, `Pdf`
 
-- `options.limit`
-  - Type: u32
-  - Use when: you want to cap results.
+- `options.include_domains`
+  - Type: `Option<Vec<String>>`
+  - Use when: you want to restrict results to specific domains.
+
+- `options.exclude_domains`
+  - Type: `Option<Vec<String>>`
+  - Use when: you want to exclude specific domains from results.
 
 - `options.tbs`
-  - Type: String
+  - Type: `Option<String>`
   - Use when: you need a time-based filter (for example `qdr:d`, `qdr:w`, `sbd:1,qdr:m`).
 
 - `options.location`
-  - Type: String
+  - Type: `Option<String>`
   - Use when: you want localized results.
 
+- `options.country`
+  - Type: `Option<String>`
+  - Use when: you want country-specific results.
+
 - `options.ignore_invalid_urls`
-  - Type: bool
+  - Type: `Option<bool>`
   - Use when: you want to drop URLs that cannot be scraped by other endpoints.
 
 - `options.timeout`
-  - Type: u32
+  - Type: `Option<u32>`
   - Use when: you need a request timeout in milliseconds.
 
+- `options.highlights`
+  - Type: `Option<bool>`
+  - Use when: you want highlighted snippets in results.
+  - Notes: defaults to true.
+
 - `options.scrape_options`
-  - Type: `ScrapeOptions`
+  - Type: `Option<ScrapeOptions>`
   - Use when: you want to scrape each search result (see Scrape parameters for fields).
 
 - `options.integration`
   - Type: `Option<String>`
   - Use when: you need an integration identifier for server-side tracking.
   - Notes: omit in agent-oriented examples unless your product intentionally sets it.
+
+- `options.origin`
+  - Type: `Option<String>`
+  - Use when: you need an origin label for telemetry.
+  - Notes: auto-fills with `"rust-sdk@{version}"` if not set.
 
 ## Scrape
 
@@ -152,68 +209,139 @@ Use scrape when you already have a URL and want structured content in one or mor
 
 `client.scrape(url, options)` → `Result<Document, FirecrawlError>` (the HTTP response `data` field is unwrapped in the SDK).
 
+Convenience: `client.scrape_with_schema(url, schema, prompt?)` for JSON extraction — wraps `scrape` with `Format::Json` and the provided schema.
+
 ### Simple Example
 
 ```rust
 use firecrawl::{Client, ScrapeOptions, Format};
 
-let doc = client
-    .scrape("https://docs.firecrawl.dev", ScrapeOptions {
-        formats: Some(vec![Format::Markdown]),
-        ..Default::default()
-    })
-    .await?;
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::new("fc-YOUR_API_KEY")?;
+
+    let doc = client
+        .scrape("https://docs.firecrawl.dev", ScrapeOptions {
+            formats: Some(vec![Format::Markdown]),
+            ..Default::default()
+        })
+        .await?;
+
+    println!("{}", doc.markdown.unwrap_or_default());
+
+    Ok(())
+}
 ```
 
 ### Complex Example
 
 ```rust
 use firecrawl::{
-    Client, ScrapeOptions, Format, JsonOptions, ScreenshotOptions, ChangeTrackingOptions,
-    ChangeTrackingMode, AttributeSelector, Action, ParserConfig, ProxyType,
+    Client, ScrapeOptions, Format, JsonOptions, ScreenshotOptions,
+    ChangeTrackingOptions, ChangeTrackingMode, AttributeSelector,
+    Action, ParserConfig, ProxyType, LocationConfig, ProfileConfig,
+    AuditMetadata,
 };
+use std::collections::HashMap;
 
-let doc = client
-    .scrape("https://example.com/pricing", ScrapeOptions {
-        formats: Some(vec![
-            Format::Markdown,
-            Format::Links,
-            Format::Json,
-            Format::Screenshot,
-            Format::ChangeTracking,
-            Format::Attributes,
-        ]),
-        json_options: Some(JsonOptions {
-            prompt: Some("Extract plan names and prices.".to_string()),
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::new("fc-YOUR_API_KEY")?;
+
+    let doc = client
+        .scrape("https://example.com/pricing", ScrapeOptions {
+            formats: Some(vec![
+                Format::Markdown,
+                Format::Links,
+                Format::Json,
+                Format::Screenshot,
+                Format::ChangeTracking,
+                Format::Attributes,
+                Format::Product,
+                Format::Menu,
+            ]),
+            headers: Some(HashMap::from([
+                ("User-Agent".to_string(), "FirecrawlBot/1.0".to_string()),
+            ])),
+            include_tags: Some(vec!["main".to_string(), "article".to_string()]),
+            exclude_tags: Some(vec!["nav".to_string(), "footer".to_string()]),
+            only_main_content: Some(true),
+            timeout: Some(30000),
+            wait_for: Some(1000),
+            mobile: Some(false),
+            json_options: Some(JsonOptions {
+                schema: Some(serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "plans": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "name": { "type": "string" },
+                                    "price": { "type": "string" }
+                                }
+                            }
+                        }
+                    }
+                })),
+                system_prompt: Some("You are a pricing data extractor.".to_string()),
+                prompt: Some("Extract plan names and prices.".to_string()),
+                check_prompt_injection: Some(true),
+                ..Default::default()
+            }),
+            screenshot_options: Some(ScreenshotOptions {
+                full_page: Some(true),
+                quality: Some(80),
+                ..Default::default()
+            }),
+            change_tracking_options: Some(ChangeTrackingOptions {
+                modes: Some(vec![ChangeTrackingMode::GitDiff]),
+                tag: Some("pricing".to_string()),
+                ..Default::default()
+            }),
+            attribute_selectors: Some(vec![AttributeSelector {
+                selector: "a".to_string(),
+                attribute: "href".to_string(),
+            }]),
+            parsers: Some(vec![ParserConfig::Pdf {
+                parser_type: "pdf".to_string(),
+                max_pages: Some(5),
+            }]),
+            actions: Some(vec![
+                Action::Click { selector: "#accept".to_string() },
+                Action::Wait { milliseconds: Some(750), selector: None },
+                Action::Scrape,
+            ]),
+            location: Some(LocationConfig {
+                country: Some("US".to_string()),
+                languages: Some(vec!["en-US".to_string()]),
+            }),
+            skip_tls_verification: Some(false),
+            remove_base64_images: Some(true),
+            fast_mode: Some(true),
+            block_ads: Some(true),
+            proxy: Some(ProxyType::Auto),
+            max_age: Some(86400),
+            min_age: Some(0),
+            store_in_cache: Some(true),
+            lockdown: Some(false),
+            redact_pii: Some(false),
+            audit_metadata: Some(AuditMetadata {
+                ..Default::default()
+            }),
+            profile: Some(ProfileConfig {
+                name: "docs-session".to_string(),
+                save_changes: Some(true),
+            }),
             ..Default::default()
-        }),
-        screenshot_options: Some(ScreenshotOptions {
-            full_page: Some(true),
-            quality: Some(80),
-            ..Default::default()
-        }),
-        change_tracking_options: Some(ChangeTrackingOptions {
-            modes: Some(vec![ChangeTrackingMode::GitDiff]),
-            tag: Some("pricing".to_string()),
-            ..Default::default()
-        }),
-        attribute_selectors: Some(vec![AttributeSelector {
-            selector: "a".to_string(),
-            attribute: "href".to_string(),
-        }]),
-        parsers: Some(vec![ParserConfig::Pdf {
-            parser_type: "pdf".to_string(),
-            max_pages: Some(5),
-        }]),
-        actions: Some(vec![
-            Action::Click { selector: "#accept".to_string() },
-            Action::Wait { milliseconds: Some(750), selector: None },
-            Action::Scrape,
-        ]),
-        proxy: Some(ProxyType::Auto),
-        ..Default::default()
-    })
-    .await?;
+        })
+        .await?;
+
+    println!("{}", doc.markdown.unwrap_or_default());
+
+    Ok(())
+}
 ```
 
 ### Parameters
@@ -223,47 +351,47 @@ let doc = client
   - Use when: you want to scrape a specific page.
 
 - `options.formats`
-  - Type: `Vec<Format>`
+  - Type: `Option<Vec<Format>>`
   - Use when: you want multiple output formats.
-  - Confirmed values: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `ChangeTracking`, `Json`, `Attributes`, `Branding`, `Audio`, `Video`
+  - Confirmed values: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `ChangeTracking`, `Json`, `Attributes`, `Branding`, `Product`, `Menu`, `Audio`, `Video`, `Question(QuestionFormat)`, `Highlights(HighlightsFormat)`
 
 - `options.headers`
-  - Type: `HashMap<String, String>`
+  - Type: `Option<HashMap<String, String>>`
   - Use when: you need custom request headers.
 
 - `options.include_tags`
-  - Type: `Vec<String>`
+  - Type: `Option<Vec<String>>`
   - Use when: you want to include only specific HTML tags.
 
 - `options.exclude_tags`
-  - Type: `Vec<String>`
+  - Type: `Option<Vec<String>>`
   - Use when: you want to exclude specific HTML tags.
 
 - `options.only_main_content`
-  - Type: bool
+  - Type: `Option<bool>`
   - Use when: you want to strip nav, footer, and other boilerplate.
 
 - `options.timeout`
-  - Type: u32
+  - Type: `Option<u32>`
   - Use when: you need a timeout in milliseconds.
 
 - `options.wait_for`
-  - Type: u32
+  - Type: `Option<u32>`
   - Use when: you need to wait for the page to render (milliseconds).
 
 - `options.mobile`
-  - Type: bool
+  - Type: `Option<bool>`
   - Use when: you want a mobile viewport.
 
 - `options.parsers`
-  - Type: `Vec<ParserConfig>`
+  - Type: `Option<Vec<ParserConfig>>`
   - Use when: you need file parsing controls.
   - Confirmed values:
     - `ParserConfig::Simple("pdf".to_string())`
     - `ParserConfig::Pdf { parser_type: "pdf", max_pages: Some(n) }`
 
 - `options.actions`
-  - Type: `Vec<Action>`
+  - Type: `Option<Vec<Action>>`
   - Use when: you need lightweight pre-scrape actions.
   - Confirmed action types:
     - `Wait`: `milliseconds` or `selector` required
@@ -277,72 +405,89 @@ let doc = client
     - `Pdf`: `format` (A0, A1, A2, A3, A4, A5, A6, Letter, Legal, Tabloid, Ledger), `landscape`, `scale` optional
 
 - `options.location`
-  - Type: `LocationConfig`
+  - Type: `Option<LocationConfig>`
   - Use when: you need geo or language-aware scraping.
-  - Confirmed fields: `country`, `languages`
+  - Confirmed fields: `country: Option<String>`, `languages: Option<Vec<String>>`
 
 - `options.skip_tls_verification`
-  - Type: bool
+  - Type: `Option<bool>`
   - Use when: you need to skip TLS verification.
 
 - `options.remove_base64_images`
-  - Type: bool
+  - Type: `Option<bool>`
   - Use when: you want to drop base64 images from markdown output.
 
 - `options.fast_mode`
-  - Type: bool
+  - Type: `Option<bool>`
   - Use when: you want faster scrapes with reduced fidelity.
 
 - `options.block_ads`
-  - Type: bool
+  - Type: `Option<bool>`
   - Use when: you want ad and cookie popup blocking.
 
 - `options.proxy`
-  - Type: `ProxyType`
+  - Type: `Option<ProxyType>`
   - Use when: you need proxy control.
   - Confirmed values: `Basic`, `Stealth`, `Enhanced`, `Auto`
 
 - `options.max_age`
-  - Type: u32
-  - Use when: you want cached data up to a maximum age (milliseconds).
+  - Type: `Option<u32>`
+  - Use when: you want cached data up to a maximum age (seconds).
 
 - `options.min_age`
-  - Type: u32
-  - Use when: you want cached data only if it is at least this old (milliseconds).
+  - Type: `Option<u32>`
+  - Use when: you want cached data only if it is at least this old (seconds).
 
 - `options.store_in_cache`
-  - Type: bool
+  - Type: `Option<bool>`
   - Use when: you want Firecrawl to cache the result.
 
+- `options.lockdown`
+  - Type: `Option<bool>`
+  - Use when: you want to enable lockdown mode for the scrape.
+
+- `options.redact_pii`
+  - Type: `Option<bool>`
+  - Use when: you want to redact personally identifiable information from the output.
+
+- `options.audit_metadata`
+  - Type: `Option<AuditMetadata>`
+  - Use when: you need to attach audit metadata to the scrape request.
+
 - `options.profile`
-  - Type: `ProfileConfig`
+  - Type: `Option<ProfileConfig>`
   - Use when: you want a persistent browser profile shared across scrapes and interactions.
-  - Confirmed fields: `name`, `save_changes`
+  - Confirmed fields: `name: String`, `save_changes: Option<bool>`
 
 - `options.integration`
   - Type: `Option<String>`
   - Use when: you need an integration identifier for server-side tracking.
   - Notes: omit in agent-oriented examples unless your product intentionally sets it.
 
+- `options.origin`
+  - Type: `Option<String>`
+  - Use when: you need an origin label for telemetry.
+  - Notes: auto-fills with `"rust-sdk@{version}"` if not set.
+
 - `options.json_options`
-  - Type: `JsonOptions`
+  - Type: `Option<JsonOptions>`
   - Use when: you want to configure JSON extraction.
-  - Confirmed fields: `schema`, `system_prompt`, `prompt`
+  - Confirmed fields: `schema: Option<Value>`, `system_prompt: Option<String>`, `prompt: Option<String>`, `check_prompt_injection: Option<bool>`
 
 - `options.screenshot_options`
-  - Type: `ScreenshotOptions`
+  - Type: `Option<ScreenshotOptions>`
   - Use when: you want to configure screenshot output.
   - Confirmed fields: `full_page`, `quality`, `viewport`
 
 - `options.change_tracking_options`
-  - Type: `ChangeTrackingOptions`
+  - Type: `Option<ChangeTrackingOptions>`
   - Use when: you want to configure change tracking output.
   - Confirmed fields: `modes` (`GitDiff` or `Json`), `schema`, `prompt`, `tag`
 
 - `options.attribute_selectors`
-  - Type: `Vec<AttributeSelector>`
+  - Type: `Option<Vec<AttributeSelector>>`
   - Use when: you want attribute extraction output.
-  - Confirmed fields: `selector`, `attribute`
+  - Confirmed fields: `selector: String`, `attribute: String`
 
 ## Interact
 
@@ -352,24 +497,43 @@ Use interact when a page requires browser actions or code execution after a scra
 
 ### Preferred SDK method
 
-`client.interact(job_id, options)`
-
-To end the browser session, use `client.stop_interaction(job_id)` (HTTP `DELETE` on `/v2/scrape/{jobId}/interact`).
+`client.interact(job_id, options)` → `Result<ScrapeExecuteResponse, FirecrawlError>`
 
 ### Simple Example
 
 ```rust
-use firecrawl::{Client, ScrapeExecuteOptions};
+use firecrawl::{Client, ScrapeOptions, ScrapeExecuteOptions, Format};
 
-let result = client
-    .interact(
-        "<scrapeJobId>",
-        ScrapeExecuteOptions {
-            prompt: Some("Click the pricing tab and summarize the plans.".to_string()),
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::new("fc-YOUR_API_KEY")?;
+
+    // First scrape to get a job ID
+    let doc = client
+        .scrape("https://example.com", ScrapeOptions {
+            formats: Some(vec![Format::Markdown]),
             ..Default::default()
-        },
-    )
-    .await?;
+        })
+        .await?;
+
+    let job_id = doc.metadata
+        .and_then(|m| m.scrape_id)
+        .ok_or("Missing scrape_id from scrape response")?;
+
+    let result = client
+        .interact(
+            &job_id,
+            ScrapeExecuteOptions {
+                prompt: Some("Click the pricing tab and summarize the plans.".to_string()),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    println!("{}", result.output.unwrap_or_default());
+
+    Ok(())
+}
 ```
 
 ### Complex Example
@@ -377,84 +541,108 @@ let result = client
 ```rust
 use firecrawl::{Client, ScrapeExecuteOptions, ScrapeExecuteLanguage};
 
-let result = client
-    .interact(
-        "<scrapeJobId>",
-        ScrapeExecuteOptions {
-            code: Some("console.log(await page.title());".to_string()),
-            language: Some(ScrapeExecuteLanguage::Node),
-            timeout: Some(60),
-            ..Default::default()
-        },
-    )
-    .await?;
-```
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::new("fc-YOUR_API_KEY")?;
 
-### Stop session
+    let result = client
+        .interact(
+            "<scrapeJobId>",
+            ScrapeExecuteOptions {
+                code: Some("console.log(await page.title());".to_string()),
+                language: Some(ScrapeExecuteLanguage::Node),
+                timeout: Some(60),
+                ..Default::default()
+            },
+        )
+        .await?;
 
-```rust
-let stopped = client.stop_interaction("<scrapeJobId>").await?;
-// stopped: ScrapeBrowserDeleteResponse { success, session_duration_ms, credits_billed, error, ... }
+    if let Some(stdout) = &result.stdout {
+        println!("stdout: {stdout}");
+    }
+    if let Some(exit_code) = result.exit_code {
+        println!("exit code: {exit_code}");
+    }
+
+    Ok(())
+}
 ```
 
 ### Parameters
 
 - `job_id`
   - Type: `impl AsRef<str>`
-  - Use when: you have a scrape job ID.
+  - Use when: you have a scrape job ID from `document.metadata.scrape_id`.
 
 - `options.code`
   - Type: `Option<String>`
   - Use when: you want to run code in the browser session.
+  - Notes: at least one of `code` or `prompt` must be non-empty; otherwise the SDK returns `FirecrawlError::Misuse` before calling the API.
 
 - `options.prompt`
   - Type: `Option<String>`
   - Use when: you want the browser agent to follow a natural-language instruction.
+  - Notes: at least one of `code` or `prompt` must be non-empty.
 
 - `options.language`
-  - Type: `ScrapeExecuteLanguage`
+  - Type: `Option<ScrapeExecuteLanguage>`
   - Use when: you need a specific runtime.
   - Confirmed values: `Python`, `Node`, `Bash`
   - Notes: defaults to `Node` in the SDK if omitted.
 
 - `options.timeout`
-  - Type: u32
+  - Type: `Option<u32>`
   - Use when: you need an execution timeout in seconds.
 
 - `options.origin`
   - Type: `Option<String>`
-  - Use when: you need an optional origin label for execution telemetry.
-  - Notes: omit in agent-oriented examples unless your product intentionally sets it.
+  - Use when: you need an origin label for execution telemetry.
+  - Notes: auto-fills with `"rust-sdk@{version}"` if not set.
 
-At least one of `options.code` or `options.prompt` must be non-empty; otherwise the SDK returns `FirecrawlError::Misuse` before calling the API.
-
-### Response types
+### Return value
 
 - `interact` → `Result<ScrapeExecuteResponse, FirecrawlError>`
-  - `success: bool` is always present; `live_view_url`, `interactive_live_view_url`, `output`, `stdout`, `result`, `stderr`, `exit_code`, `killed`, and `error` are `Option` fields on the struct.
-- `stop_interaction` → `Result<ScrapeBrowserDeleteResponse, FirecrawlError>`
-  - `success: bool` is always present; `session_duration_ms`, `credits_billed`, and `error` are optional.
+  - `success: bool`
+  - `live_view_url: Option<String>`
+  - `interactive_live_view_url: Option<String>`
+  - `output: Option<String>`
+  - `stdout: Option<String>`
+  - `result: Option<Value>`
+  - `stderr: Option<String>`
+  - `exit_code: Option<i32>`
+  - `killed: Option<bool>`
+  - `error: Option<String>`
 
-The v2 OpenAPI spec currently models the interact request body with `code` as required; the Rust SDK matches server behavior by accepting **either** `code` **or** `prompt` (see `ScrapeExecuteOptions` in `scrape.rs`).
+### Stop session
+
+```rust
+let stopped = client.stop_interaction("<scrapeJobId>").await?;
+// stopped: ScrapeBrowserDeleteResponse { success, session_duration_ms, credits_billed, error }
+```
+
+`client.stop_interaction(job_id)` → `Result<ScrapeBrowserDeleteResponse, FirecrawlError>`
+
+- `success: bool`
+- `session_duration_ms: Option<u64>`
+- `credits_billed: Option<u32>`
+- `error: Option<String>`
 
 ## Notes
 
-- Deprecated aliases: `scrape_execute`, `stop_interactive_browser`, and `delete_scrape_browser` map to `interact` and `stop_interaction`.
-- `ScrapeOptions` includes dedicated `json_options`, `screenshot_options`, and `change_tracking_options` for advanced formats.
-- `search_and_scrape(query, limit)` is a convenience helper: it calls `search` with default `ScrapeOptions` and returns `Vec<Document>` built from `SearchResultOrDocument::Document` entries in `data.web` (see `search.rs`).
+- All options structs derive `Default`, so use `..Default::default()` for unset fields.
+- Fields are serialized as camelCase for the API wire format via serde.
+- `origin` auto-fills with `"rust-sdk@{version}"` if not set.
+- Uses reqwest under the hood; all methods are async.
 - v2 SDK exports all types at the crate root: `use firecrawl::Client` (not `use firecrawl::v2::Client`).
+- Deprecated aliases: `scrape_execute()` maps to `interact()`. `stop_interactive_browser()` and `delete_scrape_browser()` map to `stop_interaction()`.
+- `search_and_scrape(query, limit)` is a convenience helper: calls `search` with default `ScrapeOptions` and returns `Vec<Document>` built from `SearchResultOrDocument::Document` entries in `data.web`.
 - Error types simplified in v2: `CrawlJobFailed(String, CrawlStatus)` → `JobFailed(String)`, `Missuse` → `Misuse`.
+- The v2 OpenAPI spec may model the interact request body with `code` as required; the Rust SDK and server accept either `code` or `prompt` (see `ScrapeExecuteOptions`).
 
 ## Source Of Truth
 
 - `firecrawl/apps/rust-sdk/Cargo.toml`
-- `firecrawl/apps/rust-sdk/src/lib.rs`
-- `firecrawl/apps/rust-sdk/src/client.rs`
-- `firecrawl/apps/rust-sdk/src/scrape.rs`
-- `firecrawl/apps/rust-sdk/src/search.rs`
-- `firecrawl/apps/rust-sdk/src/crawl.rs`
-- `firecrawl/apps/rust-sdk/src/map.rs`
-- `firecrawl/apps/rust-sdk/src/batch_scrape.rs`
-- `firecrawl/apps/rust-sdk/src/agent.rs`
-- `firecrawl/apps/rust-sdk/src/types.rs`
+- `firecrawl/apps/rust-sdk/src/v2/client.rs`
+- `firecrawl/apps/rust-sdk/src/v2/search.rs`
+- `firecrawl/apps/rust-sdk/src/v2/scrape.rs`
 - `firecrawl-docs/api-reference/v2-openapi.json`


### PR DESCRIPTION
## Summary

Refreshes all 6 agent source-of-truth files with the latest SDK API surface and OpenAPI spec data.

- **Node.js**: v4.18.2 → v4.39.0
- **Python**: v4.22.1 → latest
- **Rust**: v2.0.0 → v2.19.0
- **Java**: v1.2.0 → v1.18.0
- **Elixir**: ~> 1.0.0 → ~> 1.11
- **Curl**: refreshed against current v2 OpenAPI spec

## Changes

### New parameters added across all SDKs
- `lockdown` — serve only cached results
- `redactPII` — PII redaction with mode/entities/replaceStyle options
- `threatProtection` — per-request threat scanning override
- `auditMetadata` — SIEM attribution (username)
- `profile` — persistent browser profiles
- `integration` — integration tag
- `enterprise` — ZDR / anonymized search options
- `country` — ISO country code for geo-targeting
- `highlights` — query-relevant highlights (default true)

### New format types documented
- `question` — ask a question about the page
- `highlights` — find relevant source text
- `product` — product information extraction
- `menu` — menu/restaurant extraction

### Per-language fixes
- **Node.js**: Added `autoResume` SDK-only option, expanded deprecated aliases section
- **Python**: Clarified `redact_pii`/`min_age` availability (on `ScrapeOptions` only, not direct `scrape()` kwargs)
- **Rust**: Documented `scrape_with_schema` and `search_and_scrape` convenience methods
- **Java**: Clarified interact is code-only (no `prompt`), documented builder pattern and async variants
- **Elixir**: Noted `:stealth` proxy not in NimbleOptions validation, no `fast_mode`, interact is code-only
- **Curl**: Added `onlyCleanContent`, `rawBase64`, full `redactPII` object docs, `threatProtection` sub-fields

## Source of truth

All parameters verified against:
1. SDK source code in `firecrawl/` monorepo
2. OpenAPI spec at `api-reference/v2-openapi.json`
3. Existing docs used only as secondary reference

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBpfL2yUZihSkmtqFaSHfY

---
_Generated by [Claude Code](https://claude.ai/code/session_01XBpfL2yUZihSkmtqFaSHfY)_