### PR TITLE
Add agent quickstart docs for all five SDK languages

### DIFF
--- a/agent-quickstart/elixir.mdx
+++ b/agent-quickstart/elixir.mdx
@@ -1,0 +1,210 @@
+---
+title: "Elixir Agent Quickstart"
+description: "Canonical Firecrawl Elixir quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Elixir Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl using Elixir. It is generated from SDK source (`:firecrawl` v1.11.0) and the Firecrawl OpenAPI spec.
+
+## Install
+
+```elixir
+# mix.exs
+defp deps do
+  [
+    {:firecrawl, "~> 1.11"}
+  ]
+end
+```
+
+Requires `req ~> 0.5` and `nimble_options ~> 1.1` (pulled as transitive deps).
+
+## Authenticate
+
+```elixir
+# Application config (recommended)
+# config/config.exs
+config :firecrawl, api_key: "fc-YOUR_API_KEY"
+
+# Per-call override via opts
+Firecrawl.search_and_scrape([query: "test"], api_key: "fc-YOUR_API_KEY")
+
+# Self-hosted instance
+Firecrawl.scrape_and_extract_from_url(
+  [url: "https://example.com"],
+  base_url: "https://self-hosted.example/v2"
+)
+
+# Keyless free tier (rate-limited per IP) — just omit the api_key
+```
+
+No client struct or explicit initialization is needed. Auth is resolved per-request from application config or the `opts` keyword list.
+
+## When To Use What
+
+- **`search_and_scrape`**: Use when you start with a query and need to discover relevant pages. Returns search results across web, news, and images. Optionally scrapes each result page.
+- **`scrape_and_extract_from_url`**: Use when you already have a URL and want page content (markdown, HTML, structured data, screenshots, etc.).
+- **`interact_with_scrape_browser_session`**: Use when the page needs post-scrape browser actions — clicking buttons, filling forms, or executing code in the browser sandbox.
+
+## Search
+
+### Why use it
+
+Search finds pages matching a query across the web, news, or images. Use it for discovery when you don't have a specific URL.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.search_and_scrape(params, opts \\ [])
+Firecrawl.search_and_scrape!(params, opts \\ [])
+```
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.search_and_scrape(
+  query: "firecrawl web scraping API",
+  limit: 5
+)
+
+# response is a %Req.Response{} — access body for results
+results = response.body
+```
+
+### Parameters
+
+All parameters are passed as a keyword list. Snake_case keys are auto-mapped to camelCase for the API.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` | `:string` | **Required.** The search query (max 500 chars). |
+| `limit` | `:integer` | Max results to return. Server default: 10. |
+| `sources` | `{:list, :any}` | Which result buckets: `"web"`, `"news"`, `"images"`. Default: `["web"]`. |
+| `categories` | `{:list, :any}` | Filter by category. Default: `[]`. |
+| `include_domains` | `{:list, :string}` | Restrict results to these domains. Mutually exclusive with `exclude_domains`. |
+| `exclude_domains` | `{:list, :string}` | Exclude results from these domains. Mutually exclusive with `include_domains`. |
+| `tbs` | `:string` | Time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `:string` | Location for search results. |
+| `country` | `:string` | ISO country code for geo-targeting. Default: `"US"`. |
+| `ignore_invalid_urls` | `:boolean` | Skip invalid URLs. Default: `false`. |
+| `timeout` | `:integer` | Timeout in milliseconds. Default: `60000`. |
+| `highlights` | `:boolean` | Generate query-relevant highlights. Default: `true` (server). |
+| `scrape_options` | `:keyword_list` | Options for scraping each result page. See Scrape parameters. |
+| `enterprise` | `{:list, :string}` | Enterprise options: `["zdr"]` or `["anon"]`. |
+
+## Scrape
+
+### Why use it
+
+Scrape fetches and processes a single URL. Returns markdown, HTML, structured JSON, screenshots, and more. Use it when you have a specific page to extract content from.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.scrape_and_extract_from_url(params, opts \\ [])
+Firecrawl.scrape_and_extract_from_url!(params, opts \\ [])
+```
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown", "links"]
+)
+
+body = response.body
+IO.puts(body["data"]["markdown"])
+```
+
+### Parameters
+
+All parameters are passed as a keyword list. Snake_case keys are auto-mapped to camelCase.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `url` | `:string` | **Required.** The URL to scrape. |
+| `formats` | `{:list, :any}` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`. Default: `["markdown"]`. |
+| `headers` | `:any` | Custom HTTP headers for the request. |
+| `actions` | `{:list, :any}` | Browser actions to execute. |
+| `only_main_content` | `:boolean` | Only return main content. Default: `true`. |
+| `include_tags` | `{:list, :string}` | Only include content from these HTML tags. |
+| `exclude_tags` | `{:list, :string}` | Exclude content from these HTML tags. |
+| `wait_for` | `:integer` | Wait time in ms before scraping. Default: `0`. |
+| `timeout` | `:integer` | Timeout in milliseconds (1000–300000). Default: `60000`. |
+| `mobile` | `:boolean` | Emulate a mobile device. Default: `false`. |
+| `location` | `:keyword_list` | Geolocation settings keyword list. |
+| `proxy` | `:basic \| :enhanced \| :auto` | Proxy type. Default: `:auto`. |
+| `block_ads` | `:boolean` | Block ads and cookie popups. Default: `true`. |
+| `skip_tls_verification` | `:boolean` | Skip TLS verification. Default: `true`. |
+| `remove_base64_images` | `:boolean` | Remove base64 images from markdown. Default: `true`. |
+| `redact_pii` | `:boolean` | Redact PII. Default: `false`. |
+| `max_age` | `:integer` | Max cache age in ms. Default: `172800000` (2 days). |
+| `min_age` | `:integer` | Min cache age in ms (cache-only mode). |
+| `store_in_cache` | `:boolean` | Cache the result. Default: `true`. |
+| `lockdown` | `:boolean` | Serve only cached results. Default: `false`. |
+| `zero_data_retention` | `:boolean` | Enable zero data retention. Default: `false`. |
+| `parsers` | `{:list, :any}` | File processing controls. Default: `["pdf"]`. |
+| `profile` | `:keyword_list` | Persistent browser profile. |
+| `audit_metadata` | `:keyword_list` | SIEM logging attribution. Requires `username: "..."`. |
+
+## Interact
+
+### Why use it
+
+Interact lets you execute code in the browser sandbox tied to a scrape job. Use it for post-scrape actions: clicking buttons, filling forms, or running JavaScript.
+
+### Preferred SDK method
+
+```elixir
+Firecrawl.interact_with_scrape_browser_session(job_id, params \\ [], opts \\ [])
+Firecrawl.interact_with_scrape_browser_session!(job_id, params \\ [], opts \\ [])
+```
+
+### Example
+
+```elixir
+# Execute code in the browser
+{:ok, response} = Firecrawl.interact_with_scrape_browser_session(
+  "job-id-from-scrape",
+  code: "document.title",
+  language: :node,
+  timeout: 30
+)
+
+IO.inspect(response.body)
+
+# Stop the session when done
+Firecrawl.stop_interactive_scrape_browser_session("job-id-from-scrape")
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `job_id` | `String.t()` | **Required.** The scrape job ID (first positional argument). |
+| `code` | `:string` | **Required.** Code to execute in the browser sandbox (1–100000 chars). |
+| `language` | `:python \| :node \| :bash` | Language of the code. Default: `"node"`. |
+| `timeout` | `:integer` | Execution timeout in seconds (1–300). Default: `30`. |
+| `origin` | `:string` | Optional origin label for telemetry. |
+
+**Stop session**: `Firecrawl.stop_interactive_scrape_browser_session(job_id)` sends `DELETE /scrape/{jobId}/interact`.
+
+## Notes
+
+- **Auto-generated SDK**: The Elixir SDK is auto-generated from the OpenAPI spec (`mix run generate.exs`). Do not expect hand-written conveniences.
+- **Function names mirror OpenAPI operation IDs**: `search_and_scrape` (not `search`), `scrape_and_extract_from_url` (not `scrape`), `interact_with_scrape_browser_session` (not `interact`).
+- **Bang variants**: Every function has a `!` variant that raises instead of returning `{:error, ...}`.
+- **NimbleOptions validation**: All parameters are validated at call time before the HTTP request. Invalid keys or types return `{:error, %NimbleOptions.ValidationError{}}`.
+- **snake_case to camelCase**: You pass snake_case keyword lists; the SDK auto-converts to camelCase for the JSON body. Nested keyword lists are also recursively camelCased.
+- **Error handling**: HTTP 400+ responses are converted to `Firecrawl.Error` structs (with `status` and `body` fields), not raw `Req.Response`.
+- **No deprecated aliases**: The Elixir SDK has no deprecated function aliases.
+- **Proxy as atom**: The `proxy` parameter accepts atoms (`:basic`, `:enhanced`, `:auto`), not strings.
+
+## Source Of Truth
+
+- `firecrawl/apps/elixir-sdk/lib/firecrawl.ex`
+- `firecrawl/apps/elixir-sdk/lib/firecrawl/error.ex`
+- `firecrawl/apps/elixir-sdk/mix.exs`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/java.mdx
+++ b/agent-quickstart/java.mdx
@@ -1,0 +1,239 @@
+---
+title: "Java Agent Quickstart"
+description: "Canonical Firecrawl Java quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Java Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl using Java. It is generated from SDK source (`firecrawl-java` v1.18.0) and the Firecrawl OpenAPI spec.
+
+## Install
+
+**Maven**:
+
+```xml
+<dependency>
+  <groupId>com.firecrawl</groupId>
+  <artifactId>firecrawl-java</artifactId>
+  <version>1.18.0</version>
+</dependency>
+```
+
+**Gradle**:
+
+```groovy
+implementation("com.firecrawl:firecrawl-java:1.18.0")
+```
+
+Requires Java 11+.
+
+## Authenticate
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+
+// Builder (preferred)
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey("fc-YOUR_API_KEY")  // falls back to FIRECRAWL_API_KEY env / firecrawl.apiKey sysprop
+    .build();
+
+// Environment shortcut
+FirecrawlClient client = FirecrawlClient.fromEnv();
+
+// Full options
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey("fc-YOUR_API_KEY")
+    .apiUrl("https://api.firecrawl.dev")  // falls back to FIRECRAWL_API_URL env
+    .timeoutMs(300_000)                    // HTTP timeout, default 5 min
+    .maxRetries(3)
+    .backoffFactor(0.5)
+    .build();
+```
+
+## When To Use What
+
+- **`search`**: Use when you start with a query and need to discover relevant pages. Returns search results across web, news, and images. Optionally scrapes each result page.
+- **`scrape`**: Use when you already have a URL and want page content (markdown, HTML, structured data, screenshots, etc.).
+- **`interact`**: Use when the page needs post-scrape browser actions — clicking buttons, filling forms, or executing code in the browser sandbox.
+
+## Search
+
+### Why use it
+
+Search finds pages matching a query across the web, news, or images. Use it for discovery when you don't have a specific URL.
+
+### Preferred SDK method
+
+```java
+client.search(query)
+client.search(query, options)
+```
+
+### Example
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+import com.firecrawl.client.SearchOptions;
+import com.firecrawl.client.SearchData;
+
+FirecrawlClient client = FirecrawlClient.fromEnv();
+
+SearchData results = client.search("firecrawl web scraping API",
+    SearchOptions.builder()
+        .limit(5)
+        .build()
+);
+
+for (Map<String, Object> item : results.getWeb()) {
+    System.out.println(item.get("title") + ": " + item.get("url"));
+}
+```
+
+### Parameters
+
+`SearchOptions` fields (all nullable, built via `SearchOptions.builder()`):
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `sources` | `List<Object>` | Which result buckets: `"web"`, `"news"`, `"images"` as strings or `{type: "web"}` maps. Default: `["web"]`. |
+| `categories` | `List<Object>` | Filter by category: `"github"`, `"research"`, `"pdf"`. |
+| `includeDomains` | `List<String>` | Restrict results to these domains. Mutually exclusive with `excludeDomains`. |
+| `excludeDomains` | `List<String>` | Exclude results from these domains. Mutually exclusive with `includeDomains`. |
+| `limit` | `Integer` | Max results to return. Server default: 10, max: 100. |
+| `tbs` | `String` | Time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `String` | Location for search results. |
+| `country` | `String` | ISO country code for geo-targeting (e.g. `"us"`). Default: `"US"`. |
+| `ignoreInvalidURLs` | `Boolean` | Skip invalid URLs. Default: `false`. |
+| `timeout` | `Integer` | Timeout in milliseconds. Default: `60000`. |
+| `highlights` | `Boolean` | Generate query-relevant highlights. Default: `true`. |
+| `scrapeOptions` | `ScrapeOptions` | Options for scraping each result page. See Scrape parameters. |
+| `integration` | `String` | Integration identifier. |
+
+**Async variant**: `client.searchAsync(query, options)` returns `CompletableFuture<SearchData>`.
+
+## Scrape
+
+### Why use it
+
+Scrape fetches and processes a single URL. Returns markdown, HTML, structured JSON, screenshots, and more. Use it when you have a specific page to extract content from.
+
+### Preferred SDK method
+
+```java
+client.scrape(url)
+client.scrape(url, options)
+```
+
+### Example
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+import com.firecrawl.client.ScrapeOptions;
+import com.firecrawl.client.Document;
+
+FirecrawlClient client = FirecrawlClient.fromEnv();
+
+Document doc = client.scrape("https://example.com",
+    ScrapeOptions.builder()
+        .formats(List.of("markdown", "links"))
+        .build()
+);
+
+System.out.println(doc.getMarkdown());
+```
+
+### Parameters
+
+`ScrapeOptions` fields (all nullable, built via `ScrapeOptions.builder()`):
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `formats` | `List<Object>` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`. Also accepts typed objects like `JsonFormat`, `QuestionFormat`, `HighlightsFormat`. Default: `["markdown"]`. |
+| `headers` | `Map<String, String>` | Custom HTTP headers. |
+| `includeTags` | `List<String>` | Only include content from these HTML tags. |
+| `excludeTags` | `List<String>` | Exclude content from these HTML tags. |
+| `onlyMainContent` | `Boolean` | Only return main content. Default: `true`. |
+| `timeout` | `Integer` | Timeout in milliseconds (1000–300000). Default: `60000`. |
+| `waitFor` | `Integer` | Wait time in ms before scraping. Default: `0`. |
+| `mobile` | `Boolean` | Emulate a mobile device. Default: `false`. |
+| `parsers` | `List<Object>` | File processing controls: `"pdf"` or `PdfParser` config. Default: `["pdf"]`. |
+| `actions` | `List<Map<String, Object>>` | Browser actions to execute before/during scraping. |
+| `location` | `LocationConfig` | Geolocation: `country` (String), `languages` (List). |
+| `skipTlsVerification` | `Boolean` | Skip TLS verification. Default: `true`. |
+| `removeBase64Images` | `Boolean` | Remove base64 images from markdown. Default: `true`. |
+| `blockAds` | `Boolean` | Block ads and cookie popups. Default: `true`. |
+| `proxy` | `String` | Proxy type: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. Default: `"auto"`. |
+| `maxAge` | `Long` | Max cache age in ms. `0` bypasses cache. Default: `172800000` (2 days). |
+| `storeInCache` | `Boolean` | Cache the result. Default: `true`. |
+| `lockdown` | `Boolean` | Serve only cached results. Default: `false`. |
+| `redactPII` | `Boolean` | Redact PII. Default: `false`. |
+| `auditMetadata` | `AuditMetadata` | SIEM logging attribution: `username` (String). |
+| `integration` | `String` | Integration identifier. |
+
+**Async variant**: `client.scrapeAsync(url, options)` returns `CompletableFuture<Document>`.
+
+## Interact
+
+### Why use it
+
+Interact lets you execute code in the browser sandbox tied to a scrape job. Use it for post-scrape actions: clicking buttons, filling forms, running JavaScript, or using a natural-language prompt to control the browser.
+
+### Preferred SDK method
+
+```java
+client.interact(jobId, code)
+client.interact(jobId, code, language, timeout)
+client.interact(jobId, code, language, timeout, origin)
+```
+
+### Example
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+import com.firecrawl.client.BrowserExecuteResponse;
+
+FirecrawlClient client = FirecrawlClient.fromEnv();
+
+// Execute code in the browser
+BrowserExecuteResponse result = client.interact(
+    "job-id-from-scrape",
+    "document.title",
+    "node",
+    30
+);
+
+System.out.println(result.getResult());
+
+// Stop the session when done
+client.stopInteractiveBrowser("job-id-from-scrape");
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `jobId` | `String` | **Required.** The scrape job ID. |
+| `code` | `String` | **Required.** Code to execute in the browser sandbox (1–100000 chars). |
+| `language` | `String` | Language: `"python"`, `"node"`, `"bash"`. Default: `"node"`. |
+| `timeout` | `Integer` | Execution timeout in seconds (1–300). Default: `30`. |
+| `origin` | `String` | Optional origin label for telemetry. |
+
+**Async variants**: `client.interactAsync(...)` returns `CompletableFuture<BrowserExecuteResponse>`.
+
+**Stop session**: `client.stopInteractiveBrowser(jobId)` returns `BrowserDeleteResponse` with `success`, `sessionDurationMs`, `creditsBilled`, `error`.
+
+## Notes
+
+- **camelCase parameters**: All parameter names use camelCase (e.g. `includeDomains`, `onlyMainContent`).
+- **Builder pattern**: `ScrapeOptions` and `SearchOptions` use builders. `ScrapeOptions` has a `toBuilder()` method for copy-modify.
+- **Untyped search results**: `SearchData` returns `List<Map<String, Object>>` for `web`, `news`, and `images` — not typed models.
+- **`interact` has no prompt parameter**: Unlike the Node.js and Python SDKs, the Java SDK's `interact` method only accepts `code`, not `prompt`. Use the `code` parameter with JavaScript to achieve browser automation.
+- **SDK origin tag**: Every request automatically includes `"origin": "java-sdk@1.18.0"` in the body.
+- **API key resolution order**: explicit `.apiKey()` > `FIRECRAWL_API_KEY` env > `firecrawl.apiKey` system property.
+- **Deprecated aliases**: `scrapeExecute` → `interact`, `deleteScrapeBrowser` → `stopInteractiveBrowser`. Use the preferred names.
+
+## Source Of Truth
+
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
+- `firecrawl/apps/java-sdk/build.gradle.kts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/node.mdx
+++ b/agent-quickstart/node.mdx
@@ -1,0 +1,207 @@
+---
+title: "Node.js Agent Quickstart"
+description: "Canonical Firecrawl Node.js/TypeScript quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Node.js Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl using JavaScript or TypeScript. It is generated from SDK source (`@mendable/firecrawl-js` v4.39.0) and the Firecrawl OpenAPI spec.
+
+## Install
+
+```bash
+npm install @mendable/firecrawl-js
+```
+
+## Authenticate
+
+```typescript
+import Firecrawl from "@mendable/firecrawl-js";
+
+const app = new Firecrawl("fc-YOUR_API_KEY");
+
+// Or use an options object:
+const app = new Firecrawl({
+  apiKey: "fc-YOUR_API_KEY",  // falls back to FIRECRAWL_API_KEY env var
+  apiUrl: "https://api.firecrawl.dev", // falls back to FIRECRAWL_API_URL env var
+});
+
+// Keyless free tier (rate-limited per IP):
+const app = new Firecrawl();
+```
+
+## When To Use What
+
+- **`search`**: Use when you start with a query and need to discover relevant pages. Returns search results across web, news, and images. Optionally scrapes each result page.
+- **`scrape`**: Use when you already have a URL and want page content (markdown, HTML, structured data, screenshots, etc.).
+- **`interact`**: Use when the page needs post-scrape browser actions — clicking buttons, filling forms, or executing code in the browser sandbox.
+
+## Search
+
+### Why use it
+
+Search finds pages matching a query across the web, news, or images. Use it for discovery when you don't have a specific URL.
+
+### Preferred SDK method
+
+```typescript
+app.search(query, options?)
+```
+
+### Example
+
+```typescript
+const results = await app.search("firecrawl web scraping API", {
+  limit: 5,
+  scrapeOptions: {
+    formats: ["markdown"],
+  },
+});
+
+// Results are grouped by source type
+for (const item of results.web ?? []) {
+  console.log(item.title, item.url);
+}
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` | `string` | **Required.** The search query (max 500 chars). |
+| `limit` | `number` | Max results to return. Server default: 10. |
+| `sources` | `Array<"web" \| "news" \| "images" \| { type: ... }>` | Which result buckets to request. Default: `["web"]`. |
+| `categories` | `Array<"github" \| "research" \| "pdf" \| "developer">` | Filter by content category. `"developer"` cannot combine with others. |
+| `includeDomains` | `string[]` | Restrict results to these domains. Mutually exclusive with `excludeDomains`. |
+| `excludeDomains` | `string[]` | Exclude results from these domains. Mutually exclusive with `includeDomains`. |
+| `tbs` | `string` | Time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `string` | Location for search results (e.g. `"San Francisco,California,United States"`). |
+| `country` | `string` | ISO country code for geo-targeting (e.g. `"US"`). Default: `"US"`. |
+| `ignoreInvalidURLs` | `boolean` | Skip invalid URLs instead of failing. Default: `false`. |
+| `timeout` | `number` | Timeout in milliseconds. Default: `60000`. |
+| `highlights` | `boolean` | Generate query-relevant highlights. Default: `true`. |
+| `scrapeOptions` | `ScrapeOptions` | Options for scraping each result page. See Scrape parameters. |
+| `enterprise` | `Array<"default" \| "anon" \| "zdr">` | Enterprise options for zero data retention or anonymized search. |
+| `threatProtection` | `ThreatProtectionOptions` | Enterprise per-request threat protection override. |
+| `integration` | `string` | Integration identifier. |
+
+## Scrape
+
+### Why use it
+
+Scrape fetches and processes a single URL. Returns markdown, HTML, structured JSON, screenshots, and more. Use it when you have a specific page to extract content from.
+
+### Preferred SDK method
+
+```typescript
+app.scrape(url, options?)
+```
+
+### Example
+
+```typescript
+const doc = await app.scrape("https://example.com", {
+  formats: ["markdown", "links"],
+});
+
+console.log(doc.markdown);
+console.log(doc.links);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `url` | `string` | **Required.** The URL to scrape. |
+| `formats` | `FormatOption[]` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"changeTracking"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`. Also accepts typed objects like `JsonFormat`, `ScreenshotFormat`, `QuestionFormat`, `HighlightsFormat`. Default: `["markdown"]`. |
+| `headers` | `Record<string, string>` | Custom HTTP headers for the request. |
+| `includeTags` | `string[]` | Only include content from these HTML tags. |
+| `excludeTags` | `string[]` | Exclude content from these HTML tags. |
+| `onlyMainContent` | `boolean` | Only return main content, excluding headers/navs/footers. Default: `true`. |
+| `timeout` | `number` | Timeout in milliseconds (1000–300000). Default: `60000`. |
+| `waitFor` | `number` | Wait time in ms before scraping (for JS rendering). Default: `0`. |
+| `mobile` | `boolean` | Emulate a mobile device. Default: `false`. |
+| `parsers` | `Array<string \| PDFParser>` | File processing controls. Default: `["pdf"]`. |
+| `actions` | `ActionOption[]` | Browser actions to execute: `wait`, `screenshot`, `click`, `write`, `press`, `scroll`, `scrape`, `executeJavascript`, `pdf`. |
+| `location` | `{ country?: string, languages?: string[] }` | Geolocation settings. |
+| `skipTlsVerification` | `boolean` | Skip TLS certificate verification. Default: `true`. |
+| `removeBase64Images` | `boolean` | Remove base64 images from markdown. Default: `true`. |
+| `fastMode` | `boolean` | Enable fast mode. |
+| `blockAds` | `boolean` | Block ads and cookie popups. Default: `true`. |
+| `proxy` | `"basic" \| "stealth" \| "enhanced" \| "auto"` | Proxy type. Default: `"auto"`. |
+| `maxAge` | `number` | Use cached result if younger than this (ms). `0` bypasses cache. Default: `172800000` (2 days). |
+| `minAge` | `number` | Cache-only mode; minimum age in ms. |
+| `storeInCache` | `boolean` | Cache the result. Default: `true`. |
+| `lockdown` | `boolean` | Serve only cached results, never make outbound requests. Default: `false`. |
+| `redactPII` | `boolean \| RedactPIIOptions` | Redact personally identifiable information. Default: `false`. |
+| `profile` | `{ name: string, saveChanges?: boolean }` | Persistent browser profile. |
+| `auditMetadata` | `{ username: string }` | SIEM logging attribution metadata. |
+| `threatProtection` | `ThreatProtectionOptions` | Enterprise per-request threat protection override. |
+| `autoResume` | `boolean` | SDK-only. On timeout with `processing_continues`, SDK retries up to 5 times / 20 min. Default: `true`. Not sent to API. |
+| `integration` | `string` | Integration identifier. |
+
+## Interact
+
+### Why use it
+
+Interact lets you execute code in the browser sandbox tied to a scrape job. Use it for post-scrape actions: clicking buttons, filling forms, running JavaScript, or using a natural-language prompt to control the browser.
+
+### Preferred SDK method
+
+```typescript
+app.interact(jobId, args)
+```
+
+### Example
+
+```typescript
+// First, scrape a page with actions to get a jobId
+const doc = await app.scrape("https://example.com", {
+  formats: ["markdown"],
+});
+const jobId = doc.metadata?.jobId;
+
+// Execute code in the browser
+const result = await app.interact(jobId, {
+  code: "document.title",
+  language: "node",
+  timeout: 30,
+});
+
+console.log(result.result);
+
+// Or use a natural-language prompt
+const result2 = await app.interact(jobId, {
+  prompt: "Click the login button and fill in the email field with test@example.com",
+});
+
+// Stop the session when done
+await app.stopInteraction(jobId);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `jobId` | `string` | **Required.** The scrape job ID (from `metadata.jobId` on a scrape response). |
+| `code` | `string` | Code to execute in the browser sandbox (1–100000 chars). Required if no `prompt`. |
+| `prompt` | `string` | Natural-language instruction for the browser agent. Required if no `code`. |
+| `language` | `"python" \| "node" \| "bash"` | Language of the code. Default: `"node"`. |
+| `timeout` | `number` | Execution timeout in seconds (1–300). Default: `30`. |
+| `origin` | `string` | Optional origin label for telemetry. |
+
+## Notes
+
+- **camelCase parameters**: All parameter names use camelCase (e.g. `includeDomains`, `onlyMainContent`).
+- **`SearchData.data` trap**: Accessing `.data` on search results throws an error. Use `.web`, `.news`, or `.images` instead.
+- **Zod schema support**: When using `JsonFormat` with a Zod schema in scrape, the return type's `.json` field is automatically narrowed to the inferred Zod type.
+- **`autoResume`**: SDK-only feature (default `true`). Automatically retries scrape requests that time out while still processing. Set `false` to surface timeouts immediately.
+- **Sparse serialization**: Only non-null/non-undefined fields are sent in requests.
+- **Deprecated aliases**: `scrapeExecute` → `interact`, `stopInteractiveBrowser`/`deleteScrapeBrowser` → `stopInteraction`. Use the preferred names.
+
+## Source Of Truth
+
+- `firecrawl/apps/js-sdk/firecrawl/src/index.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/python.mdx
+++ b/agent-quickstart/python.mdx
@@ -1,0 +1,213 @@
+---
+title: "Python Agent Quickstart"
+description: "Canonical Firecrawl Python quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Python Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl using Python. It is generated from SDK source (`firecrawl-py`) and the Firecrawl OpenAPI spec.
+
+## Install
+
+```bash
+pip install firecrawl-py
+```
+
+Requires Python >= 3.8 and pydantic >= 2.0.
+
+## Authenticate
+
+```python
+from firecrawl import Firecrawl
+
+app = Firecrawl(api_key="fc-YOUR_API_KEY")
+
+# Or use environment variable FIRECRAWL_API_KEY:
+app = Firecrawl()
+
+# Async client:
+from firecrawl import AsyncFirecrawl
+app = AsyncFirecrawl(api_key="fc-YOUR_API_KEY")
+
+# Full options:
+app = Firecrawl(
+    api_key="fc-YOUR_API_KEY",       # or env FIRECRAWL_API_KEY; None = keyless free tier
+    api_url="https://api.firecrawl.dev",
+    timeout=None,                     # default request timeout in seconds
+    max_retries=3,
+    backoff_factor=0.5,
+)
+```
+
+## When To Use What
+
+- **`search`**: Use when you start with a query and need to discover relevant pages. Returns search results across web, news, and images. Optionally scrapes each result page.
+- **`scrape`**: Use when you already have a URL and want page content (markdown, HTML, structured data, screenshots, etc.).
+- **`interact`**: Use when the page needs post-scrape browser actions — clicking buttons, filling forms, or executing code in the browser sandbox.
+
+## Search
+
+### Why use it
+
+Search finds pages matching a query across the web, news, or images. Use it for discovery when you don't have a specific URL.
+
+### Preferred SDK method
+
+```python
+app.search(query, **kwargs)
+```
+
+### Example
+
+```python
+results = app.search(
+    "firecrawl web scraping API",
+    limit=5,
+    scrape_options=ScrapeOptions(formats=["markdown"]),
+)
+
+for item in results.web or []:
+    print(item.title, item.url)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` | `str` | **Required.** The search query (max 500 chars). |
+| `limit` | `int` | Max results to return. Default: `5` (SDK model default). |
+| `sources` | `list[SourceOption]` | Which result buckets to request: `"web"`, `"news"`, `"images"`. Default: `["web"]`. |
+| `categories` | `list[CategoryOption]` | Filter by content category: `"github"`, `"research"`, `"pdf"`, `"developer"`. |
+| `include_domains` | `list[str]` | Restrict results to these domains. Mutually exclusive with `exclude_domains`. |
+| `exclude_domains` | `list[str]` | Exclude results from these domains. Mutually exclusive with `include_domains`. |
+| `tbs` | `str` | Time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `str` | Location for search results. |
+| `country` | `str` | ISO country code for geo-targeting (e.g. `"US"`). Default: `"US"`. |
+| `ignore_invalid_urls` | `bool` | Skip invalid URLs instead of failing. Default: `false`. |
+| `timeout` | `int` | Timeout in milliseconds. Default: `300000` (SDK model default). |
+| `highlights` | `bool` | Generate query-relevant highlights. Default: `true` (server default). |
+| `scrape_options` | `ScrapeOptions` | Options for scraping each result page. See Scrape parameters. |
+| `enterprise` | `list[str]` | Enterprise options: `["zdr"]` for zero data retention, `["anon"]` for anonymized search. |
+| `threat_protection` | `ThreatProtectionOptions` | Enterprise per-request threat protection override. |
+| `integration` | `str` | Integration identifier. |
+
+## Scrape
+
+### Why use it
+
+Scrape fetches and processes a single URL. Returns markdown, HTML, structured JSON, screenshots, and more. Use it when you have a specific page to extract content from.
+
+### Preferred SDK method
+
+```python
+app.scrape(url, **kwargs)
+```
+
+### Example
+
+```python
+doc = app.scrape(
+    "https://example.com",
+    formats=["markdown", "links"],
+)
+
+print(doc.markdown)
+print(doc.links)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `url` | `str` | **Required.** The URL to scrape. |
+| `formats` | `list[FormatOption]` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"raw_html"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"changeTracking"`, `"change_tracking"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`. Also accepts typed objects like `JsonFormat`, `ScreenshotFormat`, `QuestionFormat`, `HighlightsFormat`. Default: `["markdown"]`. |
+| `headers` | `dict[str, str]` | Custom HTTP headers for the request. |
+| `include_tags` | `list[str]` | Only include content from these HTML tags. |
+| `exclude_tags` | `list[str]` | Exclude content from these HTML tags. |
+| `only_main_content` | `bool` | Only return main content, excluding headers/navs/footers. Default: `true`. |
+| `timeout` | `int` | Timeout in milliseconds (1000–300000). Default: `60000`. |
+| `wait_for` | `int` | Wait time in ms before scraping (for JS rendering). Default: `0`. |
+| `mobile` | `bool` | Emulate a mobile device. Default: `false`. |
+| `parsers` | `list[str \| PDFParser]` | File processing controls. Default: `["pdf"]`. |
+| `actions` | `list[Action]` | Browser actions: `WaitAction`, `ScreenshotAction`, `ClickAction`, `WriteAction`, `PressAction`, `ScrollAction`, `ScrapeAction`, `ExecuteJavascriptAction`, `PDFAction`. |
+| `location` | `Location` | Geolocation settings: `Location(country="US", languages=["en"])`. |
+| `skip_tls_verification` | `bool` | Skip TLS certificate verification. Default: `true`. |
+| `remove_base64_images` | `bool` | Remove base64 images from markdown. Default: `true`. |
+| `fast_mode` | `bool` | Enable fast mode. |
+| `block_ads` | `bool` | Block ads and cookie popups. Default: `true`. |
+| `proxy` | `str` | Proxy type: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. Default: `"auto"`. |
+| `max_age` | `int` | Use cached result if younger than this (ms). `0` bypasses cache. Default: `172800000` (2 days). |
+| `store_in_cache` | `bool` | Cache the result. Default: `true`. |
+| `lockdown` | `bool` | Serve only cached results, never make outbound requests. Default: `false`. |
+| `redact_pii` | `bool` | Redact personally identifiable information. Default: `false`. |
+| `profile` | `dict` | Persistent browser profile: `{"name": "...", "saveChanges": True}`. |
+| `audit_metadata` | `AuditMetadata` | SIEM logging attribution: `AuditMetadata(username="...")`. |
+| `threat_protection` | `ThreatProtectionOptions` | Enterprise per-request threat protection override. |
+| `auto_resume` | `bool` | SDK-only. |
+| `integration` | `str` | Integration identifier. |
+
+## Interact
+
+### Why use it
+
+Interact lets you execute code in the browser sandbox tied to a scrape job. Use it for post-scrape actions: clicking buttons, filling forms, running JavaScript, or using a natural-language prompt to control the browser.
+
+### Preferred SDK method
+
+```python
+app.interact(job_id, code=None, prompt=None, **kwargs)
+```
+
+### Example
+
+```python
+# First, scrape a page to get a job_id
+doc = app.scrape("https://example.com", formats=["markdown"])
+job_id = doc.metadata.job_id  # or doc.metadata["jobId"]
+
+# Execute code in the browser
+result = app.interact(
+    job_id,
+    code="document.title",
+    language="node",
+    timeout=30,
+)
+print(result.result)
+
+# Or use a natural-language prompt
+result = app.interact(
+    job_id,
+    prompt="Click the login button and fill in the email field with test@example.com",
+)
+
+# Stop the session when done
+app.stop_interaction(job_id)
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `job_id` | `str` | **Required.** The scrape job ID (positional). |
+| `code` | `str` | Code to execute in the browser sandbox (1–100000 chars). Required if no `prompt`. |
+| `prompt` | `str` | Natural-language instruction for the browser agent. Required if no `code`. |
+| `language` | `Literal["python", "node", "bash"]` | Language of the code. Default: `"node"`. |
+| `timeout` | `int` | Execution timeout in seconds (1–300). Default: `30`. |
+| `origin` | `str` | Optional origin label for telemetry. |
+
+## Notes
+
+- **snake_case parameters**: All parameter names use snake_case (e.g. `include_domains`, `only_main_content`).
+- **Format string normalization**: Both camelCase (`"rawHtml"`, `"changeTracking"`) and snake_case (`"raw_html"`, `"change_tracking"`) format strings are accepted.
+- **`SearchData.data` trap**: Accessing `.data` on search results raises `AttributeError`. Use `.web`, `.news`, or `.images` instead.
+- **`include_domains` / `exclude_domains` are mutually exclusive**: Passing both raises `ValueError`.
+- **Pydantic v2**: The SDK uses pydantic >= 2.0. Return types are Pydantic models with typed fields.
+- **Async support**: All methods are available on `AsyncFirecrawl` with the same signatures.
+- **Deprecated aliases**: `scrape_execute` → `interact`, `delete_scrape_browser`/`stop_interactive_browser` → `stop_interaction`, `scrape_url` → `scrape`. Use the preferred names.
+
+## Source Of Truth
+
+- `firecrawl/apps/python-sdk/firecrawl/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/rust.mdx
+++ b/agent-quickstart/rust.mdx
@@ -1,0 +1,232 @@
+---
+title: "Rust Agent Quickstart"
+description: "Canonical Firecrawl Rust quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Rust Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl using Rust. It is generated from SDK source (`firecrawl` crate v2.19.0) and the Firecrawl OpenAPI spec.
+
+## Install
+
+```toml
+# Cargo.toml
+[dependencies]
+firecrawl = "2.19"
+tokio = { version = "1", features = ["full"] }
+```
+
+Or via CLI:
+
+```bash
+cargo add firecrawl
+```
+
+## Authenticate
+
+```rust
+use firecrawl::Client;
+
+// Cloud client (API key required for most endpoints, optional for scrape/search/interact)
+let app = Client::new("fc-YOUR_API_KEY")?;
+
+// Self-hosted instance (key is optional)
+let app = Client::new_selfhosted("https://self-hosted.example/v2", Some("fc-YOUR_API_KEY"))?;
+
+// Keyless free tier (rate-limited per IP)
+let app = Client::new_selfhosted("https://api.firecrawl.dev", None::<String>)?;
+```
+
+## When To Use What
+
+- **`search`**: Use when you start with a query and need to discover relevant pages. Returns search results across web, news, and images. Optionally scrapes each result page.
+- **`scrape`**: Use when you already have a URL and want page content (markdown, HTML, structured data, screenshots, etc.).
+- **`interact`**: Use when the page needs post-scrape browser actions — clicking buttons, filling forms, or executing code in the browser sandbox.
+
+## Search
+
+### Why use it
+
+Search finds pages matching a query across the web, news, or images. Use it for discovery when you don't have a specific URL.
+
+### Preferred SDK method
+
+```rust
+app.search(query, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, SearchOptions, ScrapeOptions};
+
+let app = Client::new("fc-YOUR_API_KEY")?;
+
+let response = app.search("firecrawl web scraping API", SearchOptions {
+    limit: Some(5),
+    scrape_options: Some(ScrapeOptions::default()),
+    ..Default::default()
+}).await?;
+
+for item in response.data.web.unwrap_or_default() {
+    match item {
+        SearchResultOrDocument::SearchResult(r) => println!("{}: {}", r.title, r.url),
+        SearchResultOrDocument::Document(d) => println!("{}", d.markdown.unwrap_or_default()),
+    }
+}
+```
+
+### Parameters
+
+`SearchOptions` fields (all optional, `#[serde(rename_all = "camelCase")]`):
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `limit` | `Option<u32>` | Max results to return. Server default: 10, max: 100. |
+| `sources` | `Option<Vec<SearchSource>>` | Which result buckets: `Web`, `News`, `Images`. Default: `["web"]`. |
+| `categories` | `Option<Vec<SearchCategory>>` | Filter by category: `Github`, `Research`, `Pdf`. |
+| `include_domains` | `Option<Vec<String>>` | Restrict results to these domains. Mutually exclusive with `exclude_domains`. |
+| `exclude_domains` | `Option<Vec<String>>` | Exclude results from these domains. Mutually exclusive with `include_domains`. |
+| `tbs` | `Option<String>` | Time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `Option<String>` | Location for search results. |
+| `country` | `Option<String>` | ISO country code for geo-targeting (e.g. `"US"`). Default: `"US"`. |
+| `ignore_invalid_urls` | `Option<bool>` | Skip invalid URLs. Default: `false`. |
+| `timeout` | `Option<u32>` | Timeout in milliseconds. Default: `60000`. |
+| `highlights` | `Option<bool>` | Generate query-relevant highlights. Default: `true`. |
+| `scrape_options` | `Option<ScrapeOptions>` | Options for scraping each result page. See Scrape parameters. |
+| `integration` | `Option<String>` | Integration identifier. |
+
+**Convenience method**: `app.search_and_scrape(query, limit)` calls search with default scrape options and returns only `Vec<Document>`.
+
+## Scrape
+
+### Why use it
+
+Scrape fetches and processes a single URL. Returns markdown, HTML, structured JSON, screenshots, and more. Use it when you have a specific page to extract content from.
+
+### Preferred SDK method
+
+```rust
+app.scrape(url, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, Format};
+
+let app = Client::new("fc-YOUR_API_KEY")?;
+
+let doc = app.scrape("https://example.com", ScrapeOptions {
+    formats: Some(vec![Format::Markdown, Format::Links]),
+    ..Default::default()
+}).await?;
+
+println!("{}", doc.markdown.unwrap_or_default());
+```
+
+### Parameters
+
+`ScrapeOptions` fields (all optional, `#[serde(rename_all = "camelCase")]`):
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `formats` | `Option<Vec<Format>>` | Output formats: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `ChangeTracking`, `Json`, `Attributes`, `Branding`, `Product`, `Menu`, `Audio`, `Video`, `Question(QuestionFormat)`, `Highlights(HighlightsFormat)`. Default: `["markdown"]`. |
+| `headers` | `Option<HashMap<String, String>>` | Custom HTTP headers. |
+| `include_tags` | `Option<Vec<String>>` | Only include content from these HTML tags. |
+| `exclude_tags` | `Option<Vec<String>>` | Exclude content from these HTML tags. |
+| `only_main_content` | `Option<bool>` | Only return main content. Default: `true`. |
+| `timeout` | `Option<u32>` | Timeout in milliseconds (1000–300000). Default: `60000`. |
+| `wait_for` | `Option<u32>` | Wait time in ms before scraping. Default: `0`. |
+| `mobile` | `Option<bool>` | Emulate a mobile device. Default: `false`. |
+| `parsers` | `Option<Vec<ParserConfig>>` | File processing: `Simple(String)` or `Pdf { ... }`. Default: `["pdf"]`. |
+| `actions` | `Option<Vec<Action>>` | Browser actions to execute. |
+| `location` | `Option<LocationConfig>` | Geolocation: `{ country, languages }`. |
+| `skip_tls_verification` | `Option<bool>` | Skip TLS verification. Default: `true`. |
+| `remove_base64_images` | `Option<bool>` | Remove base64 images from markdown. Default: `true`. |
+| `fast_mode` | `Option<bool>` | Enable fast mode. |
+| `block_ads` | `Option<bool>` | Block ads and cookie popups. Default: `true`. |
+| `proxy` | `Option<ProxyType>` | Proxy type: `Basic`, `Stealth`, `Enhanced`, `Auto`. Default: `Auto`. |
+| `max_age` | `Option<u32>` | Max cache age in seconds. |
+| `min_age` | `Option<u32>` | Min cache age in seconds. |
+| `store_in_cache` | `Option<bool>` | Cache the result. Default: `true`. |
+| `lockdown` | `Option<bool>` | Serve only cached results. Default: `false`. |
+| `redact_pii` | `Option<bool>` | Redact PII. Default: `false`. Serialized as `"redactPII"`. |
+| `profile` | `Option<ProfileConfig>` | Persistent browser profile: `{ name, save_changes }`. |
+| `audit_metadata` | `Option<AuditMetadata>` | SIEM logging attribution. |
+| `json_options` | `Option<JsonOptions>` | JSON extraction: `{ schema, system_prompt, prompt, check_prompt_injection }`. |
+| `screenshot_options` | `Option<ScreenshotOptions>` | Screenshot config: `{ full_page, quality, viewport }`. |
+| `change_tracking_options` | `Option<ChangeTrackingOptions>` | Change tracking: `{ modes, schema, prompt, tag }`. |
+| `attribute_selectors` | `Option<Vec<AttributeSelector>>` | Attribute extraction: `{ selector, attribute }`. |
+| `integration` | `Option<String>` | Integration identifier. |
+
+**Convenience method**: `app.scrape_with_schema(url, schema, prompt)` scrapes with JSON extraction and returns `serde_json::Value`.
+
+## Interact
+
+### Why use it
+
+Interact lets you execute code in the browser sandbox tied to a scrape job. Use it for post-scrape actions: clicking buttons, filling forms, running JavaScript, or using a natural-language prompt to control the browser.
+
+### Preferred SDK method
+
+```rust
+app.interact(job_id, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeExecuteOptions, ScrapeExecuteLanguage};
+
+let app = Client::new("fc-YOUR_API_KEY")?;
+
+// Execute code in the browser
+let result = app.interact("job-id-from-scrape", ScrapeExecuteOptions {
+    code: Some("document.title".to_string()),
+    language: Some(ScrapeExecuteLanguage::Node),
+    timeout: Some(30),
+    ..Default::default()
+}).await?;
+
+println!("{}", result.result.unwrap_or_default());
+
+// Or use a natural-language prompt
+let result = app.interact("job-id-from-scrape", ScrapeExecuteOptions {
+    prompt: Some("Click the login button".to_string()),
+    ..Default::default()
+}).await?;
+
+// Stop the session when done
+app.stop_interaction("job-id-from-scrape").await?;
+```
+
+### Parameters
+
+`ScrapeExecuteOptions` fields (`#[serde(rename_all = "camelCase")]`):
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `code` | `Option<String>` | Code to execute in the browser sandbox (1–100000 chars). Required if no `prompt`. |
+| `prompt` | `Option<String>` | Natural-language instruction for the browser agent. Required if no `code`. |
+| `language` | `Option<ScrapeExecuteLanguage>` | Language: `Python`, `Node`, `Bash`. Default: `Node`. |
+| `timeout` | `Option<u32>` | Execution timeout in seconds (1–300). Default: `30`. |
+
+At least one of `code` or `prompt` must be provided, otherwise the SDK returns `FirecrawlError::Misuse`.
+
+## Notes
+
+- **snake_case fields**: All struct fields use snake_case in Rust. They are serialized to camelCase for the API via `#[serde(rename_all = "camelCase")]`.
+- **`impl Into<Option<T>>` pattern**: `scrape` and `search` accept `None`, the options struct directly, or `Some(options)`. `interact` requires `ScrapeExecuteOptions` (not optional).
+- **`origin` auto-injection**: All endpoints automatically set `origin` to `"rust-sdk@{version}"` if not provided by the caller.
+- **`None` fields skipped**: All `Option::None` fields are omitted from the JSON body, not sent as `null`.
+- **`SearchResultOrDocument`**: Web search results may be either `SearchResultWeb` or `Document` depending on whether scrape options were used.
+- **Deprecated aliases**: `scrape_execute` → `interact`, `stop_interactive_browser`/`delete_scrape_browser` → `stop_interaction`. Use the preferred names.
+
+## Source Of Truth
+
+- `firecrawl/apps/rust-sdk/src/scrape.rs`
+- `firecrawl/apps/rust-sdk/src/search.rs`
+- `firecrawl/apps/rust-sdk/src/client.rs`
+- `firecrawl/apps/rust-sdk/Cargo.toml`
+- `firecrawl-docs/api-reference/v2-openapi.json`


### PR DESCRIPTION
## Summary

- Adds canonical agent quickstart documents for **Node.js**, **Python**, **Rust**, **Java**, and **Elixir** in `agent-quickstart/`
- Each file covers `search`, `scrape`, and `interact` endpoints with install instructions, auth patterns, SDK method names, realistic examples, and every confirmed parameter with descriptions
- Generated from SDK source code and the OpenAPI spec as the source of truth — no parameters or methods were invented

## Files

| File | SDK Source | SDK Version |
|------|-----------|-------------|
| `agent-quickstart/node.mdx` | `@mendable/firecrawl-js` | 4.39.0 |
| `agent-quickstart/python.mdx` | `firecrawl-py` | latest |
| `agent-quickstart/rust.mdx` | `firecrawl` crate | 2.19.0 |
| `agent-quickstart/java.mdx` | `firecrawl-java` | 1.18.0 |
| `agent-quickstart/elixir.mdx` | `:firecrawl` | 1.11.0 |

## Structure per file

Each quickstart follows an identical structure:
1. Install command
2. Auth / initialization pattern
3. When To Use What (search vs scrape vs interact)
4. Search — why, method name, example, full parameter table
5. Scrape — why, method name, example, full parameter table
6. Interact — why, method name, example, full parameter table
7. Language-specific notes (naming conventions, deprecated aliases, quirks)
8. Source of truth references

## Test plan

- [ ] Verify each `.mdx` file renders cleanly in Mintlify
- [ ] Spot-check parameter tables against SDK source
- [ ] Confirm examples use preferred (non-deprecated) method names

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1Z6pcygGy33PrRH2VqWLn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1Z6pcygGy33PrRH2VqWLn)_