### PR TITLE
docs: add agent quickstart files for all SDK languages

### DIFF
--- a/agent-quickstart/elixir.mdx
+++ b/agent-quickstart/elixir.mdx
@@ -1,0 +1,222 @@
+---
+title: "Elixir Agent Quickstart"
+description: "Canonical Firecrawl Elixir quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Elixir Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl via the Elixir SDK. It is generated from SDK source and the OpenAPI spec.
+
+## Install
+
+Add to your `mix.exs`:
+
+```elixir
+defp deps do
+  [
+    {:firecrawl, "~> 1.11"}
+  ]
+end
+```
+
+Then run:
+
+```bash
+mix deps.get
+```
+
+## Authenticate
+
+```elixir
+# Set API key in application config
+config :firecrawl, api_key: "fc-YOUR-API-KEY"
+
+# Or pass per-call
+Firecrawl.search_and_scrape([query: "example"], api_key: "fc-YOUR-API-KEY")
+```
+
+Authentication options (passed as the trailing `opts` keyword list on any function call):
+
+| Option | Description |
+|---|---|
+| `api_key` | API key. Falls back to `Application.get_env(:firecrawl, :api_key)`. Omit for keyless free tier. |
+| `base_url` | Base URL. Defaults to `"https://api.firecrawl.dev/v2"`. |
+
+All other opts are passed through to `Req`.
+
+## When To Use What
+
+- **`search_and_scrape`**: Use when you start with a query and need to discover relevant pages across the web.
+- **`scrape_and_extract_from_url`**: Use when you already have a URL and want to extract page content.
+- **`interact_with_scrape_browser_session`**: Use when the page needs clicks, form fills, or post-scrape browser actions via code execution.
+
+## Search
+
+### Why use it
+
+Search finds relevant web pages for a query. Optionally scrapes each result in the same call via `scrape_options`.
+
+### Preferred SDK method
+
+```
+Firecrawl.search_and_scrape(params, opts \\ [])
+```
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.search_and_scrape(
+  query: "firecrawl web scraping",
+  limit: 5,
+  scrape_options: [formats: ["markdown"]]
+)
+
+for result <- response.body["data"]["web"] do
+  IO.puts("#{result["title"]} #{result["url"]}")
+end
+```
+
+### Parameters
+
+All parameters are passed as a keyword list. `query` is required.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `:string` | Required. The search query. |
+| `sources` | `list(any)` | Result verticals: `"web"`, `"news"`, `"images"`. |
+| `categories` | `list(any)` | Narrow search: `"github"`, `"research"`, `"pdf"`. |
+| `include_domains` | `list(string)` | Only return results from these domains. |
+| `exclude_domains` | `list(string)` | Exclude results from these domains. |
+| `limit` | `integer` | Max number of results. |
+| `tbs` | `string` | Time-based search filter (e.g. `"qdr:d"`). |
+| `location` | `string` | Geo-location string. |
+| `country` | `string` | Country code for geo-targeting. |
+| `ignore_invalid_urls` | `boolean` | Skip invalid URLs. |
+| `timeout` | `integer` | Timeout in milliseconds. |
+| `highlights` | `boolean` | Include query-relevant highlights. Default: `true` server-side. |
+| `scrape_options` | `keyword` | Scrape each result with these options (same fields as scrape params). |
+| `enterprise` | `list(string)` | Enterprise features. |
+
+**Returns:** `{:ok, %Req.Response{}}` with JSON body containing `data` with `web`, `news`, `images` arrays.
+
+**Bang variant:** `Firecrawl.search_and_scrape!/2` raises on error.
+
+## Scrape
+
+### Why use it
+
+Scrape extracts content from a single URL in any format: markdown, HTML, structured JSON, screenshots, and more.
+
+### Preferred SDK method
+
+```
+Firecrawl.scrape_and_extract_from_url(params, opts \\ [])
+```
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.scrape_and_extract_from_url(
+  url: "https://example.com",
+  formats: ["markdown", "links"]
+)
+
+IO.puts(response.body["data"]["markdown"])
+```
+
+### Parameters
+
+All parameters are passed as a keyword list. `url` is required.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `:string` | Required. The URL to scrape. |
+| `formats` | `list(any)` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"json"`, `"audio"`, `"video"`, etc. |
+| `headers` | `any` | Custom HTTP headers. |
+| `include_tags` | `list(string)` | CSS selectors to include. |
+| `exclude_tags` | `list(string)` | CSS selectors to exclude. |
+| `only_main_content` | `boolean` | Strip navbars, footers, etc. |
+| `timeout` | `integer` | Timeout in milliseconds. |
+| `wait_for` | `integer` | Wait after page load in milliseconds. |
+| `mobile` | `boolean` | Emulate mobile device. |
+| `parsers` | `list(any)` | Document parsers. |
+| `actions` | `list(any)` | Browser actions (click, type, scroll, etc.). |
+| `location` | `keyword` | Geo-location config. |
+| `skip_tls_verification` | `boolean` | Skip TLS checks. |
+| `remove_base64_images` | `boolean` | Strip base64 images. |
+| `block_ads` | `boolean` | Block ads. |
+| `proxy` | `:basic \| :enhanced \| :auto` | Proxy mode. |
+| `max_age` | `integer` | Cache max age in milliseconds. |
+| `min_age` | `integer` | Cache min age in milliseconds. |
+| `store_in_cache` | `boolean` | Store result in cache. |
+| `lockdown` | `boolean` | Cache-only mode. |
+| `redact_pii` | `boolean` | Redact PII. |
+| `audit_metadata` | `keyword` | Audit metadata (e.g. `username`). |
+| `profile` | `keyword` | Browser profile. |
+| `zero_data_retention` | `boolean` | Enable zero data retention. |
+
+**Returns:** `{:ok, %Req.Response{}}` with JSON body containing `data` with `markdown`, `html`, `links`, etc.
+
+**Bang variant:** `Firecrawl.scrape_and_extract_from_url!/2` raises on error.
+
+## Interact
+
+### Why use it
+
+Interact lets you execute code in a browser session that was started by a scrape. Use it for post-scrape actions like clicking buttons, filling forms, or extracting dynamic content.
+
+### Preferred SDK method
+
+```
+Firecrawl.interact_with_scrape_browser_session(job_id, params, opts \\ [])
+```
+
+### Example
+
+```elixir
+{:ok, response} = Firecrawl.interact_with_scrape_browser_session(
+  "job-id-from-scrape",
+  code: "console.log(await page.url())",
+  language: :node,
+  timeout: 30
+)
+
+IO.puts(response.body["stdout"])
+
+# Stop the session when done
+Firecrawl.stop_interactive_scrape_browser_session("job-id-from-scrape")
+```
+
+### Parameters
+
+`job_id` is the first positional argument. Body parameters are passed as a keyword list.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `String.t()` | Required. The scrape job ID (path parameter). |
+| `code` | `:string` | Required. Code to execute in the browser sandbox. |
+| `language` | `:python \| :node \| :bash` | Runtime language. |
+| `timeout` | `integer` | Execution timeout in seconds. |
+| `origin` | `string` | Request origin tag. |
+
+**Returns:** `{:ok, %Req.Response{}}` with JSON body containing `success`, `stdout`, `result`, `stderr`, `exitCode`, `killed`, `error`.
+
+**Related:** `Firecrawl.stop_interactive_scrape_browser_session(job_id)` ends the browser session.
+
+**Bang variant:** `Firecrawl.interact_with_scrape_browser_session!/3` raises on error.
+
+## Notes
+
+- The Elixir SDK is **auto-generated from the OpenAPI spec**. Function names match the OpenAPI operation IDs in snake_case.
+- All parameters use **snake_case** keys in keyword lists. They are automatically converted to camelCase JSON for the API.
+- The `prompt` parameter (natural-language browser instructions for interact) is not yet available in the Elixir SDK — use the Node.js or Python SDK for prompt-based interaction.
+- There are **no deprecated aliases** in the Elixir SDK.
+- Every function has a bang (`!`) variant that raises `Firecrawl.Error` instead of returning `{:error, ...}`.
+- Returns are raw `Req.Response` structs — access JSON data via `response.body`.
+- An `origin` field (`"elixir-sdk@{version}"`) is auto-injected into every request body.
+
+## Source Of Truth
+
+- `firecrawl/apps/elixir-sdk/lib/firecrawl.ex`
+- `firecrawl/apps/elixir-sdk/mix.exs`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/java.mdx
+++ b/agent-quickstart/java.mdx
@@ -1,0 +1,251 @@
+---
+title: "Java Agent Quickstart"
+description: "Canonical Firecrawl Java quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Java Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl via the Java SDK. It is generated from SDK source and the OpenAPI spec.
+
+## Install
+
+Maven:
+
+```xml
+<dependency>
+  <groupId>com.firecrawl</groupId>
+  <artifactId>firecrawl-java</artifactId>
+  <version>1.18.0</version>
+</dependency>
+```
+
+Gradle:
+
+```groovy
+implementation 'com.firecrawl:firecrawl-java:1.18.0'
+```
+
+Requires Java 11+.
+
+## Authenticate
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+
+// Builder pattern with explicit API key
+FirecrawlClient client = FirecrawlClient.builder()
+    .apiKey("fc-YOUR-API-KEY")
+    .build();
+
+// From environment variable FIRECRAWL_API_KEY or system property firecrawl.apiKey
+FirecrawlClient client = FirecrawlClient.fromEnv();
+```
+
+Builder options:
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `apiKey` | `String` | `null` | API key. `null` for keyless free tier. |
+| `apiUrl` | `String` | `"https://api.firecrawl.dev"` | Base URL. Falls back to `FIRECRAWL_API_URL` env var. |
+| `timeoutMs` | `long` | `300000` | HTTP timeout in milliseconds. |
+| `maxRetries` | `int` | `3` | Max retry attempts. |
+| `backoffFactor` | `double` | `0.5` | Exponential backoff multiplier. |
+| `asyncExecutor` | `Executor` | `ForkJoinPool.commonPool()` | Executor for async methods. |
+| `httpClient` | `OkHttpClient` | Built internally | Custom HTTP client. |
+
+## When To Use What
+
+- **`search`**: Use when you start with a query and need to discover relevant pages across the web.
+- **`scrape`**: Use when you already have a URL and want to extract page content (markdown, HTML, structured data, etc.).
+- **`interact`**: Use when the page needs clicks, form fills, or post-scrape browser actions via code execution.
+
+## Search
+
+### Why use it
+
+Search finds relevant web pages for a query. Optionally scrapes each result in the same call via `scrapeOptions`.
+
+### Preferred SDK method
+
+```
+client.search(query, options)
+```
+
+### Example
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+import com.firecrawl.client.SearchOptions;
+import com.firecrawl.client.SearchData;
+
+FirecrawlClient client = FirecrawlClient.fromEnv();
+
+SearchData results = client.search("firecrawl web scraping",
+    SearchOptions.builder()
+        .limit(5)
+        .build());
+
+for (var result : results.getWeb()) {
+    System.out.println(result.get("title") + " " + result.get("url"));
+}
+```
+
+### Parameters
+
+All `SearchOptions` fields are nullable, set via builder.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `String` | Required (first positional arg). The search query. |
+| `sources` | `List<Object>` | Result verticals: `"web"`, `"news"`, `"images"`. |
+| `categories` | `List<Object>` | Narrow search: `"github"`, `"research"`, `"pdf"`. |
+| `includeDomains` | `List<String>` | Only return results from these domains. |
+| `excludeDomains` | `List<String>` | Exclude results from these domains. |
+| `limit` | `Integer` | Max number of results. |
+| `tbs` | `String` | Time-based search filter (e.g. `"qdr:d"`). |
+| `location` | `String` | Geo-location string. |
+| `country` | `String` | Country code for geo-targeting. |
+| `ignoreInvalidURLs` | `Boolean` | Skip invalid URLs. |
+| `timeout` | `Integer` | Timeout in milliseconds. |
+| `highlights` | `Boolean` | Include query-relevant highlights. Default: `true`. |
+| `scrapeOptions` | `ScrapeOptions` | Scrape each result with these options. |
+| `integration` | `String` | Integration identifier. |
+
+**Returns:** `SearchData` with `getWeb()`, `getNews()`, `getImages()` lists.
+
+**Async:** `client.searchAsync(query, options)` returns `CompletableFuture<SearchData>`.
+
+## Scrape
+
+### Why use it
+
+Scrape extracts content from a single URL in any format: markdown, HTML, structured JSON, screenshots, and more.
+
+### Preferred SDK method
+
+```
+client.scrape(url, options)
+```
+
+### Example
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+import com.firecrawl.client.ScrapeOptions;
+import com.firecrawl.client.Document;
+
+FirecrawlClient client = FirecrawlClient.fromEnv();
+
+Document doc = client.scrape("https://example.com",
+    ScrapeOptions.builder()
+        .formats(List.of("markdown", "links"))
+        .build());
+
+System.out.println(doc.getMarkdown());
+```
+
+### Parameters
+
+All `ScrapeOptions` fields are nullable, set via builder.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `String` | Required (first positional arg). The URL to scrape. |
+| `formats` | `List<Object>` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"screenshot"`, `"json"`, `"audio"`, `"video"`, or format config objects. |
+| `headers` | `Map<String, String>` | Custom HTTP headers. |
+| `includeTags` | `List<String>` | CSS selectors to include. |
+| `excludeTags` | `List<String>` | CSS selectors to exclude. |
+| `onlyMainContent` | `Boolean` | Strip navbars, footers, etc. |
+| `timeout` | `Integer` | Timeout in milliseconds. |
+| `waitFor` | `Integer` | Wait after page load in milliseconds. |
+| `mobile` | `Boolean` | Emulate mobile device. |
+| `parsers` | `List<Object>` | Document parsers. |
+| `actions` | `List<Map<String, Object>>` | Browser actions (click, type, scroll, etc.). |
+| `location` | `LocationConfig` | Geo-location config. |
+| `skipTlsVerification` | `Boolean` | Skip TLS checks. |
+| `removeBase64Images` | `Boolean` | Strip base64 images. |
+| `blockAds` | `Boolean` | Block ads. |
+| `proxy` | `String` | Proxy mode: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. |
+| `maxAge` | `Long` | Cache max age in milliseconds. |
+| `storeInCache` | `Boolean` | Store result in cache. |
+| `lockdown` | `Boolean` | Cache-only mode. |
+| `redactPII` | `Boolean` | Redact PII. |
+| `auditMetadata` | `AuditMetadata` | Audit metadata. |
+| `integration` | `String` | Integration identifier. |
+
+**Returns:** `Document` with `getMarkdown()`, `getHtml()`, `getRawHtml()`, `getJson()`, `getSummary()`, `getMetadata()`, `getLinks()`, `getImages()`, `getScreenshot()`, `getAudio()`, `getVideo()`, `getActions()`, `getWarning()`, `getChangeTracking()`, `getBranding()`, `getProduct()`, `getMenu()`, `getPages()`, `getBlocks()`.
+
+**Async:** `client.scrapeAsync(url, options)` returns `CompletableFuture<Document>`.
+
+## Interact
+
+### Why use it
+
+Interact lets you execute code in a browser session that was started by a scrape. Use it for post-scrape actions like clicking buttons, filling forms, or extracting dynamic content.
+
+### Preferred SDK method
+
+```
+client.interact(jobId, code)
+client.interact(jobId, code, language, timeout)
+client.interact(jobId, code, language, timeout, origin)
+```
+
+### Example
+
+```java
+import com.firecrawl.client.FirecrawlClient;
+import com.firecrawl.client.BrowserExecuteResponse;
+
+FirecrawlClient client = FirecrawlClient.fromEnv();
+
+// Execute code in the browser session
+BrowserExecuteResponse result = client.interact(
+    "job-id-from-scrape",
+    "console.log(await page.url())"
+);
+
+System.out.println(result.getStdout());
+
+// With language and timeout
+BrowserExecuteResponse result2 = client.interact(
+    "job-id-from-scrape",
+    "print(page.url)",
+    "python",
+    60
+);
+
+// Stop the session when done
+client.stopInteractiveBrowser("job-id-from-scrape");
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `jobId` | `String` | Required | The scrape job ID. |
+| `code` | `String` | Required | Code to execute in the browser sandbox. |
+| `language` | `String` | `"node"` | Runtime: `"python"`, `"node"`, or `"bash"`. |
+| `timeout` | `Integer` | `30` | Execution timeout in seconds (1-300). |
+| `origin` | `String` | SDK default | Request origin tag. |
+
+**Returns:** `BrowserExecuteResponse` with `isSuccess()`, `getStdout()`, `getResult()`, `getStderr()`, `getExitCode()`, `isKilled()`, `getError()`.
+
+**Related:** `client.stopInteractiveBrowser(jobId)` ends the browser session.
+
+**Async:** `client.interactAsync(jobId, code, ...)` returns `CompletableFuture<BrowserExecuteResponse>`.
+
+## Notes
+
+- All parameter names use **camelCase** (e.g. `onlyMainContent`, `skipTlsVerification`).
+- The Java SDK's `interact` method takes `code` as a required parameter. The `prompt` parameter (natural-language browser instructions) is not yet available in the Java SDK — use the Node.js or Python SDK for prompt-based interaction.
+- **Deprecated aliases** (use the preferred names instead):
+  - `scrapeExecute()` → `interact()`
+  - `deleteScrapeBrowser()` → `stopInteractiveBrowser()`
+  - `searchGitHub()` → deprecated (sunset 2026-11-03)
+- Every method has a corresponding `*Async` variant returning `CompletableFuture`.
+
+## Source Of Truth
+
+- `firecrawl/apps/java-sdk/src/main/java/com/firecrawl/client/FirecrawlClient.java`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/node.mdx
+++ b/agent-quickstart/node.mdx
@@ -1,0 +1,225 @@
+---
+title: "Node.js Agent Quickstart"
+description: "Canonical Firecrawl Node.js quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Node.js Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl via the Node.js/TypeScript SDK. It is generated from SDK source and the OpenAPI spec.
+
+## Install
+
+```bash
+npm install firecrawl
+```
+
+## Authenticate
+
+```javascript
+import { Firecrawl } from "firecrawl";
+
+// Pass the API key directly
+const app = new Firecrawl({ apiKey: "fc-YOUR-API-KEY" });
+
+// Or set FIRECRAWL_API_KEY and omit it
+const app = new Firecrawl();
+```
+
+Constructor options:
+
+| Option | Type | Description |
+|---|---|---|
+| `apiKey` | `string \| null` | API key. Falls back to `FIRECRAWL_API_KEY` env var. Omit for keyless free tier. |
+| `apiUrl` | `string \| null` | Base URL. Falls back to `FIRECRAWL_API_URL` or `https://api.firecrawl.dev`. |
+| `timeoutMs` | `number` | Default HTTP timeout in milliseconds. |
+| `maxRetries` | `number` | Max retry attempts on transient failures. |
+| `backoffFactor` | `number` | Exponential backoff multiplier. |
+
+## When To Use What
+
+- **`search`**: Use when you start with a query and need to discover relevant pages across the web.
+- **`scrape`**: Use when you already have a URL and want to extract page content (markdown, HTML, structured data, etc.).
+- **`interact`**: Use when the page needs clicks, form fills, or post-scrape browser actions via code or natural language.
+
+## Search
+
+### Why use it
+
+Search finds relevant web pages for a query. Optionally scrapes each result in the same call via `scrapeOptions`.
+
+### Preferred SDK method
+
+```
+app.search(query, options?)
+```
+
+### Example
+
+```javascript
+const results = await app.search("firecrawl web scraping", {
+  limit: 5,
+  scrapeOptions: { formats: ["markdown"] },
+});
+
+for (const result of results.web) {
+  console.log(result.title, result.url);
+}
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `string` | Required. The search query. |
+| `sources` | `Array<"web" \| "news" \| "images">` | Result verticals to include. |
+| `categories` | `Array<"github" \| "research" \| "pdf" \| "developer">` | Narrow web search to specific categories. |
+| `includeDomains` | `string[]` | Only return results from these domains. |
+| `excludeDomains` | `string[]` | Exclude results from these domains. |
+| `limit` | `number` | Max number of results. |
+| `tbs` | `string` | Time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `string` | Geo-location for search results. |
+| `country` | `string` | ISO 3166-1 alpha-2 country code for geo-targeting. |
+| `ignoreInvalidURLs` | `boolean` | Skip invalid URLs instead of failing. |
+| `timeout` | `number` | Timeout in milliseconds. |
+| `highlights` | `boolean` | Include query-relevant text highlights. Default: `true`. |
+| `scrapeOptions` | `ScrapeOptions` | Scrape each result with these options. |
+| `enterprise` | `Array<"default" \| "anon" \| "zdr">` | Enterprise features. |
+| `threatProtection` | `ThreatProtectionOptions` | Threat protection settings. |
+| `integration` | `string` | Integration identifier. |
+| `origin` | `string` | Request origin tag. |
+
+**Returns:** `SearchData` with `.web`, `.news`, and `.images` arrays.
+
+## Scrape
+
+### Why use it
+
+Scrape extracts content from a single URL in any format: markdown, HTML, structured JSON, screenshots, and more.
+
+### Preferred SDK method
+
+```
+app.scrape(url, options?)
+```
+
+### Example
+
+```javascript
+const doc = await app.scrape("https://example.com", {
+  formats: ["markdown", "links"],
+});
+
+console.log(doc.markdown);
+console.log(doc.links);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `string` | Required. The URL to scrape. |
+| `formats` | `FormatOption[]` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`, or rich format objects. |
+| `headers` | `Record<string, string>` | Custom HTTP headers for the request. |
+| `includeTags` | `string[]` | Only include content from elements matching these CSS selectors. |
+| `excludeTags` | `string[]` | Exclude content from elements matching these CSS selectors. |
+| `onlyMainContent` | `boolean` | Strip navbars, footers, etc. and return only main content. |
+| `timeout` | `number` | Timeout in milliseconds. |
+| `waitFor` | `number` | Wait this many milliseconds after page load before extracting. |
+| `mobile` | `boolean` | Emulate a mobile device. |
+| `parsers` | `Array<string \| PDFParser>` | Document parsers (e.g. for PDFs). |
+| `actions` | `ActionOption[]` | Browser actions to execute before scraping (click, type, scroll, etc.). |
+| `location` | `LocationConfig` | Geo-location config with `country` and `languages`. |
+| `skipTlsVerification` | `boolean` | Skip TLS certificate verification. |
+| `removeBase64Images` | `boolean` | Strip base64-encoded images from output. |
+| `fastMode` | `boolean` | Use fast scraping mode (no JS rendering). |
+| `blockAds` | `boolean` | Block ads during scraping. |
+| `proxy` | `"basic" \| "stealth" \| "enhanced" \| "auto" \| string` | Proxy mode. |
+| `maxAge` | `number` | Max cache age in milliseconds. `0` bypasses cache. |
+| `minAge` | `number` | Min cache age in milliseconds. |
+| `storeInCache` | `boolean` | Store the result in cache. |
+| `lockdown` | `boolean` | Only serve cached results, no outbound requests. |
+| `redactPII` | `boolean \| RedactPIIOptions` | Redact personally identifiable information. |
+| `threatProtection` | `ThreatProtectionOptions` | Threat protection settings. |
+| `auditMetadata` | `AuditMetadata` | Audit metadata (e.g. `username`). |
+| `profile` | `{ name: string; saveChanges?: boolean }` | Browser profile for persistent state. |
+| `integration` | `string` | Integration identifier. |
+| `origin` | `string` | Request origin tag. |
+| `autoResume` | `boolean` | Auto-retry server-side processing continuations. SDK-only. |
+
+**Returns:** `Document` with fields like `markdown`, `html`, `rawHtml`, `json`, `summary`, `metadata`, `links`, `images`, `screenshot`, `audio`, `video`, `actions`, `warning`, `changeTracking`, `branding`, `product`, `menu`, `pages`, `blocks`.
+
+## Interact
+
+### Why use it
+
+Interact lets you execute code or natural-language instructions in a browser session that was started by a scrape. Use it for post-scrape actions like clicking buttons, filling forms, or extracting dynamic content.
+
+### Preferred SDK method
+
+```
+app.interact(jobId, args)
+```
+
+### Example
+
+```javascript
+// First, scrape with actions to get a job ID
+const doc = await app.scrape("https://example.com", {
+  formats: ["markdown"],
+  actions: [{ type: "wait", milliseconds: 2000 }],
+});
+
+const jobId = doc.metadata.jobId;
+
+// Execute code in the browser session
+const result = await app.interact(jobId, {
+  code: "const title = await page.title(); return title;",
+  language: "node",
+  timeout: 30,
+});
+
+console.log(result.output);
+
+// Or use a natural-language prompt
+const result2 = await app.interact(jobId, {
+  prompt: "Click the login button and wait for the form to appear",
+});
+
+// Stop the session when done
+await app.stopInteraction(jobId);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `jobId` | `string` | Required. The scrape job ID from `doc.metadata.jobId`. |
+| `code` | `string` | Code to execute in the browser sandbox. Provide `code` or `prompt`. |
+| `prompt` | `string` | Natural-language instruction for the browser agent. Provide `code` or `prompt`. |
+| `language` | `"python" \| "node" \| "bash"` | Runtime language for the code. |
+| `timeout` | `number` | Execution timeout in seconds. |
+| `origin` | `string` | Request origin tag. |
+
+**Returns:** `ScrapeExecuteResponse` with `success`, `output`, `stdout`, `result`, `stderr`, `exitCode`, `killed`, `error`, `liveViewUrl`, `interactiveLiveViewUrl`.
+
+**Related:** `app.stopInteraction(jobId)` ends the browser session and returns billing info.
+
+## Notes
+
+- All parameter names use **camelCase** (e.g. `onlyMainContent`, `skipTlsVerification`, `scrapeOptions`).
+- **Deprecated aliases** (use the preferred names instead):
+  - `scrapeExecute()` → `interact()`
+  - `stopInteractiveBrowser()` → `stopInteraction()`
+  - `deleteScrapeBrowser()` → `stopInteraction()`
+  - `scrapeUrl()` → `scrape()`
+  - `crawlUrl()` → `crawl()`
+  - `mapUrl()` → `map()`
+- The SDK auto-retries on transient errors with configurable backoff.
+- No API key is required; keyless mode gives a rate-limited free tier.
+
+## Source Of Truth
+
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/client.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/v2/types.ts`
+- `firecrawl/apps/js-sdk/firecrawl/src/index.ts`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/python.mdx
+++ b/agent-quickstart/python.mdx
@@ -1,0 +1,214 @@
+---
+title: "Python Agent Quickstart"
+description: "Canonical Firecrawl Python quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Python Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl via the Python SDK. It is generated from SDK source and the OpenAPI spec.
+
+## Install
+
+```bash
+pip install firecrawl-py
+```
+
+## Authenticate
+
+```python
+from firecrawl import Firecrawl
+
+# Pass the API key directly
+app = Firecrawl(api_key="fc-YOUR-API-KEY")
+
+# Or set FIRECRAWL_API_KEY and omit it
+app = Firecrawl()
+```
+
+Constructor parameters:
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `api_key` | `str` | `None` | API key. Falls back to `FIRECRAWL_API_KEY` env var. Omit for keyless free tier. |
+| `api_url` | `str` | `"https://api.firecrawl.dev"` | Base URL for the API. |
+| `timeout` | `float` | `None` | Default HTTP timeout in seconds. |
+| `max_retries` | `int` | `3` | Max retry attempts on transient failures. |
+| `backoff_factor` | `float` | `0.5` | Exponential backoff multiplier. |
+
+An async variant is also available: `from firecrawl import AsyncFirecrawl`.
+
+## When To Use What
+
+- **`search`**: Use when you start with a query and need to discover relevant pages across the web.
+- **`scrape`**: Use when you already have a URL and want to extract page content (markdown, HTML, structured data, etc.).
+- **`interact`**: Use when the page needs clicks, form fills, or post-scrape browser actions via code or natural language.
+
+## Search
+
+### Why use it
+
+Search finds relevant web pages for a query. Optionally scrapes each result in the same call via `scrape_options`.
+
+### Preferred SDK method
+
+```
+app.search(query, **options)
+```
+
+### Example
+
+```python
+results = app.search("firecrawl web scraping", limit=5, scrape_options={"formats": ["markdown"]})
+
+for result in results.web:
+    print(result.title, result.url)
+```
+
+### Parameters
+
+All parameters are keyword-only except `query`.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `query` | `str` | Required | The search query. |
+| `sources` | `list[str]` | `None` | Result verticals: `"web"`, `"news"`, `"images"`. |
+| `categories` | `list[str]` | `None` | Narrow search: `"github"`, `"research"`, `"pdf"`, `"developer"`. |
+| `include_domains` | `list[str]` | `None` | Only return results from these domains. |
+| `exclude_domains` | `list[str]` | `None` | Exclude results from these domains. |
+| `limit` | `int` | `5` | Max number of results. |
+| `tbs` | `str` | `None` | Time-based search filter (e.g. `"qdr:d"` for past day). |
+| `location` | `str` | `None` | Geo-location for search results. |
+| `country` | `str` | `None` | ISO 3166-1 alpha-2 country code for geo-targeting. |
+| `ignore_invalid_urls` | `bool` | `None` | Skip invalid URLs instead of failing. |
+| `timeout` | `int` | `300000` | Timeout in milliseconds. |
+| `highlights` | `bool` | `None` | Include query-relevant text highlights. Default: `True` server-side. |
+| `scrape_options` | `ScrapeOptions` | `None` | Scrape each result with these options. |
+| `enterprise` | `list[str]` | `None` | Enterprise features (e.g. `["zdr"]`). |
+| `threat_protection` | `ThreatProtectionOptions` | `None` | Threat protection settings. |
+| `integration` | `str` | `None` | Integration identifier. |
+
+**Returns:** `SearchData` with `.web`, `.news`, and `.images` lists.
+
+## Scrape
+
+### Why use it
+
+Scrape extracts content from a single URL in any format: markdown, HTML, structured JSON, screenshots, and more.
+
+### Preferred SDK method
+
+```
+app.scrape(url, **options)
+```
+
+### Example
+
+```python
+doc = app.scrape("https://example.com", formats=["markdown", "links"])
+
+print(doc.markdown)
+print(doc.links)
+```
+
+### Parameters
+
+All parameters are keyword-only except `url`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `str` | Required. The URL to scrape. |
+| `formats` | `list[str]` | Output formats: `"markdown"`, `"html"`, `"rawHtml"`, `"links"`, `"images"`, `"screenshot"`, `"summary"`, `"changeTracking"`, `"json"`, `"attributes"`, `"branding"`, `"product"`, `"menu"`, `"audio"`, `"video"`, or rich format objects. |
+| `headers` | `dict[str, str]` | Custom HTTP headers for the request. |
+| `include_tags` | `list[str]` | Only include content from elements matching these CSS selectors. |
+| `exclude_tags` | `list[str]` | Exclude content from elements matching these CSS selectors. |
+| `only_main_content` | `bool` | Strip navbars, footers, etc. and return only main content. |
+| `timeout` | `int` | Timeout in milliseconds. |
+| `wait_for` | `int` | Wait this many milliseconds after page load before extracting. |
+| `mobile` | `bool` | Emulate a mobile device. |
+| `parsers` | `list` | Document parsers (e.g. for PDFs). |
+| `actions` | `list[Action]` | Browser actions to execute before scraping (click, type, scroll, etc.). |
+| `location` | `Location` | Geo-location config with `country` and `languages`. |
+| `skip_tls_verification` | `bool` | Skip TLS certificate verification. |
+| `remove_base64_images` | `bool` | Strip base64-encoded images from output. |
+| `fast_mode` | `bool` | Use fast scraping mode (no JS rendering). |
+| `block_ads` | `bool` | Block ads during scraping. |
+| `proxy` | `str` | Proxy mode: `"basic"`, `"stealth"`, `"enhanced"`, `"auto"`. |
+| `max_age` | `int` | Max cache age in milliseconds. |
+| `store_in_cache` | `bool` | Store the result in cache. |
+| `lockdown` | `bool` | Only serve cached results, no outbound requests. |
+| `threat_protection` | `ThreatProtectionOptions` | Threat protection settings. |
+| `audit_metadata` | `AuditMetadata` | Audit metadata (e.g. `username`). |
+| `profile` | `dict` | Browser profile for persistent state. |
+| `integration` | `str` | Integration identifier. |
+| `auto_resume` | `bool` | Auto-retry server-side processing continuations. SDK-only. |
+
+**Returns:** `Document` with fields like `markdown`, `html`, `raw_html`, `json`, `summary`, `metadata`, `links`, `images`, `screenshot`, `audio`, `video`, `actions`, `warning`, `change_tracking`, `branding`, `product`, `menu`, `pages`, `blocks`.
+
+## Interact
+
+### Why use it
+
+Interact lets you execute code or natural-language instructions in a browser session that was started by a scrape. Use it for post-scrape actions like clicking buttons, filling forms, or extracting dynamic content.
+
+### Preferred SDK method
+
+```
+app.interact(job_id, code=None, **options)
+```
+
+### Example
+
+```python
+# First, scrape with actions to get a job ID
+doc = app.scrape("https://example.com", formats=["markdown"], actions=[{"type": "wait", "milliseconds": 2000}])
+
+job_id = doc.metadata.get("jobId")
+
+# Execute code in the browser session
+result = app.interact(job_id, code="const title = await page.title(); return title;", language="node", timeout=30)
+
+print(result.output)
+
+# Or use a natural-language prompt
+result2 = app.interact(job_id, prompt="Click the login button and wait for the form to appear")
+
+# Stop the session when done
+app.stop_interaction(job_id)
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `job_id` | `str` | Required | The scrape job ID from `doc.metadata["jobId"]`. |
+| `code` | `str` | `None` | Code to execute in the browser sandbox. Provide `code` or `prompt`. |
+| `prompt` | `str` | `None` | Natural-language instruction for the browser agent. Provide `code` or `prompt`. |
+| `language` | `str` | `"node"` | Runtime language: `"python"`, `"node"`, or `"bash"`. |
+| `timeout` | `int` | `None` | Execution timeout in seconds (1-300). |
+| `origin` | `str` | `None` | Request origin tag. |
+
+**Returns:** `BrowserExecuteResponse` with `success`, `output`, `stdout`, `result`, `stderr`, `exit_code`, `killed`, `error`, `cdp_url`, `live_view_url`, `interactive_live_view_url`.
+
+**Related:** `app.stop_interaction(job_id)` ends the browser session.
+
+## Notes
+
+- All parameter names use **snake_case** (e.g. `only_main_content`, `skip_tls_verification`, `scrape_options`). The SDK handles conversion to camelCase for the API.
+- **Deprecated aliases** (use the preferred names instead):
+  - `FirecrawlApp` → `Firecrawl`
+  - `AsyncFirecrawlApp` → `AsyncFirecrawl`
+  - `scrape_execute()` → `interact()`
+  - `stop_interactive_browser()` → `stop_interaction()`
+  - `delete_scrape_browser()` → `stop_interaction()`
+  - `scrape_url()` → `scrape()`
+  - `crawl_url()` → `crawl()`
+  - `map_url()` → `map()`
+- The SDK auto-retries on transient errors with configurable backoff.
+- No API key is required; keyless mode gives a rate-limited free tier.
+
+## Source Of Truth
+
+- `firecrawl/apps/python-sdk/firecrawl/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/client.py`
+- `firecrawl/apps/python-sdk/firecrawl/v2/types.py`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/agent-quickstart/rust.mdx
+++ b/agent-quickstart/rust.mdx
@@ -1,0 +1,231 @@
+---
+title: "Rust Agent Quickstart"
+description: "Canonical Firecrawl Rust quickstart for external agents using search, scrape, and interact."
+---
+
+# Firecrawl Rust Agent Quickstart
+
+This file is the canonical quickstart for external agents integrating with Firecrawl via the Rust SDK. It is generated from SDK source and the OpenAPI spec.
+
+## Install
+
+Add to your `Cargo.toml`:
+
+```toml
+[dependencies]
+firecrawl = "2"
+tokio = { version = "1", features = ["full"] }
+```
+
+## Authenticate
+
+```rust
+use firecrawl::Client;
+
+// Cloud client with API key
+let client = Client::new("fc-YOUR-API-KEY")?;
+
+// Self-hosted client (API key optional)
+let client = Client::new_selfhosted("https://your-instance.com", Some("fc-YOUR-API-KEY"))?;
+```
+
+| Constructor | Description |
+|---|---|
+| `Client::new(api_key)` | Cloud client. API key required. |
+| `Client::new_selfhosted(api_url, api_key)` | Self-hosted client. API key is optional (keyless free tier). |
+
+## When To Use What
+
+- **`search`**: Use when you start with a query and need to discover relevant pages across the web.
+- **`scrape`**: Use when you already have a URL and want to extract page content (markdown, HTML, structured data, etc.).
+- **`interact`**: Use when the page needs clicks, form fills, or post-scrape browser actions via code or natural language.
+
+## Search
+
+### Why use it
+
+Search finds relevant web pages for a query. Optionally scrapes each result in the same call via `scrape_options`.
+
+### Preferred SDK method
+
+```
+client.search(query, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, SearchOptions};
+
+let client = Client::new("fc-YOUR-API-KEY")?;
+
+let response = client.search("firecrawl web scraping", SearchOptions {
+    limit: Some(5),
+    ..Default::default()
+}).await?;
+
+if let Some(web_results) = response.data.web {
+    for result in web_results {
+        println!("{:?}", result);
+    }
+}
+```
+
+### Parameters
+
+All fields on `SearchOptions` are `Option`, defaulting to `None`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `impl AsRef<str>` | Required (first positional arg). The search query. |
+| `limit` | `Option<u32>` | Max results (default 5, max 20). |
+| `sources` | `Option<Vec<SearchSource>>` | Result verticals: `Web`, `News`, `Images`. |
+| `categories` | `Option<Vec<SearchCategory>>` | Narrow search: `Github`, `Research`, `Pdf`. |
+| `include_domains` | `Option<Vec<String>>` | Only return results from these domains. |
+| `exclude_domains` | `Option<Vec<String>>` | Exclude results from these domains. |
+| `tbs` | `Option<String>` | Time-based search filter (e.g. `"qdr:d"`). |
+| `location` | `Option<String>` | Geo-location string. |
+| `country` | `Option<String>` | Country code for geo-targeting. |
+| `ignore_invalid_urls` | `Option<bool>` | Skip invalid URLs. |
+| `timeout` | `Option<u32>` | Timeout in milliseconds. |
+| `highlights` | `Option<bool>` | Include query-relevant highlights. Default: `true` server-side. |
+| `scrape_options` | `Option<ScrapeOptions>` | Scrape each result with these options. |
+| `integration` | `Option<String>` | Integration identifier. |
+| `origin` | `Option<String>` | Auto-set to `"rust-sdk@{version}"`. |
+
+**Returns:** `SearchResponse { success, data: SearchData, warning }` where `SearchData` has `web`, `news`, `images` fields.
+
+**Convenience:** `client.search_and_scrape(query, limit).await` searches and returns only scraped `Document` results.
+
+## Scrape
+
+### Why use it
+
+Scrape extracts content from a single URL in any format: markdown, HTML, structured JSON, screenshots, and more.
+
+### Preferred SDK method
+
+```
+client.scrape(url, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeOptions, Format};
+
+let client = Client::new("fc-YOUR-API-KEY")?;
+
+let doc = client.scrape("https://example.com", ScrapeOptions {
+    formats: Some(vec![Format::Markdown, Format::Links]),
+    ..Default::default()
+}).await?;
+
+println!("{}", doc.markdown.unwrap_or_default());
+```
+
+### Parameters
+
+All fields on `ScrapeOptions` are `Option`, defaulting to `None`.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `url` | `impl AsRef<str>` | Required (first positional arg). The URL to scrape. |
+| `formats` | `Option<Vec<Format>>` | Output formats: `Markdown`, `Html`, `RawHtml`, `Links`, `Images`, `Screenshot`, `Summary`, `ChangeTracking`, `Json`, `Attributes`, `Branding`, `Product`, `Menu`, `Audio`, `Video`, `Question(...)`, `Highlights(...)`. |
+| `headers` | `Option<HashMap<String, String>>` | Custom HTTP headers. |
+| `include_tags` | `Option<Vec<String>>` | CSS selectors to include. |
+| `exclude_tags` | `Option<Vec<String>>` | CSS selectors to exclude. |
+| `only_main_content` | `Option<bool>` | Strip navbars, footers, etc. |
+| `timeout` | `Option<u32>` | Timeout in milliseconds. |
+| `wait_for` | `Option<u32>` | Wait after page load in milliseconds. |
+| `mobile` | `Option<bool>` | Emulate mobile device. |
+| `parsers` | `Option<Vec<ParserConfig>>` | Document parsers (e.g. PDF config). |
+| `actions` | `Option<Vec<Action>>` | Browser actions: `Wait`, `Screenshot`, `Click`, `Write`, `Press`, `Scroll`, `Scrape`, `ExecuteJavascript`, `Pdf`. |
+| `location` | `Option<LocationConfig>` | Geo-location with `country` and `languages`. |
+| `skip_tls_verification` | `Option<bool>` | Skip TLS checks. |
+| `remove_base64_images` | `Option<bool>` | Strip base64 images. |
+| `fast_mode` | `Option<bool>` | Fast scraping (no JS rendering). |
+| `block_ads` | `Option<bool>` | Block ads. |
+| `proxy` | `Option<ProxyType>` | Proxy: `Basic`, `Stealth`, `Enhanced`, `Auto`. |
+| `max_age` | `Option<u32>` | Cache max age in seconds. |
+| `min_age` | `Option<u32>` | Cache min age in seconds. |
+| `store_in_cache` | `Option<bool>` | Store result in cache. |
+| `lockdown` | `Option<bool>` | Cache-only mode. |
+| `redact_pii` | `Option<bool>` | Redact PII from output. |
+| `audit_metadata` | `Option<AuditMetadata>` | Audit metadata. |
+| `profile` | `Option<ProfileConfig>` | Browser profile (`name`, `save_changes`). |
+| `integration` | `Option<String>` | Integration identifier. |
+| `json_options` | `Option<JsonOptions>` | JSON extraction config (`schema`, `system_prompt`, `prompt`). |
+| `screenshot_options` | `Option<ScreenshotOptions>` | Screenshot config (`full_page`, `quality`, `viewport`). |
+| `change_tracking_options` | `Option<ChangeTrackingOptions>` | Change tracking config. |
+| `attribute_selectors` | `Option<Vec<AttributeSelector>>` | Attribute extraction selectors. |
+| `origin` | `Option<String>` | Auto-set to `"rust-sdk@{version}"`. |
+
+**Returns:** `Document` with `markdown`, `html`, `raw_html`, `json`, `summary`, `metadata`, `links`, `images`, `screenshot`, `audio`, `video`, `actions`, `warning`, `change_tracking`, `branding`, `product`, `menu`, `pages`, `blocks`.
+
+**Convenience:** `client.scrape_with_schema(url, schema, prompt).await` scrapes with JSON extraction and returns the extracted value.
+
+## Interact
+
+### Why use it
+
+Interact lets you execute code or natural-language instructions in a browser session that was started by a scrape. Use it for post-scrape actions like clicking buttons, filling forms, or extracting dynamic content.
+
+### Preferred SDK method
+
+```
+client.interact(job_id, options).await
+```
+
+### Example
+
+```rust
+use firecrawl::{Client, ScrapeExecuteOptions, ScrapeExecuteLanguage};
+
+let client = Client::new("fc-YOUR-API-KEY")?;
+
+let result = client.interact("job-id-from-scrape", ScrapeExecuteOptions {
+    code: Some("console.log(await page.url())".to_string()),
+    language: Some(ScrapeExecuteLanguage::Node),
+    timeout: Some(60),
+    ..Default::default()
+}).await?;
+
+println!("{:?}", result.stdout);
+
+// Stop the session when done
+client.stop_interaction("job-id-from-scrape").await?;
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `job_id` | `impl AsRef<str>` | Required. The scrape job ID. |
+| `code` | `Option<String>` | Code to execute in the browser sandbox. Provide `code` or `prompt`. |
+| `prompt` | `Option<String>` | Natural-language instruction for the browser agent. Provide `code` or `prompt`. |
+| `language` | `Option<ScrapeExecuteLanguage>` | Runtime: `Python`, `Node`, `Bash`. Default: `Node`. |
+| `timeout` | `Option<u32>` | Execution timeout in seconds. |
+| `origin` | `Option<String>` | Auto-set to `"rust-sdk@{version}"`. |
+
+**Returns:** `ScrapeExecuteResponse` with `success`, `output`, `stdout`, `result`, `stderr`, `exit_code`, `killed`, `error`, `live_view_url`, `interactive_live_view_url`.
+
+**Related:** `client.stop_interaction(job_id).await` ends the browser session and returns `session_duration_ms` and `credits_billed`.
+
+## Notes
+
+- All struct fields use **snake_case** (e.g. `only_main_content`, `skip_tls_verification`). The SDK handles serde serialization to camelCase for the API.
+- All option structs derive `Default`, so use `..Default::default()` for omitted fields.
+- **Deprecated aliases** (use the preferred names instead):
+  - `scrape_execute()` → `interact()`
+  - `stop_interactive_browser()` → `stop_interaction()`
+  - `delete_scrape_browser()` → `stop_interaction()`
+- The SDK is fully async (requires `tokio` runtime).
+- `origin` is auto-injected as `"rust-sdk@{version}"` on every request.
+
+## Source Of Truth
+
+- `firecrawl/apps/rust-sdk/src/scrape.rs`
+- `firecrawl/apps/rust-sdk/src/search.rs`
+- `firecrawl/apps/rust-sdk/src/client.rs`
+- `firecrawl-docs/api-reference/v2-openapi.json`

--- a/docs.json
+++ b/docs.json
@@ -285,6 +285,16 @@
                     ]
                   },
                   {
+                    "group": "Agent Quickstarts",
+                    "pages": [
+                      "agent-quickstart/node",
+                      "agent-quickstart/python",
+                      "agent-quickstart/rust",
+                      "agent-quickstart/java",
+                      "agent-quickstart/elixir"
+                    ]
+                  },
+                  {
                     "group": "Developer Guides",
                     "pages": [
                       "developer-guides/examples",


### PR DESCRIPTION
## Summary

- Adds one canonical agent quickstart file per SDK language: **Node.js**, **Python**, **Rust**, **Java**, and **Elixir**
- Each file covers the **search**, **scrape**, and **interact** endpoints with preferred SDK methods, realistic examples, and every confirmed parameter with descriptions
- Generated from SDK source code and the v2 OpenAPI spec — no invented parameters or methods
- Adds an "Agent Quickstarts" navigation group in `docs.json` between Quickstarts and Developer Guides

## Files Added

| File | Language | Key Details |
|---|---|---|
| `agent-quickstart/node.mdx` | Node.js/TypeScript | `@mendable/firecrawl-js`, camelCase params, `code` + `prompt` in interact |
| `agent-quickstart/python.mdx` | Python | `firecrawl-py`, snake_case params, `code` + `prompt` in interact |
| `agent-quickstart/rust.mdx` | Rust | `firecrawl` crate, async with tokio, `code` + `prompt` in interact |
| `agent-quickstart/java.mdx` | Java | `com.firecrawl:firecrawl-java`, builder pattern, `code` only in interact |
| `agent-quickstart/elixir.mdx` | Elixir | `:firecrawl` hex package, OpenAPI-generated, `code` only in interact |

## Notable cross-language differences documented

- **interact `prompt` param**: Available in Node.js, Python, and Rust SDKs. Not yet in Java or Elixir — documented explicitly in each file's Notes section.
- **Naming**: camelCase (JS/Java), snake_case (Python/Rust/Elixir)
- **Elixir**: Uses OpenAPI operation ID function names (e.g. `search_and_scrape`, `scrape_and_extract_from_url`)

## Test plan

- [ ] Verify each `.mdx` file renders correctly in Mintlify
- [ ] Confirm all parameter names match current SDK source
- [ ] Check navigation group appears correctly in sidebar

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Azy3JRK1deTVgn6pgjCSQB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Azy3JRK1deTVgn6pgjCSQB)_