### PR TITLE
docs: document includePaths/excludePaths limits and regex syntax

### DIFF
--- a/advanced-scraping-guide.mdx
+++ b/advanced-scraping-guide.mdx
@@ -596,6 +596,8 @@ When using the `/v2/crawl` endpoint, you can customize crawling behavior with th
 The starting URL is also checked against `includePaths`. If it does not match any of the patterns, the crawl may return 0 pages.
 </Warning>
 
+Patterns use Rust regex (RE2-style) syntax, so look-around and backreferences are not supported; a pattern that does not compile is rejected with a `400`. Each field accepts at most 1000 patterns of at most 2000 characters each, and `includePaths` and `excludePaths` together may contain at most 1000 patterns and 100,000 characters. For keyword-based filtering, send one short pattern per term instead of combining terms into a single long alternation.
+
 #### Crawl scope
 
 | Parameter | Type | Default | Description |

--- a/api-reference/v1-openapi.json
+++ b/api-reference/v1-openapi.json
@@ -755,17 +755,21 @@
                   },
                   "excludePaths": {
                     "type": "array",
+                    "maxItems": 1000,
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 2000
                     },
-                    "description": "URL pathname regex patterns that exclude matching URLs from the crawl. For example, if you set \"excludePaths\": [\"blog/.*\"] for the base URL firecrawl.dev, any results matching that pattern will be excluded, such as https://www.firecrawl.dev/blog/firecrawl-launch-week-1-recap."
+                    "description": "URL pathname regex patterns that exclude matching URLs from the crawl. For example, if you set \"excludePaths\": [\"blog/.*\"] for the base URL firecrawl.dev, any results matching that pattern will be excluded, such as https://www.firecrawl.dev/blog/firecrawl-launch-week-1-recap. Patterns use Rust regex (RE2-style) syntax: look-around and backreferences are not supported, and a pattern that does not compile is rejected with a 400. Each field accepts at most 1000 patterns of at most 2000 characters each, and includePaths and excludePaths together may contain at most 1000 patterns and 100,000 characters in total. For keyword-style filtering, send one short pattern per term rather than combining terms into a single long alternation."
                   },
                   "includePaths": {
                     "type": "array",
+                    "maxItems": 1000,
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 2000
                     },
-                    "description": "URL pathname regex patterns that include matching URLs in the crawl. Only the paths that match the specified patterns will be included in the response. For example, if you set \"includePaths\": [\"blog/.*\"] for the base URL firecrawl.dev, only results matching that pattern will be included, such as https://www.firecrawl.dev/blog/firecrawl-launch-week-1-recap."
+                    "description": "URL pathname regex patterns that include matching URLs in the crawl. Only the paths that match the specified patterns will be included in the response. For example, if you set \"includePaths\": [\"blog/.*\"] for the base URL firecrawl.dev, only results matching that pattern will be included, such as https://www.firecrawl.dev/blog/firecrawl-launch-week-1-recap. Patterns use Rust regex (RE2-style) syntax: look-around and backreferences are not supported, and a pattern that does not compile is rejected with a 400. Each field accepts at most 1000 patterns of at most 2000 characters each, and includePaths and excludePaths together may contain at most 1000 patterns and 100,000 characters in total. For keyword-style filtering, send one short pattern per term rather than combining terms into a single long alternation."
                   },
                   "regexOnFullURL": {
                     "type": "boolean",

--- a/api-reference/v2-openapi.json
+++ b/api-reference/v2-openapi.json
@@ -1743,17 +1743,21 @@
                   },
                   "excludePaths": {
                     "type": "array",
+                    "maxItems": 1000,
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 2000
                     },
-                    "description": "URL pathname regex patterns that exclude matching URLs from the crawl. For example, if you set \"excludePaths\": [\"blog/.*\"] for the base URL firecrawl.dev, any results matching that pattern will be excluded, such as https://www.firecrawl.dev/blog/firecrawl-launch-week-1-recap."
+                    "description": "URL pathname regex patterns that exclude matching URLs from the crawl. For example, if you set \"excludePaths\": [\"blog/.*\"] for the base URL firecrawl.dev, any results matching that pattern will be excluded, such as https://www.firecrawl.dev/blog/firecrawl-launch-week-1-recap. Patterns use Rust regex (RE2-style) syntax: look-around and backreferences are not supported, and a pattern that does not compile is rejected with a 400. Each field accepts at most 1000 patterns of at most 2000 characters each, and includePaths and excludePaths together may contain at most 1000 patterns and 100,000 characters in total. For keyword-style filtering, send one short pattern per term rather than combining terms into a single long alternation."
                   },
                   "includePaths": {
                     "type": "array",
+                    "maxItems": 1000,
                     "items": {
-                      "type": "string"
+                      "type": "string",
+                      "maxLength": 2000
                     },
-                    "description": "URL pathname regex patterns that include matching URLs in the crawl. Only the paths that match the specified patterns will be included in the response. Note: the starting URL is also checked against these patterns — if it does not match, the crawl may return 0 pages. For example, if you set \"includePaths\": [\"blog/.*\"] for the base URL firecrawl.dev/blog, only pages under /blog/ will be included in the results, such as https://www.firecrawl.dev/blog/firecrawl-launch-week-1-recap."
+                    "description": "URL pathname regex patterns that include matching URLs in the crawl. Only the paths that match the specified patterns will be included in the response. Note: the starting URL is also checked against these patterns — if it does not match, the crawl may return 0 pages. For example, if you set \"includePaths\": [\"blog/.*\"] for the base URL firecrawl.dev/blog, only pages under /blog/ will be included in the results, such as https://www.firecrawl.dev/blog/firecrawl-launch-week-1-recap. Patterns use Rust regex (RE2-style) syntax: look-around and backreferences are not supported, and a pattern that does not compile is rejected with a 400. Each field accepts at most 1000 patterns of at most 2000 characters each, and includePaths and excludePaths together may contain at most 1000 patterns and 100,000 characters in total. For keyword-style filtering, send one short pattern per term rather than combining terms into a single long alternation."
                   },
                   "maxDiscoveryDepth": {
                     "type": "integer",

--- a/features/crawl.mdx
+++ b/features/crawl.mdx
@@ -301,6 +301,7 @@ Coverage is bounded by the scope parameters you set, all documented in the [conf
 
 - **Children only by default.** Crawl ignores sublinks that are not children of the URL you provide. Use `crawlEntireDomain` for sibling and parent paths, `allowSubdomains` for subdomains, and `allowExternalLinks` to follow links off the domain.
 - **`includePaths` / `excludePaths` match the URL pathname**, as regex patterns — not the full URL, and not query parameters. Set `regexOnFullURL: true` to match against the full URL including query strings instead. The starting URL is also checked against `includePaths`: if it does not match, the crawl may return 0 pages.
+- **Path patterns are Rust regex (RE2-style) and are validated up front.** Look-around and backreferences are not supported, and a pattern that does not compile is rejected with a `400` instead of being silently ignored. Each field accepts at most 1000 patterns of at most 2000 characters each, and `includePaths` and `excludePaths` together may contain at most 1000 patterns and 100,000 characters. For keyword-style filtering, send one short pattern per term (`["pricing", "docs", "blog"]`) rather than combining terms into one long alternation.
 - **Sitemap mode.** With the default `sitemap: "include"`, URLs come from the sitemap plus recursive link discovery. `"skip"` uses HTML links only, so sitemap-only pages such as PDFs or deeply nested pages are missed. `"only"` crawls the sitemap plus the start URL and does not discover links from HTML.
 - **`maxDiscoveryDepth`** caps how many link-discovery hops from the root are followed. Pages at the maximum depth are still scraped, but links found on them are not followed.
 - **`limit`** caps the number of pages, and defaults to `10000`.
@@ -331,8 +332,8 @@ The full set of parameters available when submitting a crawl job:
 | `url` | `string` | (required) | The starting URL to crawl from |
 | `limit` | `integer` | `10000` | Maximum number of pages to crawl |
 | `maxDiscoveryDepth` | `integer` | (none) | Maximum depth from the root URL based on link-discovery hops, not the number of `/` segments in the URL. Each time a new URL is found on a page, it is assigned a depth one higher than the page it was discovered on. The root site and sitemapped pages have a discovery depth of 0. Pages at the max depth are still scraped, but links on them are not followed. |
-| `includePaths` | `string[]` | (none) | URL pathname regex patterns to include. Only matching paths are crawled. |
-| `excludePaths` | `string[]` | (none) | URL pathname regex patterns to exclude from the crawl |
+| `includePaths` | `string[]` | (none) | URL pathname regex patterns to include. Only matching paths are crawled. At most 1000 patterns of 2000 characters each; see [scope](#what-the-crawler-is-scoped-to-reach) for the combined limit and regex syntax. |
+| `excludePaths` | `string[]` | (none) | URL pathname regex patterns to exclude from the crawl. Same limits as `includePaths`. |
 | `regexOnFullURL` | `boolean` | `false` | Match `includePaths`/`excludePaths` against the full URL (including query parameters) instead of just the pathname |
 | `crawlEntireDomain` | `boolean` | `false` | Follow internal links to sibling or parent URLs, not just child paths |
 | `allowSubdomains` | `boolean` | `false` | Follow links to subdomains of the main domain |


### PR DESCRIPTION
## Why

firecrawl/firecrawl#4533 started validating crawl `includePaths` / `excludePaths` up front and introduced caps, and firecrawl/firecrawl#4611 raised and finalized them after a user hit the original 100-pattern cap with a keyword list. The docs did not mention any of this.

## What is now documented

- **Regex flavor**: patterns are Rust regex (RE2-style). Look-around and backreferences are not supported, and a pattern that does not compile returns `400` instead of being silently ignored.
- **Per-field limits**: at most 1000 patterns per field, at most 2000 characters per pattern.
- **Combined limit**: `includePaths` and `excludePaths` together may contain at most 1000 patterns and 100,000 characters.
- **Recommendation**: for keyword-style filtering, send one short pattern per term rather than combining terms into a single long alternation.

## Files

- `api-reference/v2-openapi.json`, `api-reference/v1-openapi.json`: `maxItems: 1000` on both fields, `maxLength: 2000` on items, and the limits appended to the descriptions. JSON validated after the edit.
- `features/crawl.mdx`: new bullet under "What the crawler is scoped to reach" and updated configuration-reference rows.
- `advanced-scraping-guide.mdx`: paragraph after the existing `includePaths` warning.

English source files only; localized copies are managed separately per `CLAUDE.md`. `scripts/check-locale-api-literals.sh` reports the same pre-existing translated identifiers in `fr/` and `pt-BR/` pages on `main` and on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
