### PR TITLE
Expire the /agent and /interact feedback bounty CTAs (studies closed)

### DIFF
--- a/snippets/agent-feedback-cta.mdx
+++ b/snippets/agent-feedback-cta.mdx
@@ -1,24 +1,11 @@
-<div className="firecrawl-cta-box">
+<div className="firecrawl-cta-box" style={{ opacity: 0.6 }}>
   <div style={{ display: "flex", alignItems: "flex-start", gap: "8px", marginBottom: "8px" }}>
-    <Icon icon="sack-dollar" color="#ff4d00" size={22} />
+    <Icon icon="sack-dollar" color="#9ca3af" size={22} />
     <div className="firecrawl-cta-title" style={{ margin: 0 }}>
-      <span style={{ color: "#ff4d00" }}>Bounty: 5,000 credit reward</span>
-      <span style={{ fontWeight: 400 }}> for solid feedback on /agent</span>
+      <span style={{ color: "#9ca3af" }}>Expired: Bounty for /agent feedback</span>
     </div>
   </div>
   <p className="firecrawl-cta-description">
-    To qualify, complete a high-signal interview (thoughtful, concrete use cases, etc) with our Firecrawl Feedback Assistant. Only takes a few minutes, can be stopped at any time, and is both human/agent-friendly (just paste the link into your agentic harness!). Never used /agent? Your take still counts.
-  </p>
-  <a
-    href="https://www.firecrawl.dev/survey/7pjb4?src=docs-agent"
-    className="firecrawl-cta-btn-primary firecrawl-cta-btn-inline"
-  >
-    Start the interview
-  </a>
-  <p
-    className="firecrawl-cta-description"
-    style={{ fontSize: "12px", fontStyle: "italic", margin: "12px 0 0 0" }}
-  >
-    Include your email to be eligible. Interviews are reviewed for quality at the end of each week.
+    All interviewees eligible for the bounty reward have been contacted. Keep an eye on future bounties within our docs!
   </p>
 </div>

--- a/snippets/interact-feedback-cta.mdx
+++ b/snippets/interact-feedback-cta.mdx
@@ -1,24 +1,11 @@
-<div className="firecrawl-cta-box">
+<div className="firecrawl-cta-box" style={{ opacity: 0.6 }}>
   <div style={{ display: "flex", alignItems: "flex-start", gap: "8px", marginBottom: "8px" }}>
-    <Icon icon="sack-dollar" color="#ff4d00" size={22} />
+    <Icon icon="sack-dollar" color="#9ca3af" size={22} />
     <div className="firecrawl-cta-title" style={{ margin: 0 }}>
-      <span style={{ color: "#ff4d00" }}>Bounty: 5,000 credit reward</span>
-      <span style={{ fontWeight: 400 }}> for solid feedback on /interact</span>
+      <span style={{ color: "#9ca3af" }}>Expired: Bounty for /interact feedback</span>
     </div>
   </div>
   <p className="firecrawl-cta-description">
-    To qualify, complete a high-signal interview (thoughtful, concrete use cases, etc) with our Firecrawl Feedback Assistant. Only takes a few minutes, can be stopped at any time, and is both human/agent-friendly (just paste the link into your agentic harness!). Never used /interact? Your take still counts.
-  </p>
-  <a
-    href="https://www.firecrawl.dev/survey/ogu30?src=docs-interact"
-    className="firecrawl-cta-btn-primary firecrawl-cta-btn-inline"
-  >
-    Start the interview
-  </a>
-  <p
-    className="firecrawl-cta-description"
-    style={{ fontSize: "12px", fontStyle: "italic", margin: "12px 0 0 0" }}
-  >
-    Include your email to be eligible. Interviews are reviewed for quality at the end of each week.
+    All interviewees eligible for the bounty reward have been contacted. Keep an eye on future bounties within our docs!
   </p>
 </div>


### PR DESCRIPTION
The /agent (`7pjb4`) and /interact (`ogu30`) interview studies are retired: both surveys are closed in Signal Lab and the final week's rewards are being issued now.

This flips both shared snippets to the dimmed expired card per the CTA convention (stage 1 of the lifecycle):
- `snippets/agent-feedback-cta.mdx`
- `snippets/interact-feedback-cta.mdx`

Imports and render sites (`features/agent.mdx`, `features/interact.mdx`) are untouched so every page updates together. Full removal follows in a later pass, matching the monitoring-CTA precedent. Localized copies sync via locadex.

Related: #1305 (gov/legal CTA removal) is still open from Aug 28 and ready to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)